### PR TITLE
Fix release file name issue

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -130,13 +130,13 @@ jobs:
       -
         name: Rename installer
         run: |
-          mv build/Output/cloudfuse.exe build/Output/cloudfuse_install_Windows_x86_64.exe
+          mv build/Output/cloudfuse.exe build/Output/cloudfuse_${{ echo github.ref_name | tr -d 'v' }}_windows_amd64.exe
       -
         name: Cache windows installer
         uses: actions/cache/save@v3
         with:
           enableCrossOsArchive: true
-          path: build/Output/cloudfuse_install_Windows_x86_64.exe
+          path: build/Output/cloudfuse_${{ echo github.ref_name | tr -d 'v' }}_windows_amd64.exe
           key: windows-cloudfuse-installer-${{ github.sha }}
 
   release:
@@ -172,7 +172,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           enableCrossOsArchive: true
-          path: build/Output/cloudfuse_install_Windows_x86_64.exe
+          path: build/Output/cloudfuse_${{ echo github.ref_name | tr -d 'v' }}_windows_amd64.exe
           key: windows-cloudfuse-installer-${{ github.sha }}
           fail-on-cache-miss: true
         continue-on-error: false

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -2,7 +2,7 @@ name: Release binaries
 on:
   push:
     tags:
-      - '*'
+      - 'v*'
 
 jobs:
   compile-gui:
@@ -128,15 +128,19 @@ jobs:
         run: |
           & "C:/Program Files (x86)/Inno Setup 6/iscc.exe" build/windows_installer_build.iss
       -
+        name: Set Version
+        id: get_version
+        run: echo ::set-output name=VERSION::$( echo ${{github.ref_name}} | tr -d 'v' )
+      -
         name: Rename installer
         run: |
-          mv build/Output/cloudfuse.exe build/Output/cloudfuse_${{ echo github.ref_name | tr -d 'v' }}_windows_amd64.exe
+          mv build/Output/cloudfuse.exe build/Output/cloudfuse_${{ steps.get_version.outputs.VERSION }}_windows_amd64.exe
       -
         name: Cache windows installer
         uses: actions/cache/save@v3
         with:
           enableCrossOsArchive: true
-          path: build/Output/cloudfuse_${{ echo github.ref_name | tr -d 'v' }}_windows_amd64.exe
+          path: build/Output/cloudfuse_${{ steps.get_version.outputs.VERSION }}_windows_amd64.exe
           key: windows-cloudfuse-installer-${{ github.sha }}
 
   release:
@@ -172,7 +176,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           enableCrossOsArchive: true
-          path: build/Output/cloudfuse_${{ echo github.ref_name | tr -d 'v' }}_windows_amd64.exe
+          path: build/Output/cloudfuse_${{ steps.get_version.outputs.VERSION }}_windows_amd64.exe
           key: windows-cloudfuse-installer-${{ github.sha }}
           fail-on-cache-miss: true
         continue-on-error: false

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -126,14 +126,6 @@ archives:
       - linux-amd64-health-monitor
     format: tar.gz
 
-    # this name template makes the OS and Arch compatible with the results of `uname`.
-    name_template: >-
-      {{ .ProjectName }}_
-      {{ .Version }}_
-      {{- title .Os }}_
-      {{- if eq .Arch "amd64" }}x86_64
-      {{- else }}{{ .Arch }}{{ end }}
-      {{- if .Arm }}v{{ .Arm }}{{ end }}
     files:
       - LICENSE
       - README.md
@@ -158,15 +150,6 @@ archives:
       - linux-arm64
       - linux-arm64-health-monitor
     format: tar.gz
-
-    # this name template makes the OS and Arch compatible with the results of `uname`.
-    name_template: >-
-      {{ .ProjectName }}_
-      {{ .Version }}_
-      {{- title .Os }}_
-      {{- if eq .Arch "amd64" }}x86_64
-      {{- else }}{{ .Arch }}{{ end }}
-      {{- if .Arm }}v{{ .Arm }}{{ end }}
     files:
       - LICENSE
       - README.md
@@ -190,14 +173,6 @@ archives:
       - windows-startup
       - windows-health-monitor
     format: zip
-    # this name template makes the OS and Arch compatible with the results of `uname`.
-    name_template: >-
-      {{ .ProjectName }}_
-      {{ .Version }}_
-      {{- title .Os }}_
-      {{- if eq .Arch "amd64" }}x86_64
-      {{- else }}{{ .Arch }}{{ end }}
-      {{- if .Arm }}v{{ .Arm }}{{ end }}
     files:
       - LICENSE
       - README.md

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -194,7 +194,7 @@ archives:
 
 release:
   extra_files: 
-    - glob: ./build/Output/cloudfuse_install_Windows_x86_64.exe
+    - glob: ./build/Output/cloudfuse_{{.Version}}_windows_amd64.exe
 
 nfpms:
   - id: default


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief

This fixes a naming issue in our released files where some file had an extra "." before the release version and other inconsistencies such as some referring to x86_64 and amd64. This has been fixed by using the default name in goreleaser for the releases.

Additionally, I fixed the name for the windows executable so it should follow the same filename as the rest of the files that goreleaser uses.

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #