### PR TITLE
Use Offsets and a Token Cache for Readdir

### DIFF
--- a/component/attr_cache/attr_cache_test.go
+++ b/component/attr_cache/attr_cache_test.go
@@ -735,43 +735,62 @@ func (suite *attrCacheTestSuite) TestStreamDirPaginated() {
 	mockTokens := []string{"firstPair", "secondPair"}
 
 	// return first two results
-	options := internal.StreamDirOptions{Name: path, Token: "", Count: 2}
-	suite.mock.EXPECT().StreamDir(options).Return(manyAttr[0:2], mockTokens[0], nil).Times(1)
+	options0 := internal.StreamDirOptions{Name: path, Token: "", Count: 2}
+	suite.mock.EXPECT().StreamDir(options0).Return(manyAttr[0:2], mockTokens[0], nil).Times(1)
 
 	suite.assertCacheEmpty() // cacheMap should be empty before call
-	returnedAttr, token, err := suite.attrCache.StreamDir(options)
+	returnedAttr, token, err := suite.attrCache.StreamDir(options0)
+	suite.assert.Nil(err)
+	suite.assert.Equal(mockTokens[0], token)
+	suite.assert.Equal(manyAttr[0:2], returnedAttr)
+
+	returnedAttr, token, err = suite.attrCache.StreamDir(options0)
 	suite.assert.Nil(err)
 	suite.assert.Equal(mockTokens[0], token)
 	suite.assert.Equal(manyAttr[0:2], returnedAttr)
 
 	// return second pair of results
-	options = internal.StreamDirOptions{Name: path, Token: mockTokens[0], Count: 2}
-	suite.mock.EXPECT().StreamDir(options).Return(manyAttr[2:4], mockTokens[1], nil).Times(1)
+	options1 := internal.StreamDirOptions{Name: path, Token: mockTokens[0], Count: 2}
+	suite.mock.EXPECT().StreamDir(options1).Return(manyAttr[2:4], mockTokens[1], nil).Times(1)
 
-	returnedAttr, token, err = suite.attrCache.StreamDir(options)
+	returnedAttr, token, err = suite.attrCache.StreamDir(options1)
+	suite.assert.Nil(err)
+	suite.assert.Equal(mockTokens[1], token)
+	suite.assert.Equal(manyAttr[2:4], returnedAttr)
+
+	returnedAttr, token, err = suite.attrCache.StreamDir(options0)
+	suite.assert.Nil(err)
+	suite.assert.Equal(mockTokens[0], token)
+	suite.assert.Equal(manyAttr[0:2], returnedAttr)
+
+	returnedAttr, token, err = suite.attrCache.StreamDir(options1)
 	suite.assert.Nil(err)
 	suite.assert.Equal(mockTokens[1], token)
 	suite.assert.Equal(manyAttr[2:4], returnedAttr)
 
 	// return last pair of results
-	options = internal.StreamDirOptions{Name: path, Token: mockTokens[1], Count: 2}
-	suite.mock.EXPECT().StreamDir(options).Return(manyAttr[4:6], "", nil).Times(1)
+	options2 := internal.StreamDirOptions{Name: path, Token: mockTokens[1], Count: 2}
+	suite.mock.EXPECT().StreamDir(options2).Return(manyAttr[4:6], "", nil).Times(1)
 
-	returnedAttr, token, err = suite.attrCache.StreamDir(options)
+	returnedAttr, token, err = suite.attrCache.StreamDir(options2)
 	suite.assert.Nil(err)
 	suite.assert.Empty(token)
 	suite.assert.Equal(manyAttr[4:6], returnedAttr)
 
-	// request the first page again
-	options = internal.StreamDirOptions{Name: path, Token: "", Count: 2}
-	// there should be no cloud requests
-	suite.mock.EXPECT().StreamDir(options).Times(0)
+	returnedAttr, token, err = suite.attrCache.StreamDir(options0)
+	suite.assert.Nil(err)
+	suite.assert.Equal(mockTokens[0], token)
+	suite.assert.Equal(manyAttr[0:2], returnedAttr)
 
-	returnedAttr, token, err = suite.attrCache.StreamDir(options)
-	// the entire listing should be returned from cache
+	returnedAttr, token, err = suite.attrCache.StreamDir(options1)
+	suite.assert.Nil(err)
+	suite.assert.Equal(mockTokens[1], token)
+	suite.assert.Equal(manyAttr[2:4], returnedAttr)
+
+	returnedAttr, token, err = suite.attrCache.StreamDir(options2)
 	suite.assert.Nil(err)
 	suite.assert.Empty(token)
-	suite.assert.Equal(manyAttr, returnedAttr)
+	suite.assert.Equal(manyAttr[4:6], returnedAttr)
 }
 
 func (suite *attrCacheTestSuite) TestStreamDirExists() {

--- a/component/attr_cache/cacheMap.go
+++ b/component/attr_cache/cacheMap.go
@@ -42,14 +42,20 @@ const (
 	AttrFlagNotInCloud
 )
 
+// list token cache
+type tokenCache struct {
+	entries   []*internal.ObjAttr
+	nextToken string
+}
+
 // attrCacheItem : Structure of each item in attr cache
 type attrCacheItem struct {
-	attr      *internal.ObjAttr
-	cachedAt  time.Time
-	listedAt  time.Time
-	listToken string
-	attrFlag  common.BitMap16
-	children  map[string]*attrCacheItem
+	attr     *internal.ObjAttr
+	cachedAt time.Time
+	listedAt time.Time
+	tokens   map[string]tokenCache
+	attrFlag common.BitMap16
+	children map[string]*attrCacheItem
 }
 
 // all cache entries are organized into this structure

--- a/component/libfuse/libfuse2_handler.go
+++ b/component/libfuse/libfuse2_handler.go
@@ -446,7 +446,7 @@ func (cf *CgofuseFS) Readdir(path string, fill func(name string, stat *fuse.Stat
 				Name:   handle.Path,
 				Offset: ofst64,
 				Token:  cacheInfo.token,
-				Count:  500,
+				Count:  1000,
 			})
 
 			if err != nil {

--- a/component/libfuse/libfuse2_handler.go
+++ b/component/libfuse/libfuse2_handler.go
@@ -484,7 +484,7 @@ func (cf *CgofuseFS) Readdir(path string, fill func(name string, stat *fuse.Stat
 			name := cacheInfo.children[cacheIndex].Name
 			// call fill with name, stat buffer, and the offset for the *next* entry
 			nextOffset++
-			osWantsMore = !fill(name, &stbuf, int64(nextOffset))
+			osWantsMore = fill(name, &stbuf, int64(nextOffset))
 			if cacheIndex == cacheInfo.length-1 && cacheInfo.token == "" {
 				listingComplete = true
 			}

--- a/component/libfuse/libfuse2_handler.go
+++ b/component/libfuse/libfuse2_handler.go
@@ -409,7 +409,7 @@ func (cf *CgofuseFS) Releasedir(path string, fh uint64) int {
 // Readdir reads a directory at the path.
 func (cf *CgofuseFS) Readdir(path string, fill func(name string, stat *fuse.Stat_t, ofst int64) bool,
 	ofst int64, fh uint64) int {
-	log.Debug("Libfuse::Readdir : %s, offset: %d, handle: %d", path, ofst, fh)
+	// log.Debug("Libfuse::Readdir : %s, offset: %d, handle: %d", path, ofst, fh)
 	handle, exists := handlemap.Load(handlemap.HandleID(fh))
 	if !exists {
 		log.Trace("Libfuse::Readdir : Failed to read %s, handle: %d", path, fh)
@@ -426,8 +426,8 @@ func (cf *CgofuseFS) Readdir(path string, fill func(name string, stat *fuse.Stat
 
 	ofst64 := uint64(ofst)
 	cacheInfo := val.(*dirChildCache)
-	log.Debug("Libfuse::Readdir : %s, offset: %d, handle: %d - cached %d-%d (token=%s)",
-		path, ofst, fh, cacheInfo.sIndex, cacheInfo.eIndex, cacheInfo.token)
+	// log.Debug("Libfuse::Readdir : %s, offset: %d, handle: %d - cached %d-%d (token=%s)",
+	// 	path, ofst, fh, cacheInfo.sIndex, cacheInfo.eIndex, cacheInfo.token)
 	stbuf := fuse.Stat_t{}
 	for {
 		getMoreEntries := ofst64 == 0 || (ofst64 >= cacheInfo.eIndex && cacheInfo.token != "")
@@ -489,7 +489,7 @@ func (cf *CgofuseFS) Readdir(path string, fill func(name string, stat *fuse.Stat
 				listingComplete = true
 			}
 		}
-		log.Debug("Libfuse::Readdir : %s, offset: %d, handle: %d - returned entries %d-%d to OS",
+		log.Debug("Libfuse::Readdir : %s, offset: %d, handle: %d - returned entries %d-%d",
 			path, ofst, fh, ofst64, nextOffset-1)
 		// don't keep fetching entries when there's nowhere to send them or there are no more
 		if !osWantsMore || listingComplete {

--- a/component/libfuse/libfuse2_handler.go
+++ b/component/libfuse/libfuse2_handler.go
@@ -484,12 +484,8 @@ func (cf *CgofuseFS) Readdir(path string, fill func(name string, stat *fuse.Stat
 			name := cacheInfo.children[cacheIndex].Name
 			// call fill with name, stat buffer, and the offset for the *next* entry
 			nextOffset++
-			if cacheIndex != cacheInfo.length-1 || cacheInfo.token != "" {
-				// more entries yet to go, so pass the next entry's offset
-				osWantsMore = fill(name, &stbuf, int64(nextOffset))
-			} else {
-				// no more entries to list - pass zero for the next entry offset
-				osWantsMore = fill(name, &stbuf, 0)
+			osWantsMore = !fill(name, &stbuf, int64(nextOffset))
+			if cacheIndex == cacheInfo.length-1 && cacheInfo.token == "" {
 				listingComplete = true
 			}
 		}

--- a/component/s3storage/s3storage.go
+++ b/component/s3storage/s3storage.go
@@ -239,7 +239,7 @@ func (s3 *S3Storage) StreamDir(options internal.StreamDirOptions) ([]*internal.O
 	var iteration int                   // = 0
 	var marker *string = &options.Token // = nil
 	var totalEntriesFetched int32
-	for totalEntriesFetched < options.Count {
+	for totalEntriesFetched+1 < options.Count {
 		newList, newMarker, err := s3.storage.List(path, marker, options.Count-totalEntriesFetched)
 		if err != nil {
 			log.Err("S3Storage::StreamDir : %s Failed to read dir [%s]", options.Name, err)
@@ -248,7 +248,7 @@ func (s3 *S3Storage) StreamDir(options internal.StreamDirOptions) ([]*internal.O
 		objectList = append(objectList, newList...)
 		marker = newMarker
 		iteration++
-		totalEntriesFetched += int32(len(objectList))
+		totalEntriesFetched += int32(len(newList))
 
 		log.Debug("S3Storage::StreamDir : %s So far retrieved %d objects in %d iterations", options.Name, totalEntriesFetched, iteration)
 		if marker == nil || *marker == "" {


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

### Describe your changes in brief
Change libfuse::Readdir to use fill properly with a non-zero offset
Add a token cache to attr_cache to serve concurrent StreamDir requests
This improves performance for Readdir by another 2x. I now see cached Readdir calls serving >8k entries in 30ms.

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [x] Added tests

### Related Issues

- Related Issue #
- Closes #