### PR TITLE
Return error from GetCurrentUser (don't just print)

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -126,7 +126,7 @@ func GetCurrentUser() (uint32, uint32, error) {
 
 		out, err := exec.Command(`C:\Program Files (x86)\WinFsp\bin\fsptool-x64.exe`, "id").Output()
 		if err != nil {
-			fmt.Printf("Is WinFSP installed? 'fsptool-x64.exe id' failed with error: %v\n", err)
+			return 0, 0, fmt.Errorf("Is WinFSP installed? 'fsptool-x64.exe id' failed with error: %w", err)
 		}
 
 		idMap := make(map[string]string)


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief
`GetCurrentUser()` should return an error if WinFSP is not installed.
This was previously part of another PR which never merged.

### Checklist

- [ ] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #