### PR TITLE
Bugfix: Two "." entries when listing root of S3 mount

### DIFF
--- a/component/s3storage/client_test.go
+++ b/component/s3storage/client_test.go
@@ -645,6 +645,15 @@ func (s *clientTestSuite) TestList() {
 	s.assert.EqualValues(len(objects), 1)
 	s.assert.EqualValues(objects[0].Name, base+"c")
 	s.assert.False(objects[0].IsDir())
+
+	// When listing the root, List should not include the root
+	objects, _, err = s.client.List("", nil, 0)
+	s.assert.Nil(err)
+	s.assert.NotNil(objects)
+	s.assert.Greater(len(objects), 0)
+	s.assert.NotEqual(objects[0].Name, "")
+	s.assert.NotEqual(objects[0].Name, "/")
+	s.assert.NotEqual(objects[0].Name, ".")
 }
 func (s *clientTestSuite) TestReadToFile() {
 	defer s.cleanupTest()

--- a/component/s3storage/s3wrappers.go
+++ b/component/s3storage/s3wrappers.go
@@ -404,8 +404,7 @@ func (cl *Client) List(prefix string, marker *string, count int32) ([]*internal.
 		// now let's add attributes for all the directories in dirList
 		for dir := range dirList {
 			dirName, _ := cl.getFile(dir)
-			dirName = internal.TruncateDirName(dirName)
-			if dirName == listPath {
+			if internal.TruncateDirName(dirName) == internal.TruncateDirName(listPath) {
 				continue
 			}
 			path := split(cl.Config.prefixPath, dirName)

--- a/component/s3storage/s3wrappers.go
+++ b/component/s3storage/s3wrappers.go
@@ -404,6 +404,7 @@ func (cl *Client) List(prefix string, marker *string, count int32) ([]*internal.
 		// now let's add attributes for all the directories in dirList
 		for dir := range dirList {
 			dirName, _ := cl.getFile(dir)
+			dirName = internal.TruncateDirName(dirName)
 			if dirName == listPath {
 				continue
 			}


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief

List() is supposed to exclude the directory being listed. But when listing the root, "/" comes up as a subdirectory.
By simply truncating the directory name before adding it, we can detect that this is the directory being listed, and should not be included.

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [x] Added tests

### Related Issues

- Related Issue #
- Closes #