### PR TITLE
Fix size of windows directory

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -56,6 +56,7 @@ const (
 
 	MbToBytes  = 1024 * 1024
 	GbToBytes  = 1024 * 1024 * 1024
+	PbToBytes  = 1024 * 1024 * 1024 * 1024 * 1024
 	CfuseStats = "cloudfuse_stats"
 
 	FuseAllowedFlags = "invalid FUSE options. Allowed FUSE configurations are: `-o attr_timeout=TIMEOUT`, `-o negative_timeout=TIMEOUT`, `-o entry_timeout=TIMEOUT` `-o allow_other`, `-o allow_root`, `-o umask=PERMISSIONS -o default_permissions`, `-o ro`"

--- a/component/libfuse/statfs_windows.go
+++ b/component/libfuse/statfs_windows.go
@@ -32,7 +32,6 @@ import (
 	"github.com/Seagate/cloudfuse/common/log"
 
 	"github.com/winfsp/cgofuse/fuse"
-	"golang.org/x/sys/windows"
 )
 
 // Statfs sets file system statistics. It returns 0 if successful.
@@ -59,18 +58,9 @@ func (cf *CgofuseFS) Statfs(path string, stat *fuse.Statfs_t) int {
 		stat.Namemax = attr.Namemax
 	} else {
 		var free, total, avail uint64
-
-		// Get path to the cache
-		pathPtr, err := windows.UTF16PtrFromString("/")
-		if err != nil {
-			log.Err("Libfuse::Statfs: Failed to get stats %s [%s]", name, err.Error())
-			return -fuse.EIO
-		}
-		err = windows.GetDiskFreeSpaceEx(pathPtr, &free, &total, &avail)
-		if err != nil {
-			log.Err("Libfuse::Statfs: Failed to get stats %s [%s]", name, err.Error())
-			return -fuse.EIO
-		}
+		total = common.PbToBytes
+		avail = total
+		free = total
 
 		const blockSize = 4096
 


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief

The size of the mounted directory on Windows is now reported as empty with a size of 1 PB. Before it was reporting an identical size of the users C: drive. This should signify that it is a cloud mount and is similar to an approach that rclone uses.

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #