### PR TITLE
Print underlying error when panicking

### DIFF
--- a/cmd/doc_test.go
+++ b/cmd/doc_test.go
@@ -49,7 +49,7 @@ func (suite *docTestSuite) SetupTest() {
 	options = mountOptions{}
 	err := log.SetDefaultLogger("silent", common.LogConfig{Level: common.ELogLevel.LOG_DEBUG()})
 	if err != nil {
-		panic("Unable to set silent logger as default.")
+		panic(fmt.Sprintf("Unable to set silent logger as default: %v", err))
 	}
 }
 

--- a/cmd/health-monitor_test.go
+++ b/cmd/health-monitor_test.go
@@ -82,7 +82,7 @@ func (suite *hmonTestSuite) SetupTest() {
 	suite.assert = assert.New(suite.T())
 	err := log.SetDefaultLogger("silent", common.LogConfig{Level: common.ELogLevel.LOG_DEBUG()})
 	if err != nil {
-		panic("Unable to set silent logger as default.")
+		panic(fmt.Sprintf("Unable to set silent logger as default: %v", err))
 	}
 }
 

--- a/cmd/mount_linux_test.go
+++ b/cmd/mount_linux_test.go
@@ -116,7 +116,7 @@ func (suite *mountTestSuite) SetupTest() {
 	options = mountOptions{}
 	err := log.SetDefaultLogger("silent", common.LogConfig{Level: common.ELogLevel.LOG_DEBUG()})
 	if err != nil {
-		panic("Unable to set silent logger as default.")
+		panic(fmt.Sprintf("Unable to set silent logger as default: %v", err))
 	}
 }
 

--- a/cmd/mount_windows_test.go
+++ b/cmd/mount_windows_test.go
@@ -80,7 +80,7 @@ func (suite *mountTestSuite) SetupTest() {
 	options = mountOptions{}
 	err := log.SetDefaultLogger("silent", common.LogConfig{Level: common.ELogLevel.LOG_DEBUG()})
 	if err != nil {
-		panic("Unable to set silent logger as default.")
+		panic(fmt.Sprintf("Unable to set silent logger as default: %v", err))
 	}
 }
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -83,7 +83,7 @@ func (suite *rootCmdSuite) SetupTest() {
 	suite.assert = assert.New(suite.T())
 	err := log.SetDefaultLogger("silent", common.LogConfig{Level: common.ELogLevel.LOG_DEBUG()})
 	if err != nil {
-		panic("Unable to set silent logger as default.")
+		panic(fmt.Sprintf("Unable to set silent logger as default: %v", err))
 	}
 	// suite.testExecute()
 }

--- a/cmd/secure_test.go
+++ b/cmd/secure_test.go
@@ -49,7 +49,7 @@ func (suite *secureConfigTestSuite) SetupTest() {
 	suite.assert = assert.New(suite.T())
 	err := log.SetDefaultLogger("silent", common.LogConfig{Level: common.ELogLevel.LOG_DEBUG()})
 	if err != nil {
-		panic("Unable to set silent logger as default.")
+		panic(fmt.Sprintf("Unable to set silent logger as default: %v", err))
 	}
 }
 

--- a/cmd/service_windows_test.go
+++ b/cmd/service_windows_test.go
@@ -49,7 +49,7 @@ func (suite *serviceTestSuite) SetupTest() {
 	servOpts = serviceOptions{}
 	err := log.SetDefaultLogger("silent", common.LogConfig{Level: common.ELogLevel.LOG_DEBUG()})
 	if err != nil {
-		panic("Unable to set silent logger as default.")
+		panic(fmt.Sprintf("Unable to set silent logger as default: %v", err))
 	}
 }
 

--- a/cmd/unmount_linux_test.go
+++ b/cmd/unmount_linux_test.go
@@ -70,7 +70,7 @@ func (suite *unmountTestSuite) SetupTest() {
 	options = mountOptions{}
 	err := log.SetDefaultLogger("silent", common.LogConfig{Level: common.ELogLevel.LOG_DEBUG()})
 	if err != nil {
-		panic("Unable to set silent logger as default.")
+		panic(fmt.Sprintf("Unable to set silent logger as default: %v", err))
 	}
 
 }

--- a/component/attr_cache/attr_cache_test.go
+++ b/component/attr_cache/attr_cache_test.go
@@ -233,7 +233,7 @@ func addDirectoryToCache(assert *assert.Assertions, attrCache *AttrCache, path s
 func (suite *attrCacheTestSuite) SetupTest() {
 	err := log.SetDefaultLogger("silent", common.LogConfig{})
 	if err != nil {
-		panic("Unable to set silent logger as default.")
+		panic(fmt.Sprintf("Unable to set silent logger as default: %v", err))
 	}
 	suite.setupTestHelper(emptyConfig)
 }

--- a/component/azstorage/config_test.go
+++ b/component/azstorage/config_test.go
@@ -26,6 +26,7 @@
 package azstorage
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/Seagate/cloudfuse/common"
@@ -44,7 +45,7 @@ type configTestSuite struct {
 func (suite *configTestSuite) SetupTest() {
 	err := log.SetDefaultLogger("silent", common.LogConfig{Level: common.ELogLevel.LOG_DEBUG()})
 	if err != nil {
-		panic("Unable to set silent logger as default.")
+		panic(fmt.Sprintf("Unable to set silent logger as default: %v", err))
 	}
 }
 

--- a/component/block_cache/block_cache_linux_test.go
+++ b/component/block_cache/block_cache_linux_test.go
@@ -500,7 +500,7 @@ func TestBlockCacheTestSuite(t *testing.T) {
 	bcsuite := new(blockCacheTestSuite)
 	err := log.SetDefaultLogger("silent", common.LogConfig{Level: common.ELogLevel.LOG_DEBUG()})
 	if err != nil {
-		panic("Unable to set silent logger as default.")
+		panic(fmt.Sprintf("Unable to set silent logger as default: %v", err))
 	}
 
 	suite.Run(t, bcsuite)

--- a/component/file_cache/cache_policy_test.go
+++ b/component/file_cache/cache_policy_test.go
@@ -26,6 +26,7 @@
 package file_cache
 
 import (
+	"fmt"
 	"io/fs"
 	"math"
 	"os"
@@ -46,7 +47,7 @@ type cachePolicyTestSuite struct {
 func (suite *cachePolicyTestSuite) SetupTest() {
 	err := log.SetDefaultLogger("silent", common.LogConfig{Level: common.ELogLevel.LOG_DEBUG()})
 	if err != nil {
-		panic("Unable to set silent logger as default.")
+		panic(fmt.Sprintf("Unable to set silent logger as default: %v", err))
 	}
 	suite.assert = assert.New(suite.T())
 	os.Mkdir(cache_path, fs.FileMode(0777))

--- a/component/file_cache/file_cache_linux_test.go
+++ b/component/file_cache/file_cache_linux_test.go
@@ -57,7 +57,7 @@ type fileCacheLinuxTestSuite struct {
 func (suite *fileCacheLinuxTestSuite) SetupTest() {
 	err := log.SetDefaultLogger("silent", common.LogConfig{Level: common.ELogLevel.LOG_DEBUG()})
 	if err != nil {
-		panic("Unable to set silent logger as default.")
+		panic(fmt.Sprintf("Unable to set silent logger as default: %v", err))
 	}
 	rand := randomString(8)
 	suite.cache_path = common.JoinUnixFilepath(home_dir, "file_cache"+rand)

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -71,7 +71,7 @@ func newTestFileCache(next internal.Component) *FileCache {
 	fileCache.SetNextComponent(next)
 	err := fileCache.Configure(true)
 	if err != nil {
-		panic("Unable to configure file cache.")
+		panic(fmt.Sprintf("Unable to configure file cache: %v", err))
 	}
 
 	return fileCache.(*FileCache)
@@ -88,7 +88,7 @@ func (suite *fileCacheTestSuite) SetupTest() {
 	rand.Seed(time.Now().UnixNano())
 	err := log.SetDefaultLogger("silent", common.LogConfig{Level: common.ELogLevel.LOG_DEBUG()})
 	if err != nil {
-		panic("Unable to set silent logger as default.")
+		panic(fmt.Sprintf("Unable to set silent logger as default: %v", err))
 	}
 	rand := randomString(8)
 	suite.cache_path = common.JoinUnixFilepath(home_dir, "file_cache"+rand)

--- a/component/file_cache/file_cache_windows_test.go
+++ b/component/file_cache/file_cache_windows_test.go
@@ -56,7 +56,7 @@ type fileCacheWindowsTestSuite struct {
 func (suite *fileCacheWindowsTestSuite) SetupTest() {
 	err := log.SetDefaultLogger("silent", common.LogConfig{Level: common.ELogLevel.LOG_DEBUG()})
 	if err != nil {
-		panic("Unable to set silent logger as default.")
+		panic(fmt.Sprintf("Unable to set silent logger as default: %v", err))
 	}
 	rand := randomString(8)
 	suite.cache_path = common.JoinUnixFilepath(home_dir, "file_cache"+rand)

--- a/component/file_cache/lfu_policy_test.go
+++ b/component/file_cache/lfu_policy_test.go
@@ -50,7 +50,7 @@ var cache_path = common.JoinUnixFilepath(home_dir, "file_cache")
 func (suite *lfuPolicyTestSuite) SetupTest() {
 	err := log.SetDefaultLogger("silent", common.LogConfig{Level: common.ELogLevel.LOG_DEBUG()})
 	if err != nil {
-		panic("Unable to set silent logger as default.")
+		panic(fmt.Sprintf("Unable to set silent logger as default: %v", err))
 	}
 	suite.assert = assert.New(suite.T())
 

--- a/component/file_cache/lru_policy_test.go
+++ b/component/file_cache/lru_policy_test.go
@@ -47,7 +47,7 @@ type lruPolicyTestSuite struct {
 func (suite *lruPolicyTestSuite) SetupTest() {
 	// err := log.SetDefaultLogger("silent", common.LogConfig{Level: common.ELogLevel.LOG_DEBUG()})
 	// if err != nil {
-	// 	panic("Unable to set silent logger as default.")
+	// 	panic(fmt.Sprintf("Unable to set silent logger as default: %v", err))
 	// }
 	suite.assert = assert.New(suite.T())
 

--- a/component/libfuse/libfuse2_handler_test_wrapper.go
+++ b/component/libfuse/libfuse2_handler_test_wrapper.go
@@ -27,6 +27,7 @@ package libfuse
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
 	"runtime"
 	"strings"
@@ -62,13 +63,13 @@ var cfuseFS *CgofuseFS
 func newTestLibfuse(next internal.Component, configuration string) *Libfuse {
 	err := config.ReadConfigFromReader(strings.NewReader(configuration))
 	if err != nil {
-		panic("Unable to read config from reader.")
+		panic(fmt.Sprintf("Unable to read config from reader: %v", err))
 	}
 	libfuse := NewLibfuseComponent()
 	libfuse.SetNextComponent(next)
 	err = libfuse.Configure(true)
 	if err != nil {
-		panic("Unable to configure for testing.")
+		panic(fmt.Sprintf("Unable to configure for testing: %v", err))
 	}
 
 	return libfuse.(*Libfuse)
@@ -77,7 +78,7 @@ func newTestLibfuse(next internal.Component, configuration string) *Libfuse {
 func (suite *libfuseTestSuite) SetupTest() {
 	err := log.SetDefaultLogger("silent", common.LogConfig{})
 	if err != nil {
-		panic("Unable to set silent logger as default.")
+		panic(fmt.Sprintf("Unable to set silent logger as default: %v", err))
 	}
 	suite.setupTestHelper(emptyConfig)
 }

--- a/component/s3storage/config_test.go
+++ b/component/s3storage/config_test.go
@@ -26,6 +26,7 @@
 package s3storage
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/Seagate/cloudfuse/common"
@@ -47,7 +48,7 @@ func (s *configTestSuite) SetupTest() {
 	// Silent logger
 	err := log.SetDefaultLogger("silent", common.LogConfig{Level: common.ELogLevel.LOG_DEBUG()})
 	if err != nil {
-		panic("Unable to set silent logger as default.")
+		panic(fmt.Sprintf("Unable to set silent logger as default: %v", err))
 	}
 
 	// Set S3Storage

--- a/component/stream/read_test.go
+++ b/component/stream/read_test.go
@@ -28,6 +28,7 @@ package stream
 import (
 	"context"
 	"crypto/rand"
+	"fmt"
 	"os"
 	"strings"
 	"sync"
@@ -86,7 +87,7 @@ func (suite *streamTestSuite) setupTestHelper(config string, ro bool) {
 func (suite *streamTestSuite) SetupTest() {
 	err := log.SetDefaultLogger("silent", common.LogConfig{})
 	if err != nil {
-		panic("Unable to set silent logger as default.")
+		panic(fmt.Sprintf("Unable to set silent logger as default: %v", err))
 	}
 	suite.setupTestHelper(emptyConfig, true)
 }

--- a/tools/health-monitor/monitor/cpu_mem_profiler/cpu_mem_monitor_test.go
+++ b/tools/health-monitor/monitor/cpu_mem_profiler/cpu_mem_monitor_test.go
@@ -47,7 +47,7 @@ func (suite *cpuMemMonitorTestSuite) SetupTest() {
 	suite.assert = assert.New(suite.T())
 	err := log.SetDefaultLogger("silent", common.LogConfig{Level: common.ELogLevel.LOG_DEBUG()})
 	if err != nil {
-		panic("Unable to set silent logger as default.")
+		panic(fmt.Sprintf("Unable to set silent logger as default: %v", err))
 	}
 }
 


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief
Whenever we call panic with a literal string, this PR adds the underlying error to the string.

### Checklist

- [ ] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #