### PR TITLE
Change secure to use config file name when encrypting files

### DIFF
--- a/cmd/secure.go
+++ b/cmd/secure.go
@@ -46,7 +46,7 @@ type secureOptions struct {
 }
 
 const SecureConfigEnvName string = "CLOUDFUSE_SECURE_CONFIG_PASSPHRASE"
-const SecureConfigExtension string = ".azsec"
+const SecureConfigExtension string = ".aes"
 
 var secOpts secureOptions
 
@@ -149,8 +149,7 @@ func encryptConfigFile(saveConfig bool) ([]byte, error) {
 	if saveConfig {
 		outputFileName := ""
 		if secOpts.OutputFile == "" {
-			outputFileName = filepath.Join(common.ExpandPath(common.DefaultWorkDir), filepath.Base(secOpts.ConfigFile))
-			outputFileName += SecureConfigExtension
+			outputFileName = secOpts.ConfigFile + SecureConfigExtension
 		} else {
 			outputFileName = secOpts.OutputFile
 		}
@@ -176,14 +175,14 @@ func decryptConfigFile(saveConfig bool) ([]byte, error) {
 	if saveConfig {
 		outputFileName := ""
 		if secOpts.OutputFile == "" {
-			outputFileName = filepath.Join(os.ExpandEnv(common.DefaultWorkDir), filepath.Base(secOpts.ConfigFile))
+			outputFileName = secOpts.ConfigFile
 			extension := filepath.Ext(outputFileName)
 			outputFileName = outputFileName[0 : len(outputFileName)-len(extension)]
 		} else {
 			outputFileName = secOpts.OutputFile
 		}
 
-		return plainText, saveToFile(outputFileName, plainText, false)
+		return plainText, saveToFile(outputFileName, plainText, true)
 	}
 
 	return plainText, nil


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief

Using `secure encrypt` and `secure decrypt` without the --output-file parameter currently writes the file to a default .cloudfuse directory. Now, instead it use the same filename as the original file. Encrypt will now add the ".aes" extension for an aes encrypted to the file name. And decrypt will remove the ".aes" extension by default. This has the added benefit that running encrypt and decrypt right after each other will produce the original file with the same file name.

Additionally, secure decrypt did not delete the encrypted file. I have changed that so decrypt now deletes the file.

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #