### PR TITLE
Bugfix: Access Denied on Windows When Running as a Service

### DIFF
--- a/component/libfuse/libfuse2_handler.go
+++ b/component/libfuse/libfuse2_handler.go
@@ -101,11 +101,11 @@ func (lf *Libfuse) initFuse() error {
 		lf.attributeExpiration,
 		lf.negativeTimeout)
 
-	// With WinFSP this will present all files as owned by the current user and group
+	// With WinFSP this will present all files as owned by the Authenticated Users group
 	if runtime.GOOS == "windows" {
 		options = fmt.Sprintf("uid=%d,gid=%d,entry_timeout=%d,attr_timeout=%d,negative_timeout=%d",
-			-1,
-			-1,
+			11,
+			11,
 			lf.entryExpiration,
 			lf.attributeExpiration,
 			lf.negativeTimeout)

--- a/component/libfuse/libfuse2_handler.go
+++ b/component/libfuse/libfuse2_handler.go
@@ -32,7 +32,6 @@ import (
 	"io/fs"
 	"os"
 	"runtime"
-	"strings"
 	"syscall"
 	"time"
 
@@ -272,14 +271,6 @@ func (cf *CgofuseFS) Getattr(path string, stat *fuse.Stat_t, fh uint64) int {
 
 	// Populate stat
 	fuseFS.fillStat(attr, stat)
-	if strings.Contains(name, "gEdit") {
-		log.Debug("Libfuse::Getattr : Returning attributes of %s: mode %x, Uid %x, Gid %x, Rdev %x, size %d, blocks %d, flags %x",
-			name, stat.Mode, stat.Uid, stat.Gid, stat.Rdev, stat.Size, stat.Blocks, stat.Flags)
-	}
-	if name == "" {
-		log.Debug("Libfuse::Getattr : Returning root attributes: mode %x, Uid %x, Gid %x, Rdev %x, size %d, blocks %d, flags %x",
-			stat.Mode, stat.Uid, stat.Gid, stat.Rdev, stat.Size, stat.Blocks, stat.Flags)
-	}
 	return 0
 }
 
@@ -410,14 +401,6 @@ func (cf *CgofuseFS) Readdir(path string, fill func(name string, stat *fuse.Stat
 		cacheInfo.token = token
 		cacheInfo.children = cacheInfo.children[:0]
 		cacheInfo.children = attrs
-	}
-
-	// find our troubled file in the children
-	for _, child := range cacheInfo.children {
-		if strings.Contains(child.Name, "gEdit") {
-			log.Debug("Libfuse::Readdir : Path %s, handle: %d, offset %d. Returning gEdit child attributes: flags %x, mode %x, size %d",
-				handle.Path, handle.ID, ofst64, child.Flags, child.Mode, child.Size)
-		}
 	}
 
 	if ofst64 >= cacheInfo.eIndex {


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief
We were giving file ownership to the "current user" (-1), but when launching as a service, the current user is SYSTEM, which does not allow files to be modified by any users (including admin!).
This changes ownership to the "Authenticated Users" group, which allows writes but stops short of allowing writes for the EVERYONE group.
This bug, and the unsophisticated fix this PR introduces suggest that we need to give more serious treatment to security / permissions on Windows at some future point.

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #