### PR TITLE
Cleanup docs

### DIFF
--- a/cmd/unmount_all.go
+++ b/cmd/unmount_all.go
@@ -38,7 +38,7 @@ import (
 var umntAllCmd = &cobra.Command{
 	Use:               "all",
 	Short:             "Unmount all instances of Cloudfuse",
-	Long:              "Unmount all instances of Cloudfuse. Only available on Linux",
+	Long:              "Unmount all instances of Cloudfuse",
 	SuggestFor:        []string{"al", "all"},
 	FlagErrorHandling: cobra.ExitOnError,
 	RunE: func(cmd *cobra.Command, _ []string) error {

--- a/doc/cloudfuse_mount.md
+++ b/doc/cloudfuse_mount.md
@@ -13,48 +13,51 @@ cloudfuse mount [path] [flags]
 ### Options
 
 ```
-      --allow-other                     Allow other users to access this mount point.
-      --attr-cache-timeout uint32       attribute cache timeout (default 120)
-      --attr-timeout uint32              The attribute timeout in seconds
-      --block-cache-block-size uint     Size (in MB) of a block to be downloaded for block-cache.
-      --block-cache-disk-size uint      Size (in MB) of total disk capacity that block-cache can use.
-      --block-cache-path string         Path to store downloaded blocks.
-      --block-cache-pool-size uint      Size (in MB) of total memory preallocated for block-cache.
-      --block-cache-prefetch uint32     Max number of blocks to prefetch.
-      --block-cache-prefetch-on-open    Start prefetching on open or wait for first read.
-      --block-size-mb uint              Size (in MB) of a block to be downloaded during streaming.
-      --cache-size-mb uint32            max size in MB that file-cache can occupy on local disk for caching
-      --config-file string              Configures the path for the file where the account credentials are provided. Default is config.yaml in current directory.
-      --container-name string           Configures the name of the container to be mounted
-      --disable-compression             Disable transport layer compression.
-      --disable-writeback-cache         Disallow libfuse to buffer write requests if you must strictly open files in O_WRONLY or O_APPEND mode.
-      --dry-run                         Test mount configuration, credentials, etc., but don't make any changes to the container or the local file system. Implies foreground.
-      --entry-timeout uint32            The entry timeout in seconds.
-      --file-cache-timeout uint32       file cache timeout (default 120)
-      --foreground                      Mount the system in foreground mode. Default value false.
-      --hard-limit                      File cache limits are hard limits or not.
-  -h, --help                            help for mount
-      --high-disk-threshold uint32      percentage of cache utilization which kicks in early eviction (default 90)
-      --ignore-open-flags               Ignore unsupported open flags (APPEND, WRONLY) by cloudfuse when writeback caching is enabled. (default true)
-      --ignore-sync                     Just ignore sync call and do not invalidate locally cached file.
-      --log-file-path string            Configures the path for log files. Default is $HOME/.cloudfuse/cloudfuse.log (default "$HOME/.cloudfuse/cloudfuse.log")
-      --log-level string                Enables logs written to syslog. Set to LOG_WARNING by default. Allowed values are LOG_OFF|LOG_CRIT|LOG_ERR|LOG_WARNING|LOG_INFO|LOG_DEBUG (default "LOG_WARNING")
-      --log-type string                 Type of logger to be used by the system. Set to syslog by default. Allowed values are silent|syslog|base. (default "syslog")
-      --low-disk-threshold uint32       percentage of cache utilization which stops early eviction started by high-disk-threshold (default 80)
-      --negative-timeout uint32         The negative entry timeout in seconds.
-      --network-share                   Run as a network share. Only supported on Windows.
-      --no-cache-dirs                   whether or not empty directories should be cached
-      --no-symlinks                     whether or not symlinks should be supported
-      --passphrase string               Key to decrypt config file. Can also be specified by env-variable CLOUDFUSE_SECURE_CONFIG_PASSPHRASE.
-                                        Key length shall be 16 (AES-128), 24 (AES-192), or 32 (AES-256) bytes in length.
-      --read-only                       Mount the system in read only mode. Default value false.
-      --restricted-characters-windows   Enable support for displaying restricted characters on Windows.
-      --secure-config                   Encrypt auto generated config file for each container
-      --subdirectory string             Mount only this sub-directory from given container.
-      --sync-to-flush                   Sync call on file will force a upload of the file. (default true)
-      --tmp-path string                 configures the tmp location for the cache. Configure the fastest disk (SSD or ramdisk) for best performance.
-      --virtual-directory               Support virtual directories without existence of a special marker blob.
-      --wait-for-mount duration         Let parent process wait for given timeout before exit (default 5s)
+      --allow-other                       Allow other users to access this mount point.
+      --attr-cache-timeout uint32         attribute cache timeout (default 120)
+      --attr-timeout uint32                The attribute timeout in seconds
+      --block-cache-block-size float      Size (in MB) of a block to be downloaded for block-cache.
+      --block-cache-disk-size uint        Size (in MB) of total disk capacity that block-cache can use.
+      --block-cache-disk-timeout uint32   Timeout (in seconds) for which persisted data remains in disk cache.
+      --block-cache-parallelism uint32    Number of worker thread responsible for upload/download jobs. (default 128)
+      --block-cache-path string           Path to store downloaded blocks.
+      --block-cache-pool-size uint        Size (in MB) of total memory preallocated for block-cache.
+      --block-cache-prefetch uint32       Max number of blocks to prefetch.
+      --block-cache-prefetch-on-open      Start prefetching on open or wait for first read.
+      --block-size-mb uint                Size (in MB) of a block to be downloaded during streaming.
+      --cache-size-mb uint32              max size in MB that file-cache can occupy on local disk for caching
+      --config-file string                Configures the path for the file where the account credentials are provided. Default is config.yaml in current directory.
+      --container-name string             Configures the name of the container to be mounted
+      --cpk-enabled                       Enable client provided key.
+      --disable-compression               Disable transport layer compression.
+      --disable-writeback-cache           Disallow libfuse to buffer write requests if you must strictly open files in O_WRONLY or O_APPEND mode.
+      --dry-run                           Test mount configuration, credentials, etc., but don't make any changes to the container or the local file system. Implies foreground.
+      --entry-timeout uint32              The entry timeout in seconds.
+      --file-cache-timeout uint32         file cache timeout (default 120)
+      --foreground                        Mount the system in foreground mode. Default value false.
+      --hard-limit                        File cache limits are hard limits or not.
+  -h, --help                              help for mount
+      --high-disk-threshold uint32        percentage of cache utilization which kicks in early eviction (default 90)
+      --ignore-open-flags                 Ignore unsupported open flags (APPEND, WRONLY) by cloudfuse when writeback caching is enabled. (default true)
+      --ignore-sync                       Just ignore sync call and do not invalidate locally cached file.
+      --log-file-path string              Configures the path for log files. Default is $HOME/.cloudfuse/cloudfuse.log (default "$HOME/.cloudfuse/cloudfuse.log")
+      --log-level string                  Enables logs written to syslog. Set to LOG_WARNING by default. Allowed values are LOG_OFF|LOG_CRIT|LOG_ERR|LOG_WARNING|LOG_INFO|LOG_DEBUG (default "LOG_WARNING")
+      --log-type string                   Type of logger to be used by the system. Set to syslog by default. Allowed values are silent|syslog|base. (default "syslog")
+      --low-disk-threshold uint32         percentage of cache utilization which stops early eviction started by high-disk-threshold (default 80)
+      --negative-timeout uint32           The negative entry timeout in seconds.
+      --network-share                     Run as a network share. Only supported on Windows.
+      --no-cache-dirs                     whether or not empty directories should be cached
+      --no-symlinks                       whether or not symlinks should be supported
+      --passphrase string                 Key to decrypt config file. Can also be specified by env-variable CLOUDFUSE_SECURE_CONFIG_PASSPHRASE.
+                                          Key length shall be 16 (AES-128), 24 (AES-192), or 32 (AES-256) bytes in length.
+      --read-only                         Mount the system in read only mode. Default value false.
+      --restricted-characters-windows     Enable support for displaying restricted characters on Windows.
+      --secure-config                     Encrypt auto generated config file for each container
+      --subdirectory string               Mount only this sub-directory from given container.
+      --sync-to-flush                     Sync call on file will force a upload of the file. (default true)
+      --tmp-path string                   configures the tmp location for the cache. Configure the fastest disk (SSD or ramdisk) for best performance.
+      --virtual-directory                 Support virtual directories without existence of a special marker blob.
+      --wait-for-mount duration           Let parent process wait for given timeout before exit (default 5s)
 ```
 
 ### Options inherited from parent commands
@@ -69,4 +72,4 @@ cloudfuse mount [path] [flags]
 * [cloudfuse mount all](cloudfuse_mount_all.md)	 - Mounts all containers for a given cloud account as a filesystem
 * [cloudfuse mount list](cloudfuse_mount_list.md)	 - List all cloudfuse mountpoints
 
-###### Auto generated by spf13/cobra on 3-Jan-2024
+###### Auto generated by spf13/cobra on 14-Feb-2024

--- a/doc/cloudfuse_mount_all.md
+++ b/doc/cloudfuse_mount_all.md
@@ -19,51 +19,54 @@ cloudfuse mount all [path] <flags> [flags]
 ### Options inherited from parent commands
 
 ```
-      --allow-other                     Allow other users to access this mount point.
-      --attr-cache-timeout uint32       attribute cache timeout (default 120)
-      --attr-timeout uint32              The attribute timeout in seconds
-      --block-cache-block-size uint     Size (in MB) of a block to be downloaded for block-cache.
-      --block-cache-disk-size uint      Size (in MB) of total disk capacity that block-cache can use.
-      --block-cache-path string         Path to store downloaded blocks.
-      --block-cache-pool-size uint      Size (in MB) of total memory preallocated for block-cache.
-      --block-cache-prefetch uint32     Max number of blocks to prefetch.
-      --block-cache-prefetch-on-open    Start prefetching on open or wait for first read.
-      --block-size-mb uint              Size (in MB) of a block to be downloaded during streaming.
-      --cache-size-mb uint32            max size in MB that file-cache can occupy on local disk for caching
-      --config-file string              Configures the path for the file where the account credentials are provided. Default is config.yaml in current directory.
-      --container-name string           Configures the name of the container to be mounted
-      --disable-compression             Disable transport layer compression.
-      --disable-version-check           To disable version check that is performed automatically
-      --disable-writeback-cache         Disallow libfuse to buffer write requests if you must strictly open files in O_WRONLY or O_APPEND mode.
-      --entry-timeout uint32            The entry timeout in seconds.
-      --file-cache-timeout uint32       file cache timeout (default 120)
-      --foreground                      Mount the system in foreground mode. Default value false.
-      --hard-limit                      File cache limits are hard limits or not.
-      --high-disk-threshold uint32      percentage of cache utilization which kicks in early eviction (default 90)
-      --ignore-open-flags               Ignore unsupported open flags (APPEND, WRONLY) by cloudfuse when writeback caching is enabled. (default true)
-      --ignore-sync                     Just ignore sync call and do not invalidate locally cached file.
-      --log-file-path string            Configures the path for log files. Default is $HOME/.cloudfuse/cloudfuse.log (default "$HOME/.cloudfuse/cloudfuse.log")
-      --log-level string                Enables logs written to syslog. Set to LOG_WARNING by default. Allowed values are LOG_OFF|LOG_CRIT|LOG_ERR|LOG_WARNING|LOG_INFO|LOG_DEBUG (default "LOG_WARNING")
-      --log-type string                 Type of logger to be used by the system. Set to syslog by default. Allowed values are silent|syslog|base. (default "syslog")
-      --low-disk-threshold uint32       percentage of cache utilization which stops early eviction started by high-disk-threshold (default 80)
-      --negative-timeout uint32         The negative entry timeout in seconds.
-      --network-share                   Run as a network share. Only supported on Windows.
-      --no-cache-dirs                   whether or not empty directories should be cached
-      --no-symlinks                     whether or not symlinks should be supported
-      --passphrase string               Key to decrypt config file. Can also be specified by env-variable CLOUDFUSE_SECURE_CONFIG_PASSPHRASE.
-                                        Key length shall be 16 (AES-128), 24 (AES-192), or 32 (AES-256) bytes in length.
-      --read-only                       Mount the system in read only mode. Default value false.
-      --restricted-characters-windows   Enable support for displaying restricted characters on Windows.
-      --secure-config                   Encrypt auto generated config file for each container
-      --subdirectory string             Mount only this sub-directory from given container.
-      --sync-to-flush                   Sync call on file will force a upload of the file. (default true)
-      --tmp-path string                 configures the tmp location for the cache. Configure the fastest disk (SSD or ramdisk) for best performance.
-      --virtual-directory               Support virtual directories without existence of a special marker blob.
-      --wait-for-mount duration         Let parent process wait for given timeout before exit (default 5s)
+      --allow-other                       Allow other users to access this mount point.
+      --attr-cache-timeout uint32         attribute cache timeout (default 120)
+      --attr-timeout uint32                The attribute timeout in seconds
+      --block-cache-block-size float      Size (in MB) of a block to be downloaded for block-cache.
+      --block-cache-disk-size uint        Size (in MB) of total disk capacity that block-cache can use.
+      --block-cache-disk-timeout uint32   Timeout (in seconds) for which persisted data remains in disk cache.
+      --block-cache-parallelism uint32    Number of worker thread responsible for upload/download jobs. (default 128)
+      --block-cache-path string           Path to store downloaded blocks.
+      --block-cache-pool-size uint        Size (in MB) of total memory preallocated for block-cache.
+      --block-cache-prefetch uint32       Max number of blocks to prefetch.
+      --block-cache-prefetch-on-open      Start prefetching on open or wait for first read.
+      --block-size-mb uint                Size (in MB) of a block to be downloaded during streaming.
+      --cache-size-mb uint32              max size in MB that file-cache can occupy on local disk for caching
+      --config-file string                Configures the path for the file where the account credentials are provided. Default is config.yaml in current directory.
+      --container-name string             Configures the name of the container to be mounted
+      --cpk-enabled                       Enable client provided key.
+      --disable-compression               Disable transport layer compression.
+      --disable-version-check             To disable version check that is performed automatically
+      --disable-writeback-cache           Disallow libfuse to buffer write requests if you must strictly open files in O_WRONLY or O_APPEND mode.
+      --entry-timeout uint32              The entry timeout in seconds.
+      --file-cache-timeout uint32         file cache timeout (default 120)
+      --foreground                        Mount the system in foreground mode. Default value false.
+      --hard-limit                        File cache limits are hard limits or not.
+      --high-disk-threshold uint32        percentage of cache utilization which kicks in early eviction (default 90)
+      --ignore-open-flags                 Ignore unsupported open flags (APPEND, WRONLY) by cloudfuse when writeback caching is enabled. (default true)
+      --ignore-sync                       Just ignore sync call and do not invalidate locally cached file.
+      --log-file-path string              Configures the path for log files. Default is $HOME.cloudfuse/cloudfuse.log (default "$HOME/.cloudfuse/cloudfuse.log")
+      --log-level string                  Enables logs written to syslog. Set to LOG_WARNING by default. Allowed values are LOG_OFF|LOG_CRIT|LOG_ERR|LOG_WARNING|LOG_INFO|LOG_DEBUG (default "LOG_WARNING")
+      --log-type string                   Type of logger to be used by the system. Set to syslog by default. Allowed values are silent|syslog|base. (default "syslog")
+      --low-disk-threshold uint32         percentage of cache utilization which stops early eviction started by high-disk-threshold (default 80)
+      --negative-timeout uint32           The negative entry timeout in seconds.
+      --network-share                     Run as a network share. Only supported on Windows.
+      --no-cache-dirs                     whether or not empty directories should be cached
+      --no-symlinks                       whether or not symlinks should be supported
+      --passphrase string                 Key to decrypt config file. Can also be specified by env-variable CLOUDFUSE_SECURE_CONFIG_PASSPHRASE.
+                                          Key length shall be 16 (AES-128), 24 (AES-192), or 32 (AES-256) bytes in length.
+      --read-only                         Mount the system in read only mode. Default value false.
+      --restricted-characters-windows     Enable support for displaying restricted characters on Windows.
+      --secure-config                     Encrypt auto generated config file for each container
+      --subdirectory string               Mount only this sub-directory from given container.
+      --sync-to-flush                     Sync call on file will force a upload of the file. (default true)
+      --tmp-path string                   configures the tmp location for the cache. Configure the fastest disk (SSD or ramdisk) for best performance.
+      --virtual-directory                 Support virtual directories without existence of a special marker blob.
+      --wait-for-mount duration           Let parent process wait for given timeout before exit (default 5s)
 ```
 
 ### SEE ALSO
 
 * [cloudfuse mount](cloudfuse_mount.md)	 - Mounts the container as a filesystem
 
-###### Auto generated by spf13/cobra on 3-Jan-2024
+###### Auto generated by spf13/cobra on 14-Feb-2024

--- a/doc/cloudfuse_mount_list.md
+++ b/doc/cloudfuse_mount_list.md
@@ -25,51 +25,54 @@ cloudfuse mount list
 ### Options inherited from parent commands
 
 ```
-      --allow-other                     Allow other users to access this mount point.
-      --attr-cache-timeout uint32       attribute cache timeout (default 120)
-      --attr-timeout uint32              The attribute timeout in seconds
-      --block-cache-block-size uint     Size (in MB) of a block to be downloaded for block-cache.
-      --block-cache-disk-size uint      Size (in MB) of total disk capacity that block-cache can use.
-      --block-cache-path string         Path to store downloaded blocks.
-      --block-cache-pool-size uint      Size (in MB) of total memory preallocated for block-cache.
-      --block-cache-prefetch uint32     Max number of blocks to prefetch.
-      --block-cache-prefetch-on-open    Start prefetching on open or wait for first read.
-      --block-size-mb uint              Size (in MB) of a block to be downloaded during streaming.
-      --cache-size-mb uint32            max size in MB that file-cache can occupy on local disk for caching
-      --config-file string              Configures the path for the file where the account credentials are provided. Default is config.yaml in current directory.
-      --container-name string           Configures the name of the container to be mounted
-      --disable-compression             Disable transport layer compression.
-      --disable-version-check           To disable version check that is performed automatically
-      --disable-writeback-cache         Disallow libfuse to buffer write requests if you must strictly open files in O_WRONLY or O_APPEND mode.
-      --entry-timeout uint32            The entry timeout in seconds.
-      --file-cache-timeout uint32       file cache timeout (default 120)
-      --foreground                      Mount the system in foreground mode. Default value false.
-      --hard-limit                      File cache limits are hard limits or not.
-      --high-disk-threshold uint32      percentage of cache utilization which kicks in early eviction (default 90)
-      --ignore-open-flags               Ignore unsupported open flags (APPEND, WRONLY) by cloudfuse when writeback caching is enabled. (default true)
-      --ignore-sync                     Just ignore sync call and do not invalidate locally cached file.
-      --log-file-path string            Configures the path for log files. Default is $HOME/.cloudfuse/cloudfuse.log (default "$HOME/.cloudfuse/cloudfuse.log")
-      --log-level string                Enables logs written to syslog. Set to LOG_WARNING by default. Allowed values are LOG_OFF|LOG_CRIT|LOG_ERR|LOG_WARNING|LOG_INFO|LOG_DEBUG (default "LOG_WARNING")
-      --log-type string                 Type of logger to be used by the system. Set to syslog by default. Allowed values are silent|syslog|base. (default "syslog")
-      --low-disk-threshold uint32       percentage of cache utilization which stops early eviction started by high-disk-threshold (default 80)
-      --negative-timeout uint32         The negative entry timeout in seconds.
-      --network-share                   Run as a network share. Only supported on Windows.
-      --no-cache-dirs                   whether or not empty directories should be cached
-      --no-symlinks                     whether or not symlinks should be supported
-      --passphrase string               Key to decrypt config file. Can also be specified by env-variable CLOUDFUSE_SECURE_CONFIG_PASSPHRASE.
-                                        Key length shall be 16 (AES-128), 24 (AES-192), or 32 (AES-256) bytes in length.
-      --read-only                       Mount the system in read only mode. Default value false.
-      --restricted-characters-windows   Enable support for displaying restricted characters on Windows.
-      --secure-config                   Encrypt auto generated config file for each container
-      --subdirectory string             Mount only this sub-directory from given container.
-      --sync-to-flush                   Sync call on file will force a upload of the file. (default true)
-      --tmp-path string                 configures the tmp location for the cache. Configure the fastest disk (SSD or ramdisk) for best performance.
-      --virtual-directory               Support virtual directories without existence of a special marker blob.
-      --wait-for-mount duration         Let parent process wait for given timeout before exit (default 5s)
+      --allow-other                       Allow other users to access this mount point.
+      --attr-cache-timeout uint32         attribute cache timeout (default 120)
+      --attr-timeout uint32                The attribute timeout in seconds
+      --block-cache-block-size float      Size (in MB) of a block to be downloaded for block-cache.
+      --block-cache-disk-size uint        Size (in MB) of total disk capacity that block-cache can use.
+      --block-cache-disk-timeout uint32   Timeout (in seconds) for which persisted data remains in disk cache.
+      --block-cache-parallelism uint32    Number of worker thread responsible for upload/download jobs. (default 128)
+      --block-cache-path string           Path to store downloaded blocks.
+      --block-cache-pool-size uint        Size (in MB) of total memory preallocated for block-cache.
+      --block-cache-prefetch uint32       Max number of blocks to prefetch.
+      --block-cache-prefetch-on-open      Start prefetching on open or wait for first read.
+      --block-size-mb uint                Size (in MB) of a block to be downloaded during streaming.
+      --cache-size-mb uint32              max size in MB that file-cache can occupy on local disk for caching
+      --config-file string                Configures the path for the file where the account credentials are provided. Default is config.yaml in current directory.
+      --container-name string             Configures the name of the container to be mounted
+      --cpk-enabled                       Enable client provided key.
+      --disable-compression               Disable transport layer compression.
+      --disable-version-check             To disable version check that is performed automatically
+      --disable-writeback-cache           Disallow libfuse to buffer write requests if you must strictly open files in O_WRONLY or O_APPEND mode.
+      --entry-timeout uint32              The entry timeout in seconds.
+      --file-cache-timeout uint32         file cache timeout (default 120)
+      --foreground                        Mount the system in foreground mode. Default value false.
+      --hard-limit                        File cache limits are hard limits or not.
+      --high-disk-threshold uint32        percentage of cache utilization which kicks in early eviction (default 90)
+      --ignore-open-flags                 Ignore unsupported open flags (APPEND, WRONLY) by cloudfuse when writeback caching is enabled. (default true)
+      --ignore-sync                       Just ignore sync call and do not invalidate locally cached file.
+      --log-file-path string              Configures the path for log files. Default is $HOME/.cloudfuse/cloudfuse.log (default "$HOME/.cloudfuse/cloudfuse.log")
+      --log-level string                  Enables logs written to syslog. Set to LOG_WARNING by default. Allowed values are LOG_OFF|LOG_CRIT|LOG_ERR|LOG_WARNING|LOG_INFO|LOG_DEBUG (default "LOG_WARNING")
+      --log-type string                   Type of logger to be used by the system. Set to syslog by default. Allowed values are silent|syslog|base. (default "syslog")
+      --low-disk-threshold uint32         percentage of cache utilization which stops early eviction started by high-disk-threshold (default 80)
+      --negative-timeout uint32           The negative entry timeout in seconds.
+      --network-share                     Run as a network share. Only supported on Windows.
+      --no-cache-dirs                     whether or not empty directories should be cached
+      --no-symlinks                       whether or not symlinks should be supported
+      --passphrase string                 Key to decrypt config file. Can also be specified by env-variable CLOUDFUSE_SECURE_CONFIG_PASSPHRASE.
+                                          Key length shall be 16 (AES-128), 24 (AES-192), or 32 (AES-256) bytes in length.
+      --read-only                         Mount the system in read only mode. Default value false.
+      --restricted-characters-windows     Enable support for displaying restricted characters on Windows.
+      --secure-config                     Encrypt auto generated config file for each container
+      --subdirectory string               Mount only this sub-directory from given container.
+      --sync-to-flush                     Sync call on file will force a upload of the file. (default true)
+      --tmp-path string                   configures the tmp location for the cache. Configure the fastest disk (SSD or ramdisk) for best performance.
+      --virtual-directory                 Support virtual directories without existence of a special marker blob.
+      --wait-for-mount duration           Let parent process wait for given timeout before exit (default 5s)
 ```
 
 ### SEE ALSO
 
 * [cloudfuse mount](cloudfuse_mount.md)	 - Mounts the container as a filesystem
 
-###### Auto generated by spf13/cobra on 3-Jan-2024
+###### Auto generated by spf13/cobra on 14-Feb-2024


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

### Describe your changes in brief

This updates some of the docs with some of the flags that were changed in blobfuse2.2.0, namely the flags surrounding the block cache. Additionally, it fixes a comment that no longer applies with the unmount all command on Linux.

### Checklist

- [ ] Tested locally
- [ ] Added new dependencies
- [x] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #