### PR TITLE
Cache Directory List

### DIFF
--- a/component/attr_cache/attr_cache.go
+++ b/component/attr_cache/attr_cache.go
@@ -484,13 +484,15 @@ func (ac *AttrCache) StreamDir(options internal.StreamDirOptions) ([]*internal.O
 // and the token for the next page (if there is one).
 // If page requests are repeated or backtrack, this may cause unexpected OS behavior.
 func (ac *AttrCache) fetchCachedDirList(path string, token string) ([]*internal.ObjAttr, string, error) {
-	log.Trace("AttrCache::fetchCachedDirList : %s token=\"%s\"", path, token)
-
 	var pathList []*internal.ObjAttr
+
 	if !ac.cacheOnList {
 		log.Debug("AttrCache::fetchCachedDirList : %s cache on list is disabled", path)
 		return pathList, "", fmt.Errorf("cache on list is disabled")
 	}
+
+	log.Trace("AttrCache::fetchCachedDirList : %s token=\"%s\"", path, token)
+
 	listDirCache, found := ac.cache.get(path)
 	if !found {
 		log.Debug("AttrCache::fetchCachedDirList : %s directory not found in cache", path)

--- a/component/attr_cache/attr_cache.go
+++ b/component/attr_cache/attr_cache.go
@@ -30,7 +30,7 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"syscall"
@@ -343,9 +343,29 @@ func (ac *AttrCache) DeleteDir(options internal.DeleteDirOptions) error {
 func (ac *AttrCache) ReadDir(options internal.ReadDirOptions) (pathList []*internal.ObjAttr, err error) {
 	log.Trace("AttrCache::ReadDir : %s", options.Name)
 
+	// try to fetch listing from cache
+	cachedPathList, cachedToken, err := ac.fetchCachedDirList(options.Name, "")
+	if err == nil && cachedToken == "" {
+		// sort and return
+		slices.SortFunc[[]*internal.ObjAttr, *internal.ObjAttr](cachedPathList, func(a, b *internal.ObjAttr) int {
+			return strings.Compare(a.Path, b.Path)
+		})
+		return cachedPathList, err
+	}
+	// listing is not cached, call cloud storage
 	pathList, err = ac.NextComponent().ReadDir(options)
 	if err == nil {
-		ac.cacheAttributes(pathList)
+		// strip symlink attributes
+		if ac.noSymlinks {
+			for _, attr := range pathList {
+				if attr.IsSymlink() {
+					attr.Flags.Clear(internal.PropFlagSymlink)
+				}
+			}
+		}
+		// cache returned list
+		ac.cacheAttributes(pathList, options.Name, "")
+		//
 		if ac.cacheDirs {
 			// remember that this directory is in cloud storage
 			if len(pathList) > 0 {
@@ -354,10 +374,17 @@ func (ac *AttrCache) ReadDir(options internal.ReadDirOptions) (pathList []*inter
 			// merge directory cache into the results
 			var numAdded int // prevent shadowing pathList in following line
 			pathList, numAdded = ac.addDirsNotInCloudToListing(options.Name, pathList)
-			log.Trace("AttrCache::ReadDir : %s +%d from cache = %d",
+			log.Info("AttrCache::ReadDir : %s +%d from cache = %d",
 				options.Name, numAdded, len(pathList))
 		}
 	}
+
+	// values should be returned in ascending order by key, without duplicates
+	// sort
+	slices.SortFunc[[]*internal.ObjAttr, *internal.ObjAttr](pathList, func(a, b *internal.ObjAttr) int {
+		return strings.Compare(a.Path, b.Path)
+	})
+
 	return pathList, err
 }
 
@@ -380,21 +407,32 @@ func (ac *AttrCache) addDirsNotInCloudToListing(listPath string, pathList []*int
 	}
 	ac.cacheLock.RUnlock()
 
-	// values should be returned in ascending order by key
-	// sort the list before returning it
-	sort.Slice(pathList, func(i, j int) bool {
-		return pathList[i].Path < pathList[j].Path
-	})
-
 	return pathList, numAdded
 }
 
 // StreamDir : Optionally cache attributes of paths returned by next component
 func (ac *AttrCache) StreamDir(options internal.StreamDirOptions) ([]*internal.ObjAttr, string, error) {
-	log.Trace("AttrCache::StreamDir : %s", options.Name)
+	log.Trace("AttrCache::StreamDir : %s, token=\"%s\"", options.Name, options.Token)
 
+	// try to fetch listing from cache
+	cachedPathList, cachedToken, err := ac.fetchCachedDirList(options.Name, options.Token)
+	if err == nil {
+		// if we have all of it, return it
+		if cachedToken == "" {
+			// sort and return
+			slices.SortFunc[[]*internal.ObjAttr, *internal.ObjAttr](cachedPathList, func(a, b *internal.ObjAttr) int {
+				return strings.Compare(a.Path, b.Path)
+			})
+			return cachedPathList, cachedToken, err
+		}
+		// if there is more, let's get more
+		options.Token = cachedToken
+	}
+	// listing cache is not complete, so call cloud storage
 	pathList, token, err := ac.NextComponent().StreamDir(options)
 	if err == nil {
+		log.Debug("AttrCache::StreamDir : %s got %d entries from cloud, token=\"%s\"",
+			options.Name, len(pathList), token)
 		// strip symlink attributes
 		if ac.noSymlinks {
 			for _, attr := range pathList {
@@ -403,26 +441,84 @@ func (ac *AttrCache) StreamDir(options internal.StreamDirOptions) ([]*internal.O
 				}
 			}
 		}
-		// TODO: will limiting the number of items cached cause bugs when cacheDirs is enabled?
-		ac.cacheAttributes(pathList)
+		// cache returned list
+		ac.cacheAttributes(pathList, options.Name, token)
+		//
+		if ac.cacheDirs {
+			// remember that this directory is in cloud storage
+			if len(pathList) > 0 {
+				ac.markAncestorsInCloud(options.Name, time.Now())
+			}
+			// merge missing directory cache into the last page of results
+			if ac.cacheDirs && token == "" {
+				var numAdded int // prevent shadowing pathList in following line
+				pathList, numAdded = ac.addDirsNotInCloudToListing(options.Name, pathList)
+				log.Info("AttrCache::StreamDir : %s +%d from cache = %d",
+					options.Name, numAdded, len(pathList))
+			}
+		}
+	}
+	// add cached items in
+	if len(cachedPathList) > 0 {
+		log.Info("AttrCache::StreamDir : %s merging in %d list cache entries...", options.Name, len(cachedPathList))
+		pathList = append(pathList, cachedPathList...)
+	}
+	// values should be returned in ascending order by key, without duplicates
+	// sort
+	slices.SortFunc[[]*internal.ObjAttr, *internal.ObjAttr](pathList, func(a, b *internal.ObjAttr) int {
+		return strings.Compare(a.Path, b.Path)
+	})
+	// remove duplicates
+	pathList = slices.CompactFunc[[]*internal.ObjAttr, *internal.ObjAttr](pathList, func(a, b *internal.ObjAttr) bool {
+		return a.Path == b.Path
+	})
 
-		// merge missing directory cache into the last page of results
-		if ac.cacheDirs && token == "" {
-			var numAdded int // prevent shadowing pathList in following line
-			pathList, numAdded = ac.addDirsNotInCloudToListing(options.Name, pathList)
-			log.Trace("AttrCache::StreamDir : %s +%d from cache = %d",
-				options.Name, numAdded, len(pathList))
+	log.Trace("AttrCache::StreamDir : %s returning %d entries", options.Name, len(pathList))
+	return pathList, token, err
+}
+
+// Return directory listing from cache
+// Any request other than a request for the next page will return all children,
+// and the token for the next page (if there is one).
+// If page requests are repeated or backtrack, this may cause unexpected OS behavior.
+func (ac *AttrCache) fetchCachedDirList(path string, token string) ([]*internal.ObjAttr, string, error) {
+	log.Trace("AttrCache::fetchCachedDirList : %s token=\"%s\"", path, token)
+
+	var pathList []*internal.ObjAttr
+	listDirCache, getErr := ac.cacheMap.get(path)
+	if getErr != nil {
+		log.Debug("AttrCache::fetchCachedDirList : %s directory not found in cache", path)
+		return pathList, "", fmt.Errorf("%s directory not found in cache", path)
+	}
+	log.Debug("AttrCache::fetchCachedDirList : %s listing token=\"%s\"", path, listDirCache.listToken)
+	// check timeout
+	if time.Since(listDirCache.listedAt).Seconds() >= float64(ac.cacheTimeout) {
+		log.Debug("AttrCache::fetchCachedDirList : %s listing cache expired", path)
+		return pathList, "", fmt.Errorf("%s directory listing expired", path)
+	}
+	// don't provide cached data when new (uncached) data is being requested
+	if token != "" && token == listDirCache.listToken {
+		log.Debug("AttrCache::fetchCachedDirList : %s listing incomplete (requested token=\"%s\")", path, token)
+		return pathList, "", fmt.Errorf("%s directory listing is incomplete (%s token requested)", path, token)
+	}
+	// convert directory contents from map to slice
+	for _, item := range listDirCache.children {
+		if item.exists() {
+			pathList = append(pathList, item.attr)
 		}
 	}
 
-	return pathList, token, err
+	log.Debug("AttrCache::fetchCachedDirList : %s token=\"%s\"->\"%s\" serving %d items from cache",
+		path, token, listDirCache.listToken, len(listDirCache.children))
+	return pathList, listDirCache.listToken, nil
 }
 
 // cacheAttributes : On dir listing cache the attributes for all files
 // this will lock and release the mutex for writing
-func (ac *AttrCache) cacheAttributes(pathList []*internal.ObjAttr) {
+func (ac *AttrCache) cacheAttributes(pathList []*internal.ObjAttr, listDirPath string, token string) {
 	// Check whether or not we are supposed to cache on list
-	if ac.cacheOnList && len(pathList) > 0 {
+	if ac.cacheOnList {
+		log.Debug("AttrCache::cacheAttributes : %s token=\"%s\" caching %d attributes", listDirPath, token, len(pathList))
 		// Putting this inside loop is heavy as for each item we will do a kernel call to get current time
 		// If there are millions of blobs then cost of this is very high.
 		currTime := time.Now()
@@ -434,7 +530,16 @@ func (ac *AttrCache) cacheAttributes(pathList []*internal.ObjAttr) {
 		}
 		// pathList was returned by the cloud storage component when listing a directory
 		// so that directory is clearly in the cloud
-		ac.markAncestorsInCloud(getParentDir(pathList[0].Path), currTime)
+		ac.markAncestorsInCloud(listDirPath, currTime)
+		// record when the directory was listed, an up to what token
+		// this will allow us to serve directory listings from this cache
+		listDirItem, err := ac.cacheMap.get(listDirPath)
+		if err != nil {
+			log.Err("AttrCache::cacheAttributes : %s failed to cache directory listing state", listDirPath)
+			return
+		}
+		listDirItem.listedAt = currTime
+		listDirItem.listToken = token
 	}
 }
 

--- a/component/attr_cache/attr_cache_test.go
+++ b/component/attr_cache/attr_cache_test.go
@@ -198,7 +198,6 @@ func generateDirectory(path string) (*list.List, *list.List, *list.List) {
 func generateNestedPathAttr(path string, size int64, mode os.FileMode) []*internal.ObjAttr {
 	a, _, _ := generateDirectory(path)
 	pathAttrs := make([]*internal.ObjAttr, 0)
-	i := 0
 	for p := a.Front(); p != nil; p = p.Next() {
 		pString := p.Value.(string)
 		isDir := pString[len(pString)-1] == '/'
@@ -208,7 +207,17 @@ func generateNestedPathAttr(path string, size int64, mode os.FileMode) []*intern
 			newPathAttr = getDirPathAttr(pString)
 		}
 		pathAttrs = append(pathAttrs, newPathAttr)
-		i++
+	}
+	return pathAttrs
+}
+
+func generateListPathAttr(path string, numEntries int) []*internal.ObjAttr {
+	path = internal.TruncateDirName(path)
+	pathAttrs := make([]*internal.ObjAttr, 0)
+	for i := 0; i < numEntries; i++ {
+		filename := fmt.Sprintf("%s/file%d", path, i)
+		newPathAttr := getPathAttr(filename, defaultSize, fs.FileMode(defaultMode), true)
+		pathAttrs = append(pathAttrs, newPathAttr)
 	}
 	return pathAttrs
 }
@@ -507,7 +516,7 @@ func (suite *attrCacheTestSuite) TestReadDirDoesNotExist() {
 
 			// Success
 			// Entries Do Not Already Exist
-			suite.mock.EXPECT().ReadDir(options).Return(aAttr, nil)
+			suite.mock.EXPECT().ReadDir(options).Return(aAttr, nil).Times(1)
 
 			suite.assert.Empty(suite.attrCache.cacheMap.children) // cacheMap should be empty before call
 			returnedAttr, err := suite.attrCache.ReadDir(options)
@@ -526,6 +535,12 @@ func (suite *attrCacheTestSuite) TestReadDirDoesNotExist() {
 				suite.assert.True(checkItem.valid())
 				suite.assert.True(checkItem.exists())
 			}
+
+			// test same result from subsequent call without using cloud storage
+			returnedAttr, err = suite.attrCache.ReadDir(options)
+			suite.assert.Nil(err)
+			aDepth1Attr := append(aAttr[1:2], aAttr[3])
+			suite.assert.Equal(aDepth1Attr, returnedAttr)
 		})
 	}
 }
@@ -553,7 +568,7 @@ func (suite *attrCacheTestSuite) TestReadDirExists() {
 			for _, p := range aAttr {
 				suite.assertUntouched(p.Path)
 			}
-			suite.mock.EXPECT().ReadDir(options).Return(aAttr, nil)
+			suite.mock.EXPECT().ReadDir(options).Return(aAttr, nil).Times(1)
 			returnedAttr, err := suite.attrCache.ReadDir(options)
 			suite.assert.Nil(err)
 			suite.assert.Equal(aAttr, returnedAttr)
@@ -580,6 +595,312 @@ func (suite *attrCacheTestSuite) TestReadDirExists() {
 				cachePath := internal.TruncateDirName(pString)
 				suite.assertUntouched(cachePath)
 			}
+
+			// test same result from subsequent call without using cloud storage
+			returnedAttr, err = suite.attrCache.ReadDir(options)
+			suite.assert.Nil(err)
+			aDepth1Attr := append(aAttr[1:2], aAttr[3])
+			suite.assert.Equal(aDepth1Attr, returnedAttr)
+		})
+	}
+}
+
+func (suite *attrCacheTestSuite) TestReadDirNoCacheOnList() {
+	defer suite.cleanupTest()
+	suite.cleanupTest() // clean up the default attr cache generated
+	cacheOnList := false
+	config := fmt.Sprintf("attr_cache:\n  no-cache-on-list: %t", !cacheOnList)
+	suite.setupTestHelper(config) // setup a new attr cache with a custom config (clean up will occur after the test as usual)
+	suite.assert.EqualValues(cacheOnList, suite.attrCache.cacheOnList)
+	path := "a"
+	size := int64(1024)
+	mode := os.FileMode(0)
+	aAttr := generateNestedPathAttr(path, size, mode)
+
+	options := internal.ReadDirOptions{Name: path}
+	suite.mock.EXPECT().ReadDir(options).Return(aAttr, nil).Times(1)
+
+	suite.assert.Empty(suite.attrCache.cacheMap.children) // cacheMap should be empty before call
+	returnedAttr, err := suite.attrCache.ReadDir(options)
+	suite.assert.Nil(err)
+	suite.assert.Equal(aAttr, returnedAttr)
+
+	// cacheMap should only have the listed after the call
+	suite.assertExists(path)
+}
+
+func (suite *attrCacheTestSuite) TestReadDirNoCacheOnListNoCacheDirs() {
+	defer suite.cleanupTest()
+	suite.cleanupTest() // clean up the default attr cache generated
+	cacheOnList := false
+	cacheDirs := false
+	config := fmt.Sprintf("attr_cache:\n  no-cache-on-list: %t\n  no-cache-dirs: %t", !cacheOnList, !cacheDirs)
+	suite.setupTestHelper(config) // setup a new attr cache with a custom config (clean up will occur after the test as usual)
+	suite.assert.EqualValues(cacheOnList, suite.attrCache.cacheOnList)
+	suite.assert.EqualValues(cacheDirs, suite.attrCache.cacheDirs)
+	path := "a"
+	size := int64(1024)
+	mode := os.FileMode(0)
+	aAttr := generateNestedPathAttr(path, size, mode)
+
+	options := internal.ReadDirOptions{Name: path}
+	suite.mock.EXPECT().ReadDir(options).Return(aAttr, nil).Times(1)
+
+	suite.assert.Empty(suite.attrCache.cacheMap.children) // cacheMap should be empty before call
+	returnedAttr, err := suite.attrCache.ReadDir(options)
+	suite.assert.Nil(err)
+	suite.assert.Equal(aAttr, returnedAttr)
+
+	suite.assert.Empty(suite.attrCache.cacheMap.children) // cacheMap should be empty after call
+}
+
+func (suite *attrCacheTestSuite) TestReadDirError() {
+	defer suite.cleanupTest()
+	var paths = []string{"a", "a/", "ab", "ab/"}
+
+	for _, path := range paths {
+		// This is a little janky but required since testify suite does not support running setup or clean up for subtests.
+		suite.cleanupTest()
+		suite.SetupTest()
+		suite.Run(path, func() {
+			truncatedPath := internal.TruncateDirName(path)
+			options := internal.ReadDirOptions{Name: path}
+
+			// Error
+			suite.mock.EXPECT().ReadDir(options).Return(make([]*internal.ObjAttr, 0), errors.New("Failed to read a directory"))
+
+			_, err := suite.attrCache.ReadDir(options)
+			suite.assert.NotNil(err)
+			suite.assertNotInCache(truncatedPath)
+		})
+	}
+}
+
+// Tests Stream Directory
+func (suite *attrCacheTestSuite) TestStreamDirDoesNotExist() {
+	defer suite.cleanupTest()
+	var paths = []string{"a", "a/"}
+	size := int64(1024)
+	mode := os.FileMode(0)
+
+	for _, path := range paths {
+		// This is a little janky but required since testify suite does not support running setup or clean up for subtests.
+		suite.cleanupTest()
+		suite.SetupTest()
+		suite.Run(path, func() {
+			aAttr := generateNestedPathAttr(path, size, mode)
+
+			options := internal.StreamDirOptions{Name: path}
+
+			// Success
+			// Entries Do Not Already Exist
+			suite.mock.EXPECT().StreamDir(options).Return(aAttr, "", nil).Times(1)
+
+			suite.assert.Empty(suite.attrCache.cacheMap.children) // cacheMap should be empty before call
+			returnedAttr, token, err := suite.attrCache.StreamDir(options)
+			suite.assert.Nil(err)
+			suite.assert.Equal(aAttr, returnedAttr)
+			suite.assert.Empty(token)
+
+			// Entries should now be in the cache
+			for _, p := range aAttr {
+				checkItem, err := suite.attrCache.cacheMap.get(p.Path)
+				suite.assert.Nil(err)
+				suite.assert.NotEqualValues(checkItem.attr, &internal.ObjAttr{})
+				if !p.IsDir() {
+					suite.assert.EqualValues(size, checkItem.attr.Size) // new size should be set
+					suite.assert.EqualValues(mode, checkItem.attr.Mode) // new mode should be set
+				}
+				suite.assert.True(checkItem.valid())
+				suite.assert.True(checkItem.exists())
+			}
+
+			// test same result from subsequent call without using cloud storage
+			returnedAttr, token, err = suite.attrCache.StreamDir(options)
+			suite.assert.Nil(err)
+			suite.assert.Empty(token)
+			aDepth1Attr := append(aAttr[1:2], aAttr[3])
+			suite.assert.Equal(aDepth1Attr, returnedAttr)
+		})
+	}
+}
+
+func (suite *attrCacheTestSuite) TestStreamDirPaginated() {
+	defer suite.cleanupTest()
+	path := "a"
+	manyAttr := generateListPathAttr(path, 6)
+	mockTokens := []string{"firstPair", "secondPair"}
+
+	// return first two results
+	options := internal.StreamDirOptions{Name: path, Token: "", Count: 2}
+	suite.mock.EXPECT().StreamDir(options).Return(manyAttr[0:2], mockTokens[0], nil).Times(1)
+
+	suite.assert.Empty(suite.attrCache.cacheMap.children) // cacheMap should be empty before call
+	returnedAttr, token, err := suite.attrCache.StreamDir(options)
+	suite.assert.Nil(err)
+	suite.assert.Equal(mockTokens[0], token)
+	suite.assert.Equal(manyAttr[0:2], returnedAttr)
+
+	// return second pair of results
+	options = internal.StreamDirOptions{Name: path, Token: mockTokens[0], Count: 2}
+	suite.mock.EXPECT().StreamDir(options).Return(manyAttr[2:4], mockTokens[1], nil).Times(1)
+
+	returnedAttr, token, err = suite.attrCache.StreamDir(options)
+	suite.assert.Nil(err)
+	suite.assert.Equal(mockTokens[1], token)
+	suite.assert.Equal(manyAttr[2:4], returnedAttr)
+
+	// return last pair of results
+	options = internal.StreamDirOptions{Name: path, Token: mockTokens[1], Count: 2}
+	suite.mock.EXPECT().StreamDir(options).Return(manyAttr[4:6], "", nil).Times(1)
+
+	returnedAttr, token, err = suite.attrCache.StreamDir(options)
+	suite.assert.Nil(err)
+	suite.assert.Empty(token)
+	suite.assert.Equal(manyAttr[4:6], returnedAttr)
+
+	// request the first page again
+	options = internal.StreamDirOptions{Name: path, Token: "", Count: 2}
+	// there should be no cloud requests
+	suite.mock.EXPECT().StreamDir(options).Times(0)
+
+	returnedAttr, token, err = suite.attrCache.StreamDir(options)
+	// the entire listing should be returned from cache
+	suite.assert.Nil(err)
+	suite.assert.Empty(token)
+	suite.assert.Equal(manyAttr, returnedAttr)
+}
+
+func (suite *attrCacheTestSuite) TestStreamDirExists() {
+	defer suite.cleanupTest()
+	var paths = []string{"a", "a/"}
+	size := int64(1024)
+	mode := os.FileMode(0)
+
+	for _, path := range paths {
+		// This is a little janky but required since testify suite does not support running setup or clean up for subtests.
+		suite.cleanupTest()
+		suite.SetupTest()
+		suite.Run(path, func() {
+			aAttr := generateNestedPathAttr(path, size, mode)
+
+			options := internal.StreamDirOptions{Name: path}
+
+			// Success
+			// Entries Already Exist
+			a, ab, ac := suite.addDirectoryToCache(path, false)
+
+			suite.assert.NotEmpty(suite.attrCache.cacheMap) // cacheMap should NOT be empty before read dir call and values should be untouched
+			for _, p := range aAttr {
+				suite.assertUntouched(p.Path)
+			}
+			suite.mock.EXPECT().StreamDir(options).Return(aAttr, "", nil).Times(1)
+			returnedAttr, token, err := suite.attrCache.StreamDir(options)
+			suite.assert.Nil(err)
+			suite.assert.Empty(token)
+			suite.assert.Equal(aAttr, returnedAttr)
+
+			// a paths should now be updated in the cache
+			for p := a.Front(); p != nil; p = p.Next() {
+				pString := p.Value.(string)
+				cachePath := internal.TruncateDirName(pString)
+				checkItem, err := suite.attrCache.cacheMap.get(cachePath)
+				suite.assert.Nil(err)
+				suite.assert.NotEqualValues(checkItem.attr, &internal.ObjAttr{})
+				if !checkItem.attr.IsDir() {
+					suite.assert.EqualValues(size, checkItem.attr.Size) // new size should be set
+					suite.assert.EqualValues(mode, checkItem.attr.Mode) // new mode should be set
+				}
+				suite.assert.True(checkItem.valid())
+				suite.assert.True(checkItem.exists())
+			}
+
+			// ab and ac paths should be untouched
+			ab.PushBackList(ac)
+			for p := ab.Front(); p != nil; p = p.Next() {
+				pString := p.Value.(string)
+				cachePath := internal.TruncateDirName(pString)
+				suite.assertUntouched(cachePath)
+			}
+
+			// test same result from subsequent call without using cloud storage
+			returnedAttr, token, err = suite.attrCache.StreamDir(options)
+			suite.assert.Nil(err)
+			suite.assert.Empty(token)
+			aDepth1Attr := append(aAttr[1:2], aAttr[3])
+			suite.assert.Equal(aDepth1Attr, returnedAttr)
+		})
+	}
+}
+
+func (suite *attrCacheTestSuite) TestStreamDirNoCacheOnList() {
+	defer suite.cleanupTest()
+	suite.cleanupTest() // clean up the default attr cache generated
+	cacheOnList := false
+	config := fmt.Sprintf("attr_cache:\n  no-cache-on-list: %t", !cacheOnList)
+	suite.setupTestHelper(config) // setup a new attr cache with a custom config (clean up will occur after the test as usual)
+	suite.assert.EqualValues(cacheOnList, suite.attrCache.cacheOnList)
+	path := "a"
+	size := int64(1024)
+	mode := os.FileMode(0)
+	aAttr := generateNestedPathAttr(path, size, mode)
+
+	options := internal.StreamDirOptions{Name: path}
+	suite.mock.EXPECT().StreamDir(options).Return(aAttr, "", nil).Times(1)
+
+	suite.assert.Empty(suite.attrCache.cacheMap.children) // cacheMap should be empty before call
+	returnedAttr, token, err := suite.attrCache.StreamDir(options)
+	suite.assert.Nil(err)
+	suite.assert.Empty(token)
+	suite.assert.Equal(aAttr, returnedAttr)
+
+	// cacheMap should only have the listed after the call
+	suite.assertExists(path)
+}
+
+func (suite *attrCacheTestSuite) TestStreamDirNoCacheOnListNoCacheDirs() {
+	defer suite.cleanupTest()
+	suite.cleanupTest() // clean up the default attr cache generated
+	cacheOnList := false
+	cacheDirs := false
+	config := fmt.Sprintf("attr_cache:\n  no-cache-on-list: %t\n  no-cache-dirs: %t", !cacheOnList, !cacheDirs)
+	suite.setupTestHelper(config) // setup a new attr cache with a custom config (clean up will occur after the test as usual)
+	suite.assert.EqualValues(cacheOnList, suite.attrCache.cacheOnList)
+	suite.assert.EqualValues(cacheDirs, suite.attrCache.cacheDirs)
+	path := "a"
+	size := int64(1024)
+	mode := os.FileMode(0)
+	aAttr := generateNestedPathAttr(path, size, mode)
+
+	options := internal.StreamDirOptions{Name: path}
+	suite.mock.EXPECT().StreamDir(options).Return(aAttr, "", nil)
+
+	suite.assert.Empty(suite.attrCache.cacheMap.children) // cacheMap should be empty before call
+	returnedAttr, _, err := suite.attrCache.StreamDir(options)
+	suite.assert.Nil(err)
+	suite.assert.Equal(aAttr, returnedAttr)
+
+	suite.assert.Empty(suite.attrCache.cacheMap.children) // cacheMap should be empty after call
+}
+
+func (suite *attrCacheTestSuite) TestStreamDirError() {
+	defer suite.cleanupTest()
+	var paths = []string{"a", "a/", "ab", "ab/"}
+
+	for _, path := range paths {
+		// This is a little janky but required since testify suite does not support running setup or clean up for subtests.
+		suite.cleanupTest()
+		suite.SetupTest()
+		suite.Run(path, func() {
+			truncatedPath := internal.TruncateDirName(path)
+			options := internal.StreamDirOptions{Name: path}
+
+			// Error
+			suite.mock.EXPECT().StreamDir(options).Return(make([]*internal.ObjAttr, 0), "", errors.New("Failed to read a directory"))
+
+			_, _, err := suite.attrCache.StreamDir(options)
+			suite.assert.NotNil(err)
+			suite.assertNotInCache(truncatedPath)
 		})
 	}
 }
@@ -613,77 +934,6 @@ func (suite *attrCacheTestSuite) TestDirInCloud() {
 	suite.assertInCloud("a/b/c")
 	suite.assertInCloud("a/b")
 	suite.assertInCloud("a")
-}
-
-func (suite *attrCacheTestSuite) TestReadDirNoCacheOnList() {
-	defer suite.cleanupTest()
-	suite.cleanupTest() // clean up the default attr cache generated
-	cacheOnList := false
-	config := fmt.Sprintf("attr_cache:\n  no-cache-on-list: %t", !cacheOnList)
-	suite.setupTestHelper(config) // setup a new attr cache with a custom config (clean up will occur after the test as usual)
-	suite.assert.EqualValues(cacheOnList, suite.attrCache.cacheOnList)
-	path := "a"
-	size := int64(1024)
-	mode := os.FileMode(0)
-	aAttr := generateNestedPathAttr(path, size, mode)
-
-	options := internal.ReadDirOptions{Name: path}
-	suite.mock.EXPECT().ReadDir(options).Return(aAttr, nil)
-
-	suite.assert.Empty(suite.attrCache.cacheMap.children) // cacheMap should be empty before call
-	returnedAttr, err := suite.attrCache.ReadDir(options)
-	suite.assert.Nil(err)
-	suite.assert.Equal(aAttr, returnedAttr)
-
-	// cacheMap should only have the listed after the call
-	suite.assertExists(path)
-}
-
-func (suite *attrCacheTestSuite) TestReadDirNoCacheOnListNoCacheDirs() {
-	defer suite.cleanupTest()
-	suite.cleanupTest() // clean up the default attr cache generated
-	cacheOnList := false
-	cacheDirs := false
-	config := fmt.Sprintf("attr_cache:\n  no-cache-on-list: %t\n  no-cache-dirs: %t", !cacheOnList, !cacheDirs)
-	suite.setupTestHelper(config) // setup a new attr cache with a custom config (clean up will occur after the test as usual)
-	suite.assert.EqualValues(cacheOnList, suite.attrCache.cacheOnList)
-	suite.assert.EqualValues(cacheDirs, suite.attrCache.cacheDirs)
-	path := "a"
-	size := int64(1024)
-	mode := os.FileMode(0)
-	aAttr := generateNestedPathAttr(path, size, mode)
-
-	options := internal.ReadDirOptions{Name: path}
-	suite.mock.EXPECT().ReadDir(options).Return(aAttr, nil)
-
-	suite.assert.Empty(suite.attrCache.cacheMap.children) // cacheMap should be empty before call
-	returnedAttr, err := suite.attrCache.ReadDir(options)
-	suite.assert.Nil(err)
-	suite.assert.Equal(aAttr, returnedAttr)
-
-	suite.assert.Empty(suite.attrCache.cacheMap.children) // cacheMap should be empty after call
-}
-
-func (suite *attrCacheTestSuite) TestReadDirError() {
-	defer suite.cleanupTest()
-	var paths = []string{"a", "a/", "ab", "ab/"}
-
-	for _, path := range paths {
-		// This is a little janky but required since testify suite does not support running setup or clean up for subtests.
-		suite.cleanupTest()
-		suite.SetupTest()
-		suite.Run(path, func() {
-			truncatedPath := internal.TruncateDirName(path)
-			options := internal.ReadDirOptions{Name: path}
-
-			// Error
-			suite.mock.EXPECT().ReadDir(options).Return(make([]*internal.ObjAttr, 0), errors.New("Failed to read a directory"))
-
-			_, err := suite.attrCache.ReadDir(options)
-			suite.assert.NotNil(err)
-			suite.assertNotInCache(truncatedPath)
-		})
-	}
 }
 
 func (suite *attrCacheTestSuite) TestIsDirEmpty() {

--- a/component/attr_cache/cacheMap.go
+++ b/component/attr_cache/cacheMap.go
@@ -46,10 +46,12 @@ const (
 
 // attrCacheItem : Structure of each item in attr cache
 type attrCacheItem struct {
-	attr     *internal.ObjAttr
-	cachedAt time.Time
-	attrFlag common.BitMap16
-	children map[string]*attrCacheItem
+	attr      *internal.ObjAttr
+	cachedAt  time.Time
+	listedAt  time.Time
+	listToken string
+	attrFlag  common.BitMap16
+	children  map[string]*attrCacheItem
 }
 
 func newAttrCacheItem(attr *internal.ObjAttr, exists bool, cachedAt time.Time) *attrCacheItem {

--- a/component/libfuse/libfuse2_handler.go
+++ b/component/libfuse/libfuse2_handler.go
@@ -382,6 +382,7 @@ func (cf *CgofuseFS) Opendir(path string) (int, uint64) {
 	})
 
 	fh := handlemap.Add(handle)
+	log.Debug("Libfuse::Opendir : %s fh=%d", name, fh)
 
 	// This needs to return a uint64 representing the filehandle
 	// We have to do a casting here to make the Go compiler happy but
@@ -408,6 +409,7 @@ func (cf *CgofuseFS) Releasedir(path string, fh uint64) int {
 // Readdir reads a directory at the path.
 func (cf *CgofuseFS) Readdir(path string, fill func(name string, stat *fuse.Stat_t, ofst int64) bool,
 	ofst int64, fh uint64) int {
+	log.Debug("Libfuse::Readdir : %s, offset: %d, handle: %d", path, ofst, fh)
 	handle, exists := handlemap.Load(handlemap.HandleID(fh))
 	if !exists {
 		log.Trace("Libfuse::Readdir : Failed to read %s, handle: %d", path, fh)
@@ -424,6 +426,8 @@ func (cf *CgofuseFS) Readdir(path string, fill func(name string, stat *fuse.Stat
 
 	ofst64 := uint64(ofst)
 	cacheInfo := val.(*dirChildCache)
+	log.Debug("Libfuse::Readdir : %s, offset: %d, handle: %d - cached %d-%d (token=%s)",
+		path, ofst, fh, cacheInfo.sIndex, cacheInfo.eIndex, cacheInfo.token)
 	if ofst64 == 0 ||
 		(ofst64 >= cacheInfo.eIndex && cacheInfo.token != "") {
 		attrs, token, err := fuseFS.NextComponent().StreamDir(internal.StreamDirOptions{

--- a/component/s3storage/s3storage.go
+++ b/component/s3storage/s3storage.go
@@ -255,7 +255,7 @@ func (s3 *S3Storage) StreamDir(options internal.StreamDirOptions) ([]*internal.O
 		if marker == nil || *marker == "" {
 			break
 		} else {
-			log.Debug("S3Storage::StreamDir : %s %d nextMarker=\"%s\"",
+			log.Debug("S3Storage::StreamDir : %s List iteration %d nextMarker=\"%s\"",
 				options.Name, iteration, *nextMarker)
 		}
 	}

--- a/component/s3storage/s3storage.go
+++ b/component/s3storage/s3storage.go
@@ -240,19 +240,23 @@ func (s3 *S3Storage) StreamDir(options internal.StreamDirOptions) ([]*internal.O
 	var marker *string = &options.Token // = nil
 	var totalEntriesFetched int32
 	for totalEntriesFetched < options.Count {
-		newList, newMarker, err := s3.storage.List(path, marker, options.Count-totalEntriesFetched)
+		newList, nextMarker, err := s3.storage.List(path, marker, options.Count-totalEntriesFetched)
 		if err != nil {
 			log.Err("S3Storage::StreamDir : %s Failed to read dir [%s]", options.Name, err)
 			return objectList, "", err
 		}
 		objectList = append(objectList, newList...)
-		marker = newMarker
+		marker = nextMarker
 		iteration++
-		totalEntriesFetched += int32(len(objectList))
+		totalEntriesFetched += int32(len(newList))
 
-		log.Debug("S3Storage::StreamDir : %s So far retrieved %d objects in %d iterations", options.Name, totalEntriesFetched, iteration)
+		log.Debug("S3Storage::StreamDir : %s So far retrieved %d objects in %d iterations",
+			options.Name, totalEntriesFetched, iteration)
 		if marker == nil || *marker == "" {
 			break
+		} else {
+			log.Debug("S3Storage::StreamDir : %s %d nextMarker=\"%s\"",
+				options.Name, iteration, *nextMarker)
 		}
 	}
 

--- a/component/s3storage/s3wrappers.go
+++ b/component/s3storage/s3wrappers.go
@@ -289,12 +289,12 @@ func (cl *Client) ListBuckets() ([]string, error) {
 // If count=0 - fetch max entries.
 // the *string being returned is the token / marker and will be nil when the listing is complete.
 func (cl *Client) List(prefix string, marker *string, count int32) ([]*internal.ObjAttr, *string, error) {
-	log.Trace("Client::List : prefix %s, marker %s", prefix, func(marker *string) string {
+	log.Trace("Client::List : prefix %s, marker %s, count %d", prefix, func(marker *string) string {
 		if marker != nil {
 			return *marker
 		}
 		return ""
-	}(marker))
+	}(marker), count)
 
 	// prepare parameters
 	bucketName := cl.Config.authConfig.BucketName
@@ -415,6 +415,8 @@ func (cl *Client) List(prefix string, marker *string, count int32) ([]*internal.
 	sort.Slice(objectAttrList, func(i, j int) bool {
 		return objectAttrList[i].Path < objectAttrList[j].Path
 	})
+
+	log.Debug("Client::List : %s returning %d entries", prefix, len(objectAttrList))
 
 	return objectAttrList, newMarker, nil
 }

--- a/internal/mock_component.go
+++ b/internal/mock_component.go
@@ -415,19 +415,26 @@ func (m *MockComponent) ReadDir(arg0 ReadDirOptions) ([]*ObjAttr, error) {
 	return ret0, ret1
 }
 
-// ReadDir mocks base method.
+// StreamDir mocks base method.
 func (m *MockComponent) StreamDir(arg0 StreamDirOptions) ([]*ObjAttr, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StreamDir", arg0)
 	ret0, _ := ret[0].([]*ObjAttr)
-	ret1, _ := ret[1].(error)
-	return ret0, "", ret1
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // ReadDir indicates an expected call of ReadDir.
 func (mr *MockComponentMockRecorder) ReadDir(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadDir", reflect.TypeOf((*MockComponent)(nil).ReadDir), arg0)
+}
+
+// StreamDir indicates an expected call of StreamDir.
+func (mr *MockComponentMockRecorder) StreamDir(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamDir", reflect.TypeOf((*MockComponent)(nil).StreamDir), arg0)
 }
 
 // ReadFile mocks base method.

--- a/setup/baseConfig.yaml
+++ b/setup/baseConfig.yaml
@@ -116,8 +116,8 @@ file_cache:
   
 # Attribute cache related configuration
 attr_cache:
-  timeout-sec: <time attributes can be cached (in sec). Default - 120 sec>
-  no-cache-on-list: true|false <do not cache attributes during listing, to optimize performance>
+  timeout-sec: <time attributes and directory contents can be cached (in sec). Default - 120 sec>
+  no-cache-on-list: true|false <do not cache attributes or directory contents during listing. Enabling this flag may cause performance problems.>
   no-symlinks: true|false <to improve performance disable symlink support. symlinks will be treated like regular files.>
   max-files: <maximum number of files in the attribute cache at a time. Default - 5000000>
   no-cache-dirs: true|false <to prevent double-listing directories and to make timestamps accurate, disable caching directories. Breaks s3storage.>


### PR DESCRIPTION
Bugfix: bad math in S3storage::StreamDir.
Keep filling dir list cache when OS re-lists from the beginning (>MaxDirListCount entries).


### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

### Describe your changes in brief
Use attr_cache to respond to StreamDir and ReadDir without using cloud storage.
Respect attr_cache `timeout-sec`.
Use repeated OS `Readdir` calls with zero offset to complete directory listing despite bad OS behavior.

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [x] Added tests

### Related Issues

- Closes [#81](https://github.com/Seagate/cloudfuse/issues/81)