### PR TITLE
GUI: Look for cloudfuse CLI in path

### DIFF
--- a/gui/common_qt_functions.py
+++ b/gui/common_qt_functions.py
@@ -116,7 +116,7 @@ class defaultSettingsManager():
         self.settings.setValue('foreground',False)
         
         # Common
-        self.settings.setValue('allow-other',True)
+        self.settings.setValue('allow-other',False)
         self.settings.setValue('read-only',False)
         self.settings.setValue('nonempty',False)
         self.settings.setValue('restricted-characters-windows',False) # not exposed

--- a/gui/mountPrimaryWindow.py
+++ b/gui/mountPrimaryWindow.py
@@ -26,6 +26,7 @@ from sys import platform
 import os
 import time
 import yaml
+from shutil import which
 
 # Import QT libraries
 from PySide6.QtCore import Qt, QSettings
@@ -50,6 +51,9 @@ if platform == 'win32':
     # on Windows, the mound directory must not exist before mounting,
     # so name a non-existent subdirectory of the user-chosen path
     mountDirSuffix = 'cloudFuse'
+#  if cloudfuse is not in the path, look for it in the current directory
+if which(cloudfuseCli) is None:
+    cloudfuseCli = './' + cloudfuseCli
 
 class FUSEWindow(QMainWindow, Ui_primaryFUSEwindow):
     def __init__(self):

--- a/gui/mountPrimaryWindow.py
+++ b/gui/mountPrimaryWindow.py
@@ -42,6 +42,14 @@ from common_qt_functions import widgetCustomFunctions as widgetFuncs
 
 bucketOptions = ['s3storage', 'azstorage']
 mountTargetComponent = 3
+cloudfuseCli = 'cloudfuse'
+mountDirSuffix = ''
+if platform == 'win32':
+    # on Windows, the cli command ends in '.exe'
+    cloudfuseCli += '.exe'
+    # on Windows, the mound directory must not exist before mounting,
+    # so name a non-existent subdirectory of the user-chosen path
+    mountDirSuffix = 'cloudFuse'
 
 class FUSEWindow(QMainWindow, Ui_primaryFUSEwindow):
     def __init__(self):
@@ -63,8 +71,7 @@ class FUSEWindow(QMainWindow, Ui_primaryFUSEwindow):
             # Note: Different versions of Python don't like the embedded null character, send in the raw string instead
             self.lineEdit_mountPoint.setValidator(QtGui.QRegularExpressionValidator(r'^[^\0]*$',self))
        
-
-        # Set up the signals for all the interactable intities
+        # Set up the signals for all the interactive entities
         self.button_browse.clicked.connect(self.getFileDirInput)
         self.button_config.clicked.connect(self.showSettingsWidget)
         self.button_mount.clicked.connect(self.mountBucket)
@@ -112,7 +119,6 @@ class FUSEWindow(QMainWindow, Ui_primaryFUSEwindow):
     # There are unique settings per bucket selected for the pipeline, 
     #   so we must use different widgets to show the different settings
     def showSettingsWidget(self):
-
         targetIndex = self.dropDown_bucketSelect.currentIndex()
         if bucketOptions[targetIndex] == 's3storage':
             self.settings = s3SettingsWidget()
@@ -136,10 +142,7 @@ class FUSEWindow(QMainWindow, Ui_primaryFUSEwindow):
 
     # Display the custom dialog box for the cloudfuse 'about' page.
     def showAboutCloudFusePage(self):
-        if platform == "win32":
-            commandParts = ['cloudfuse.exe', '--version']
-        else:
-            commandParts = ['./cloudfuse', '--version']
+        commandParts = [cloudfuseCli, '--version']
         (stdOut, stdErr, exitCode, executableFound) = self.runCommand(commandParts)
 
         if not executableFound:
@@ -156,91 +159,81 @@ class FUSEWindow(QMainWindow, Ui_primaryFUSEwindow):
         self.page = underConstruction()
         self.page.show()
 
-
     def mountBucket(self):
-
+        # get mount directory
         try:
             directory = str(self.lineEdit_mountPoint.text())
         except ValueError as e:
             self.addOutputText(f"Invalid mount path: {str(e)}")
             return
+        directory = os.path.join(directory, mountDirSuffix)
+        # get config path
         configPath = os.path.join(widgetFuncs.getWorkingDir(self), 'config.yaml')
 
+        # on Windows, the mount directory should not exist (yet)
         if platform == "win32":
-            # Windows mount has a quirk where the folder shouldn't exist yet,
-            #   add CloudFuse at the end of the directory 
-            directory = os.path.join(directory,'cloudFuse')
-            
-            # make sure the mount directory doesn't already exist
             if os.path.exists(directory):
                 self.addOutputText(f"Directory {directory} already exists! Aborting new mount.")
                 self.errorMessageBox(f"Error: Cloudfuse needs to create the directory {directory}, but it already exists!")
                 return
-            
-            # do a dry run to validate options and credentials
-            commandParts = ['cloudfuse.exe', 'mount', directory, f'--config-file={configPath}', '--dry-run']
-            (stdOut, stdErr, exitCode, executableFound) = self.runCommand(commandParts)
-            if not executableFound:
-                self.addOutputText("cloudfuse.exe not found! Is it installed?")
-                self.errorMessageBox("Error running cloudfuse CLI - Please re-install Cloudfuse.")
-                return
-            
-            if exitCode != 0:
-                self.addOutputText(stdErr)
-                self.errorMessageBox("Mount failed: " + stdErr)
-                return
-            
-            if stdOut != "":
-                self.addOutputText(stdOut)
+        
+        # do a dry run to validate options and credentials
+        commandParts = [cloudfuseCli, 'mount', directory, f'--config-file={configPath}', '--dry-run']
+        (stdOut, stdErr, exitCode, executableFound) = self.runCommand(commandParts)
+        if not executableFound:
+            self.addOutputText("cloudfuse.exe not found! Is it installed?")
+            self.errorMessageBox("Error running cloudfuse CLI - Please re-install Cloudfuse.")
+            return
+        
+        if exitCode != 0:
+            self.addOutputText(stdErr)
+            self.errorMessageBox("Mount failed: " + stdErr)
+            return
+        
+        if stdOut != "":
+            self.addOutputText(stdOut)
 
-            # now actually mount
-            commandParts = ['cloudfuse.exe', 'mount', directory, f'--config-file={configPath}']
-            (stdOut, stdErr, exitCode, executableFound) = self.runCommand(commandParts)
-            if not executableFound:
-                self.addOutputText("cloudfuse.exe not found! Is it installed?")
-                self.errorMessageBox("Error running cloudfuse CLI - Please re-install Cloudfuse.")
-                return
-            
-            if exitCode != 0:
-                self.addOutputText(stdErr)
-                if stdErr.find("mount path exists") != -1:
-                    self.errorMessageBox("This container is already mounted at this directory.")
-                return
-            
-            if stdOut != "":
-                self.addOutputText(stdOut)
-            
-            # wait for mount, then check that mount succeeded by verifying that the mount directory exists
-            self.addOutputText("Mount command successfully sent to Windows service.\nVerifying mount success...")
-            def verifyMountSuccess():
-                if not os.path.exists(directory):
-                    self.addOutputText(f"Failed to create mount directory {directory}")
-                    self.errorMessageBox("Mount failed. Please check error logs.")
-                else:
-                    self.addOutputText("Successfully mounted container")
-            QtCore.QTimer.singleShot(4000, verifyMountSuccess)
-        else:
-            commandParts = ['./cloudfuse', 'mount', directory, f'--config-file={configPath}']
-            (stdOut, stdErr, exitCode, executableFound) = self.runCommand(commandParts)
-            if exitCode != 0:
-                self.addOutputText(f"Error mounting container: {stdErr}")
+        # now actually mount
+        commandParts = [cloudfuseCli, 'mount', directory, f'--config-file={configPath}']
+        (stdOut, stdErr, exitCode, executableFound) = self.runCommand(commandParts)
+        if not executableFound:
+            self.addOutputText("cloudfuse.exe not found! Is it installed?")
+            self.errorMessageBox("Error running cloudfuse CLI - Please re-install Cloudfuse.")
+            return
+        
+        if exitCode != 0:
+            self.addOutputText(f"Error mounting container: {stdErr}")
+            if stdErr.find("mount path exists") != -1:
+                self.errorMessageBox("This container is already mounted at this directory.")
+            else:
                 self.errorMessageBox(f"Error mounting container - check the settings and try again\n{stdErr}")
-                return
-            
-            self.addOutputText("Successfully mounted container\n")
+            return
+        
+        if stdOut != "":
+            self.addOutputText(stdOut)
+        
+        # wait for mount, then check that mount succeeded by verifying that the mount directory exists
+        self.addOutputText("Verifying mount success...")
+        def verifyMountSuccess():
+            if platform == 'win32':
+                success = os.path.exists(directory)
+            else:
+                success = os.path.ismount(directory)
+            if not success:
+                self.addOutputText(f"Failed to create mount directory {directory}")
+                self.errorMessageBox("Mount failed. Please check error logs.")
+            else:
+                self.addOutputText("Successfully mounted container")
+        QtCore.QTimer.singleShot(4000, verifyMountSuccess)
 
     def unmountBucket(self):
         directory = str(self.lineEdit_mountPoint.text())
         commandParts = []
         # TODO: properly handle unmount. This is relying on the line_edit not being changed by the user.
-        
-        if platform == "win32":
-            # for windows, 'cloudfuse' was added to the directory so add it back in for umount
-            directory = os.path.join(directory, 'cloudFuse')
-            commandParts = "cloudfuse.exe unmount".split()
-        else:
-            commandParts = "./cloudfuse unmount --lazy".split()
-        commandParts.append(directory)
+        directory = os.path.join(directory, mountDirSuffix)
+        commandParts = [cloudfuseCli, "unmount", directory]
+        if platform != "win32":
+            commandParts.append("--lazy")
         
         (stdOut, stdErr, exitCode, executableFound) = self.runCommand(commandParts)
         if not executableFound:
@@ -251,8 +244,6 @@ class FUSEWindow(QMainWindow, Ui_primaryFUSEwindow):
             self.errorMessageBox(f"Failed to unmount container: {stdErr}")
         else:
             self.addOutputText(f"Successfully unmounted container {stdErr}")
-
-
 
     # This function reads in the config file, modifies the components section, then writes the config file back
     def modifyPipeline(self):

--- a/gui/mountPrimaryWindow.py
+++ b/gui/mountPrimaryWindow.py
@@ -33,7 +33,7 @@ from PySide6.QtCore import Qt, QSettings
 from PySide6 import QtWidgets, QtGui, QtCore
 from PySide6.QtWidgets import QMainWindow
 
-# Import the custom class created with QtDesigner 
+# Import the custom class created with QtDesigner
 from ui_mountPrimaryWindow import Ui_primaryFUSEwindow
 from s3_config_common import s3SettingsWidget
 from azure_config_common import azureSettingsWidget
@@ -50,7 +50,7 @@ if platform == 'win32':
     cloudfuseCli += '.exe'
     # on Windows, the mound directory must not exist before mounting,
     # so name a non-existent subdirectory of the user-chosen path
-    mountDirSuffix = 'cloudFuse'
+    mountDirSuffix = 'cloudfuse'
 #  if cloudfuse is not in the path, look for it in the current directory
 if which(cloudfuseCli) is None:
     cloudfuseCli = './' + cloudfuseCli
@@ -74,7 +74,7 @@ class FUSEWindow(QMainWindow, Ui_primaryFUSEwindow):
             # Allow anything BUT Nul
             # Note: Different versions of Python don't like the embedded null character, send in the raw string instead
             self.lineEdit_mountPoint.setValidator(QtGui.QRegularExpressionValidator(r'^[^\0]*$',self))
-       
+
         # Set up the signals for all the interactive entities
         self.button_browse.clicked.connect(self.getFileDirInput)
         self.button_config.clicked.connect(self.showSettingsWidget)
@@ -109,7 +109,7 @@ class FUSEWindow(QMainWindow, Ui_primaryFUSEwindow):
         except:
             # Nothing in the settings for mountDir, leave mountPoint blank
             return
-        
+
     def updateMountPointInSettings(self):
         try:
             directory = str(self.lineEdit_mountPoint.text())
@@ -120,7 +120,7 @@ class FUSEWindow(QMainWindow, Ui_primaryFUSEwindow):
 
     # Define the slots that will be triggered when the signals in Qt are activated
 
-    # There are unique settings per bucket selected for the pipeline, 
+    # There are unique settings per bucket selected for the pipeline,
     #   so we must use different widgets to show the different settings
     def showSettingsWidget(self):
         targetIndex = self.dropDown_bucketSelect.currentIndex()
@@ -155,7 +155,7 @@ class FUSEWindow(QMainWindow, Ui_primaryFUSEwindow):
             cloudfuseVersion = stdOut
         else:
             cloudfuseVersion = 'Cloudfuse version not found'
-            
+
         self.page = aboutPage(cloudfuseVersion)
         self.page.show()
 
@@ -180,7 +180,7 @@ class FUSEWindow(QMainWindow, Ui_primaryFUSEwindow):
                 self.addOutputText(f"Directory {directory} already exists! Aborting new mount.")
                 self.errorMessageBox(f"Error: Cloudfuse needs to create the directory {directory}, but it already exists!")
                 return
-        
+
         # do a dry run to validate options and credentials
         commandParts = [cloudfuseCli, 'mount', directory, f'--config-file={configPath}', '--dry-run']
         (stdOut, stdErr, exitCode, executableFound) = self.runCommand(commandParts)
@@ -188,12 +188,12 @@ class FUSEWindow(QMainWindow, Ui_primaryFUSEwindow):
             self.addOutputText("cloudfuse.exe not found! Is it installed?")
             self.errorMessageBox("Error running cloudfuse CLI - Please re-install Cloudfuse.")
             return
-        
+
         if exitCode != 0:
             self.addOutputText(stdErr)
             self.errorMessageBox("Mount failed: " + stdErr)
             return
-        
+
         if stdOut != "":
             self.addOutputText(stdOut)
 
@@ -204,7 +204,7 @@ class FUSEWindow(QMainWindow, Ui_primaryFUSEwindow):
             self.addOutputText("cloudfuse.exe not found! Is it installed?")
             self.errorMessageBox("Error running cloudfuse CLI - Please re-install Cloudfuse.")
             return
-        
+
         if exitCode != 0:
             self.addOutputText(f"Error mounting container: {stdErr}")
             if stdErr.find("mount path exists") != -1:
@@ -212,10 +212,10 @@ class FUSEWindow(QMainWindow, Ui_primaryFUSEwindow):
             else:
                 self.errorMessageBox(f"Error mounting container - check the settings and try again\n{stdErr}")
             return
-        
+
         if stdOut != "":
             self.addOutputText(stdOut)
-        
+
         # wait for mount, then check that mount succeeded by verifying that the mount directory exists
         self.addOutputText("Verifying mount success...")
         def verifyMountSuccess():
@@ -238,7 +238,7 @@ class FUSEWindow(QMainWindow, Ui_primaryFUSEwindow):
         commandParts = [cloudfuseCli, "unmount", directory]
         if platform != "win32":
             commandParts.append("--lazy")
-        
+
         (stdOut, stdErr, exitCode, executableFound) = self.runCommand(commandParts)
         if not executableFound:
             self.addOutputText("cloudfuse.exe not found! Is it installed?")
@@ -251,7 +251,7 @@ class FUSEWindow(QMainWindow, Ui_primaryFUSEwindow):
 
     # This function reads in the config file, modifies the components section, then writes the config file back
     def modifyPipeline(self):
-        
+
         self.addOutputText("Validating configuration...")
         # Update the pipeline/components before mounting the target
 
@@ -267,8 +267,8 @@ class FUSEWindow(QMainWindow, Ui_primaryFUSEwindow):
                 f"Could not read the config file in {workingDir}. Consider going through the settings for selected target.",
                 "Could not read config file")
             return
-        
-        # Modify the components (pipeline) in the config file. 
+
+        # Modify the components (pipeline) in the config file.
         #   If the components are not present, there's a chance the configs are wrong. Notify user.
 
         components = configs.get('components')
@@ -280,15 +280,15 @@ class FUSEWindow(QMainWindow, Ui_primaryFUSEwindow):
                 f"The components is missing in {workingDir}/config.yaml. Consider Going through the settings to create one.",
                 "Components in config missing")
             return
-        
-        # Write the config file with the modified components 
+
+        # Write the config file with the modified components
         try:
             with open(workingDir+'/config.yaml','w') as file:
                 yaml.safe_dump(configs,file)
         except:
             self.errorMessageBox(f"Could not modify {workingDir}/config.yaml.", "Could not modify config file")
             return
-    
+
     # run command and return tuple:
     # (stdOut, stdErr, exitCode, executableFound)
     def runCommand(self, commandParts):
@@ -306,12 +306,12 @@ class FUSEWindow(QMainWindow, Ui_primaryFUSEwindow):
             return ('', '', -1, False)
         except PermissionError:
             return ('', '', -1, False)
-    
+
     def addOutputText(self, textString):
         self.textEdit_output.setText(f"{self.textEdit_output.toPlainText()}{textString}\n")
         self.textEdit_output.repaint()
         self.textEdit_output.moveCursor(QtGui.QTextCursor.End)
-    
+
     def errorMessageBox(self, messageString, titleString="Error"):
         msg = QtWidgets.QMessageBox()
         # Get the user's attention by popping open a new window

--- a/gui/s3_config_common.ui
+++ b/gui/s3_config_common.ui
@@ -58,7 +58,7 @@
      <item>
       <widget class="QCheckBox" name="checkBox_daemonForeground">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Run CloudFuse in the foreground of background. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Run Cloudfuse in the foreground of background. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="text">
         <string>Run in foreground</string>
@@ -140,7 +140,7 @@
        <item>
         <widget class="QLabel" name="label_2">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the pipeline mode for CloudFuse&lt;/p&gt;&lt;p&gt;Choose either File caching or Streaming&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the pipeline mode for Cloudfuse&lt;/p&gt;&lt;p&gt;Choose either File caching or Streaming&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="text">
           <string>Mode</string>


### PR DESCRIPTION

### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief

- Use system path to find cloudfuse CLI, and only use current directory as a fallback.
- Set allow-other to false by default, since Linux fuse throws an error
- Use the same mount logic for Windows and Linux

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #