### PR TITLE
Keep window open on failed write in GUI

### DIFF
--- a/gui/common_qt_functions.py
+++ b/gui/common_qt_functions.py
@@ -239,6 +239,10 @@ class widgetCustomFunctions(QWidget):
             try:
                 with open(currentDir+'/default_config.yaml','r') as file:
                     configs = yaml.safe_load(file)
+                    if configs is None:
+                        # The default file is empty, use programmed defaults
+                        defaultSettingsManager.setAllDefaultSettings(self)
+                        configs = self.constructDictForConfig()
             except:
                 # There is no default config file, use programmed defaults
                 defaultSettingsManager.setAllDefaultSettings(self)
@@ -247,7 +251,11 @@ class widgetCustomFunctions(QWidget):
             try:
                 with open(currentDir+'/config.yaml', 'r') as file:
                     configs = yaml.safe_load(file)
+                    if configs is None:
+                       # The configs file exists, but is empty, use default settings
+                       configs = self.getConfigs(True) 
             except:
+                # Could not open or config file does not exist, use default settings
                 configs = self.getConfigs(True)
         return configs
     
@@ -264,8 +272,6 @@ class widgetCustomFunctions(QWidget):
     #   settings defined in defaultSettingManager.
     def initSettingsFromConfig(self):
         dictForConfigs = self.getConfigs()
-        if dictForConfigs is None:
-            dictForConfigs = self.getConfigs(True)
         for option in dictForConfigs:
             if type(dictForConfigs[option]) == dict:
                 tempDict = self.settings.value(option)

--- a/gui/common_qt_functions.py
+++ b/gui/common_qt_functions.py
@@ -222,12 +222,16 @@ class widgetCustomFunctions(QWidget):
         self.updateSettingsFromUIChoices()
         dictForConfigs = self.constructDictForConfig()
         currentDir = self.getCurrentDir()
-        with open(currentDir+'/config.yaml','w') as (file, err):
-            if err:
-                return False
-            else:
+        try:
+            with open(currentDir+'/config.yaml','w') as file:
                 yaml.safe_dump(dictForConfigs,file)
                 return True
+        except:
+            msg = QtWidgets.QMessageBox()
+            msg.setWindowTitle("Write Failed")
+            msg.setInformativeText("Writing the config file failed. Check file permissions and try again.")
+            msg.exec()
+            return False
             
     def getConfigs(self,useDefault=False):
         currentDir = self.getCurrentDir()
@@ -260,6 +264,8 @@ class widgetCustomFunctions(QWidget):
     #   settings defined in defaultSettingManager.
     def initSettingsFromConfig(self):
         dictForConfigs = self.getConfigs()
+        if dictForConfigs is None:
+            dictForConfigs = self.getConfigs(True)
         for option in dictForConfigs:
             if type(dictForConfigs[option]) == dict:
                 tempDict = self.settings.value(option)

--- a/gui/common_qt_functions.py
+++ b/gui/common_qt_functions.py
@@ -193,8 +193,10 @@ class widgetCustomFunctions(QWidget):
         elif ret == QtWidgets.QMessageBox.Save:
             # Insert all settings to yaml file
             self.exitWindowCleanup()
-            self.writeConfigFile()
-            event.accept()
+            if self.writeConfigFile():
+                event.accept()
+            else:
+                event.ignore()
         
     def constructDictForConfig(self):
         optionKeys = self.settings.allKeys()
@@ -220,8 +222,12 @@ class widgetCustomFunctions(QWidget):
         self.updateSettingsFromUIChoices()
         dictForConfigs = self.constructDictForConfig()
         currentDir = self.getCurrentDir()
-        with open(currentDir+'/config.yaml','w') as file:
-            yaml.safe_dump(dictForConfigs,file)
+        with open(currentDir+'/config.yaml','w') as (file, err):
+            if err:
+                return False
+            else:
+                yaml.safe_dump(dictForConfigs,file)
+                return True
             
     def getConfigs(self,useDefault=False):
         currentDir = self.getCurrentDir()


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief
If the GUI fails to write the config file, a warning window will pop up, and the config window will not longer close on its own. 
Fixed a bug where the code fails when the config or default_config files are empty, use the built in programmed default values if all else fails.

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #