### PR TITLE
Sample config allow non empty temp

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -88,6 +88,9 @@ archives:
         dst: "./samples/sampleStreamingConfigS3.yaml"
       - src: "sampleStreamingConfigAzure.yaml"
         dst: "./samples/sampleStreamingConfigAzure.yaml"
+        # default config
+      - src: "sampleFileCacheConfigS3.yaml"
+        dst: "./config.yaml"
 
   - id: linux-arm64
     builds:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -88,9 +88,6 @@ archives:
         dst: "./samples/sampleStreamingConfigS3.yaml"
       - src: "sampleStreamingConfigAzure.yaml"
         dst: "./samples/sampleStreamingConfigAzure.yaml"
-        # default config
-      - src: "sampleFileCacheConfigS3.yaml"
-        dst: "./config.yaml"
 
   - id: linux-arm64
     builds:

--- a/build/windows_installer_build.iss
+++ b/build/windows_installer_build.iss
@@ -55,7 +55,7 @@ Source: "..\sampleFileCacheWithSASConfigAzure.yaml"; DestDir: "{app}"; Flags: ig
 Source: "..\sampleStreamingConfigAzure.yaml"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\sampleStreamingConfigS3.yaml"; DestDir: "{app}"; Flags: ignoreversion
 ; Deploy default config
-Source: "..\sampleFileCacheConfigS3.yaml"; DestDir: "{userappdata}\{#MyAppName}"; DestName: "config.yaml"; Flags: ignoreversion
+Source: "..\sampleFileCacheConfigS3.yaml"; DestDir: "{userappdata}\{#MyAppName}"; DestName: "config.yaml"; Flags: onlyifdoesntexist
 
 Source: "..\winfsp-2.0.23075.msi"; DestDir: "{app}"; Flags: ignoreversion
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files

--- a/build/windows_installer_build.iss
+++ b/build/windows_installer_build.iss
@@ -38,6 +38,10 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
+[Dirs]
+; Create directory in AppData/Roaming
+Name: "{userappdata}\{#MyAppName}"; Flags: uninsalwaysuninstall
+
 [Files]
 Source: "..\gui\dist\cloudfuseGUI_Windows\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\gui\dist\cloudfuseGUI_Windows\_internal\*"; DestDir: "{app}\_internal\"; Flags: ignoreversion recursesubdirs createallsubdirs
@@ -50,13 +54,11 @@ Source: "..\sampleFileCacheConfigS3.yaml"; DestDir: "{app}"; Flags: ignoreversio
 Source: "..\sampleFileCacheWithSASConfigAzure.yaml"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\sampleStreamingConfigAzure.yaml"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\sampleStreamingConfigS3.yaml"; DestDir: "{app}"; Flags: ignoreversion
+; Deploy default config
+Source: "..\sampleFileCacheConfigS3.yaml"; DestDir: "{userappdata}\{#MyAppName}"; DestName: "config.yaml"; Flags: ignoreversion
 
 Source: "..\winfsp-2.0.23075.msi"; DestDir: "{app}"; Flags: ignoreversion
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
-
-[Dirs]
-; Create directory in AppData/Roaming
-Name: "{userappdata}\{#MyAppName}"; Flags: uninsalwaysuninstall
 
 [Icons]
 Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"

--- a/sampleFileCacheConfigAzure.yaml
+++ b/sampleFileCacheConfigAzure.yaml
@@ -19,6 +19,7 @@ file_cache:
   path: /<PATH>/<TO>/<CACHE_DIR>
   timeout-sec: 120
   max-size-mb: 4096
+  allow-non-empty-temp: true
 
 attr_cache:
   timeout-sec: 7200

--- a/sampleFileCacheConfigS3.yaml
+++ b/sampleFileCacheConfigS3.yaml
@@ -19,6 +19,7 @@ file_cache:
   path: /<PATH>/<TO>/<CACHE_DIR>
   timeout-sec: 120
   max-size-mb: 4096
+  allow-non-empty-temp: true
 
 attr_cache:
   timeout-sec: 7200

--- a/sampleFileCacheWithSASConfigAzure.yaml
+++ b/sampleFileCacheWithSASConfigAzure.yaml
@@ -19,6 +19,7 @@ file_cache:
   path: /<PATH>/<TO>/<CACHE_DIR>
   timeout-sec: 120
   max-size-mb: 4096
+  allow-non-empty-temp: true
 
 attr_cache:
   timeout-sec: 7200

--- a/setup/baseConfig.yaml
+++ b/setup/baseConfig.yaml
@@ -105,7 +105,7 @@ file_cache:
   high-threshold: <% disk space consumed which triggers eviction. This parameter overrides 'timeout-sec' parameter and cached files will be removed even if they have not expired. Default - 80>
   low-threshold: <% disk space consumed which triggers eviction to stop when previously triggered by the high-threshold. Default - 60>
   create-empty-file: true|false <create an empty file on container when create call is received from kernel>
-  allow-non-empty-temp: true|false <allow non empty temp directory at startup>
+  allow-non-empty-temp: true|false <allow non empty temp directory at startup. Set true to persist local cache across reboots.>
   cleanup-on-start: true|false <cleanup the temp directory on startup, if its not empty>
   policy-trace: true|false <generate eviction policy logs showing which files will expire soon>
   offload-io: true|false <by default libfuse will service reads/writes to files for better perf. Set to true to make file-cache component service read/write calls.>


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief
Set option true in sample configs and deploy file cache with S3 as default config on Windows (without overwriting any existing config).
GoReleaser doesn't have an option to prevent overwriting, so no default config is deployed on Windows.

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #