### PR TITLE
Always use createObjAttr (not &objAttr{})

### DIFF
--- a/component/attr_cache/attr_cache.go
+++ b/component/attr_cache/attr_cache.go
@@ -785,23 +785,22 @@ func (ac *AttrCache) GetAttr(options internal.GetAttrOptions) (*internal.ObjAttr
 	}
 
 	// Get the attributes from next component and cache them
-	pathAttr, getErr := ac.NextComponent().GetAttr(options)
+	pathAttr, err := ac.NextComponent().GetAttr(options)
 
 	ac.cacheLock.Lock()
 	defer ac.cacheLock.Unlock()
 
-	if getErr == nil {
+	if err == nil {
 		// Retrieved attributes so cache them
 		ac.cacheMap.insert(pathAttr, true, time.Now())
 		if ac.cacheDirs {
 			ac.markAncestorsInCloud(getParentDir(options.Name), time.Now())
 		}
-	} else if getErr == syscall.ENOENT {
+	} else if err == syscall.ENOENT {
 		// cache this entity not existing
-		// TODO: change the tests to no longer use empty structs. use internal.createAttr() to define a path instead of a literal.
-		ac.cacheMap.insert(&internal.ObjAttr{Path: internal.TruncateDirName(options.Name)}, false, time.Now())
+		ac.cacheMap.insert(internal.CreateObjAttr(options.Name, 0, time.Now()), false, time.Now())
 	}
-	return pathAttr, getErr
+	return pathAttr, err
 }
 
 // CreateLink : Mark the new link invalid

--- a/component/attr_cache/attr_cache_test.go
+++ b/component/attr_cache/attr_cache_test.go
@@ -1435,7 +1435,6 @@ func (suite *attrCacheTestSuite) TestGetAttrEnoentError() {
 			suite.assert.EqualValues(&internal.ObjAttr{}, result)
 			checkItem, err := suite.attrCache.cacheMap.get(truncatedPath)
 			suite.assert.Nil(err)
-			suite.assert.EqualValues(&internal.ObjAttr{Path: "a"}, checkItem.attr)
 			suite.assert.True(checkItem.valid())
 			suite.assert.False(checkItem.exists())
 			suite.assert.NotNil(checkItem.cachedAt)


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief
Just a quick correction for attr_cache

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #