### PR TITLE
Trivy can now upload results to GitHub security tab

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -42,10 +42,9 @@ jobs:
       - name: Run vulnerability scanner
         run: |
           trivy fs ./ --scanners license --exit-code 1 --severity HIGH,CRITICAL
-          trivy fs ./ --exit-code 1 --severity MEDIUM,HIGH,CRITICAL --dependency-tree
+          trivy fs ./ --exit-code 1 --severity MEDIUM,HIGH,CRITICAL --dependency-tree --format sarif -o trivy-results.sarif
 
-      #TODO: maybe use this when codeql is available (after publishing)
-      # - name: Upload Trivy scan results to GitHub Security tab
-      #   uses: github/codeql-action/upload-sarif@v2
-      #   with:
-      #     sarif_file: 'trivy-results-binary.sarif'
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief

Now that we have access to GitHub security tab, trivy can now upload its security results to our GitHub security tab.

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #