### PR TITLE
Bugfix: File cache rename directory fails to remove source directory

### DIFF
--- a/component/file_cache/cache_policy_test.go
+++ b/component/file_cache/cache_policy_test.go
@@ -54,7 +54,10 @@ func (suite *cachePolicyTestSuite) SetupTest() {
 }
 
 func (suite *cachePolicyTestSuite) cleanupTest() {
-	os.RemoveAll(cache_path)
+	err := os.RemoveAll(cache_path)
+	if err != nil {
+		fmt.Printf("cachePolicyTestSuite::cleanupTest : os.RemoveAll(%s) failed [%v]\n", cache_path, err)
+	}
 }
 
 func (suite *cachePolicyTestSuite) TestGetUsage() {

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -401,7 +401,7 @@ func (fc *FileCache) invalidateDirectory(name string) {
 	// TODO : wouldn't this cause a race condition? a thread might get the lock before we purge - and the file would be non-existent
 	err = filepath.WalkDir(localPath, func(path string, d fs.DirEntry, err error) error {
 		if err == nil && d != nil {
-			log.Debug("FileCache::invalidateDirectory : %s (%d) getting removed from cache", path, d.IsDir())
+			log.Debug("FileCache::invalidateDirectory : %s (IsDir=%t) getting removed from cache", path, d.IsDir())
 			if !d.IsDir() {
 				fc.policy.CachePurge(path)
 			} else {

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -201,7 +201,11 @@ func (c *FileCache) TempCacheCleanup() error {
 		}
 
 		for _, entry := range dirents {
-			os.RemoveAll(common.JoinUnixFilepath(c.tmpPath, entry.Name()))
+			localPath := common.JoinUnixFilepath(c.tmpPath, entry.Name())
+			err = os.RemoveAll(localPath)
+			if err != nil {
+				log.Warn("FileCache::TempCacheCleanup : os.RemoveAll(%s) failed [%v]", localPath, err)
+			}
 		}
 	}
 

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -389,7 +389,7 @@ func isLocalDirEmpty(path string) bool {
 func (fc *FileCache) invalidateDirectory(name string) {
 	log.Trace("FileCache::invalidateDirectory : %s", name)
 
-	localPath := fc.tmpPath + "/" + name
+	localPath := filepath.Join(fc.tmpPath, name)
 	_, err := os.Stat(localPath)
 	if os.IsNotExist(err) {
 		log.Info("FileCache::invalidateDirectory : %s does not exist in local cache.", name)

--- a/component/file_cache/file_cache_linux_test.go
+++ b/component/file_cache/file_cache_linux_test.go
@@ -66,8 +66,14 @@ func (suite *fileCacheLinuxTestSuite) SetupTest() {
 	log.Debug(defaultConfig)
 
 	// Delete the temp directories created
-	os.RemoveAll(suite.cache_path)
-	os.RemoveAll(suite.fake_storage_path)
+	err = os.RemoveAll(suite.cache_path)
+	if err != nil {
+		fmt.Printf("fileCacheLinuxTestSuite::SetupTest : os.RemoveAll(%s) failed [%v]\n", suite.cache_path, err)
+	}
+	err = os.RemoveAll(suite.fake_storage_path)
+	if err != nil {
+		fmt.Printf("fileCacheLinuxTestSuite::SetupTest : os.RemoveAll(%s) failed [%v]\n", suite.fake_storage_path, err)
+	}
 	suite.setupTestHelper(defaultConfig)
 }
 
@@ -93,8 +99,14 @@ func (suite *fileCacheLinuxTestSuite) cleanupTest() {
 	}
 
 	// Delete the temp directories created
-	os.RemoveAll(suite.cache_path)
-	os.RemoveAll(suite.fake_storage_path)
+	err = os.RemoveAll(suite.cache_path)
+	if err != nil {
+		fmt.Printf("fileCacheLinuxTestSuite::cleanupTest : os.RemoveAll(%s) failed [%v]\n", suite.cache_path, err)
+	}
+	err = os.RemoveAll(suite.fake_storage_path)
+	if err != nil {
+		fmt.Printf("fileCacheLinuxTestSuite::cleanupTest : os.RemoveAll(%s) failed [%v]\n", suite.fake_storage_path, err)
+	}
 }
 
 func (suite *fileCacheLinuxTestSuite) TestChmodNotInCache() {

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -93,8 +93,8 @@ func (suite *fileCacheTestSuite) SetupTest() {
 		panic(fmt.Sprintf("Unable to set silent logger as default: %v", err))
 	}
 	rand := randomString(8)
-	suite.cache_path = filepath.Join(home_dir, "file_cache"+rand)
-	suite.fake_storage_path = filepath.Join(home_dir, "fake_storage"+rand)
+	suite.cache_path = common.JoinUnixFilepath(home_dir, "file_cache"+rand)
+	suite.fake_storage_path = common.JoinUnixFilepath(home_dir, "fake_storage"+rand)
 	defaultConfig := fmt.Sprintf("file_cache:\n  path: %s\n  offload-io: true\n  timeout-sec: 0\n\nloopbackfs:\n  path: %s", suite.cache_path, suite.fake_storage_path)
 	log.Debug(defaultConfig)
 
@@ -306,10 +306,10 @@ func (suite *fileCacheTestSuite) TestCreateDir() {
 	suite.assert.NoError(err)
 
 	// Path should not be added to the file cache
-	_, err = os.Stat(filepath.Join(suite.cache_path, path))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
 	suite.assert.True(os.IsNotExist(err))
 	// Path should be in fake storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 }
 
@@ -490,10 +490,10 @@ func (suite *fileCacheTestSuite) TestCreateFile() {
 	suite.assert.True(f.Dirty()) // Handle should be dirty since it was not created in cloud storage
 
 	// Path should be added to the file cache
-	_, err = os.Stat(filepath.Join(suite.cache_path, path))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 	// Path should not be in fake storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, path))
 	suite.assert.True(os.IsNotExist(err))
 }
 
@@ -508,12 +508,12 @@ func (suite *fileCacheTestSuite) TestCreateFileInDir() {
 	suite.assert.True(f.Dirty()) // Handle should be dirty since it was not created in cloud storage
 
 	// Path should be added to the file cache, including directory
-	_, err = os.Stat(filepath.Join(suite.cache_path, dir))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, dir))
 	suite.assert.True(err == nil || os.IsExist(err))
-	_, err = os.Stat(filepath.Join(suite.cache_path, path))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 	// Path should not be in fake storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, path))
 	suite.assert.True(os.IsNotExist(err))
 }
 
@@ -532,10 +532,10 @@ func (suite *fileCacheTestSuite) TestCreateFileCreateEmptyFile() {
 	suite.assert.False(f.Dirty()) // Handle should not be dirty since it was written to storage
 
 	// Path should be added to the file cache
-	_, err = os.Stat(filepath.Join(suite.cache_path, path))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 	// Path should be in fake storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 }
 
@@ -555,14 +555,14 @@ func (suite *fileCacheTestSuite) TestCreateFileInDirCreateEmptyFile() {
 	suite.assert.False(f.Dirty()) // Handle should be dirty since it was not created in cloud storage
 
 	// Path should be added to the file cache, including directory
-	_, err = os.Stat(filepath.Join(suite.cache_path, dir))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, dir))
 	suite.assert.True(err == nil || os.IsExist(err))
-	_, err = os.Stat(filepath.Join(suite.cache_path, path))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 	// Path should be in fake storage, including directory
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, dir))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, dir))
 	suite.assert.True(err == nil || os.IsExist(err))
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 }
 
@@ -587,7 +587,7 @@ func (suite *fileCacheTestSuite) TestSyncFile() {
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: handle})
 
 	// Path should not be in file cache
-	_, err = os.Stat(filepath.Join(suite.cache_path, path))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
 	suite.assert.True(os.IsNotExist(err))
 
 	path = "file.fsync"
@@ -600,7 +600,7 @@ func (suite *fileCacheTestSuite) TestSyncFile() {
 	err = suite.fileCache.SyncFile(internal.SyncFileOptions{Handle: handle})
 	suite.assert.NoError(err)
 	suite.assert.False(handle.Dirty())
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
+	_, err = os.Stat(suite.fake_storage_path + "/" + path)
 	suite.assert.True(err == nil || os.IsExist(err))
 
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: handle})
@@ -619,10 +619,10 @@ func (suite *fileCacheTestSuite) TestDeleteFile() {
 	suite.assert.NoError(err)
 
 	// Path should not be in file cache
-	_, err = os.Stat(filepath.Join(suite.cache_path, path))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
 	suite.assert.True(os.IsNotExist(err))
 	// Path should not be in fake storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, path))
 	suite.assert.True(os.IsNotExist(err))
 }
 
@@ -639,10 +639,10 @@ func (suite *fileCacheTestSuite) TestDeleteFileCase2() {
 	suite.assert.Equal(syscall.EIO, err)
 
 	// Path should not be in local cache (since we failed the operation)
-	_, err = os.Stat(filepath.Join(suite.cache_path, path))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 	// Path should not be in fake storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, path))
 	suite.assert.True(os.IsNotExist(err))
 }
 
@@ -664,10 +664,10 @@ func (suite *fileCacheTestSuite) TestOpenFileNotInCache() {
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: handle})
 
 	// loop until file does not exist - done due to async nature of eviction
-	_, err := os.Stat(filepath.Join(suite.cache_path, path))
+	_, err := os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
 	for i := 0; i < 10 && !os.IsNotExist(err); i++ {
 		time.Sleep(time.Second)
-		_, err = os.Stat(filepath.Join(suite.cache_path, path))
+		_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
 	}
 	// TODO: find out why this delayed eviction check fails in CI on Windows sometimes
 	if runtime.GOOS == "windows" {
@@ -683,7 +683,7 @@ func (suite *fileCacheTestSuite) TestOpenFileNotInCache() {
 	suite.assert.False(handle.Dirty())
 
 	// File should exist in cache
-	_, err = os.Stat(filepath.Join(suite.cache_path, path))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 }
 
@@ -703,7 +703,7 @@ func (suite *fileCacheTestSuite) TestOpenFileInCache() {
 	suite.assert.False(handle.Dirty())
 
 	// File should exist in cache
-	_, err = os.Stat(filepath.Join(suite.cache_path, path))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 }
 
@@ -723,19 +723,19 @@ func (suite *fileCacheTestSuite) TestCloseFile() {
 	suite.assert.NoError(err)
 
 	// loop until file does not exist - done due to async nature of eviction
-	_, err = os.Stat(filepath.Join(suite.cache_path, path))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
 	for i := 0; i < 10 && !os.IsNotExist(err); i++ {
 		time.Sleep(time.Second)
-		_, err = os.Stat(filepath.Join(suite.cache_path, path))
+		_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
 	}
 	suite.assert.True(os.IsNotExist(err))
 
 	suite.assert.False(suite.fileCache.policy.IsCached(path)) // File should be invalidated
 	// File should not be in cache
-	_, err = os.Stat(filepath.Join(suite.cache_path, path))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
 	suite.assert.True(os.IsNotExist(err))
 	// File should be in cloud storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 }
 
@@ -758,25 +758,25 @@ func (suite *fileCacheTestSuite) TestCloseFileTimeout() {
 	suite.assert.False(suite.fileCache.policy.IsCached(path)) // File should be invalidated
 
 	// File should be in cache
-	_, err = os.Stat(filepath.Join(suite.cache_path, path))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 	// File should be in cloud storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 
 	// loop until file does not exist - done due to async nature of eviction
-	_, err = os.Stat(filepath.Join(suite.cache_path, path))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
 	for i := 0; i < (cacheTimeout*3) && !os.IsNotExist(err); i++ {
 		time.Sleep(time.Second)
-		_, err = os.Stat(filepath.Join(suite.cache_path, path))
+		_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
 	}
 
 	// File should not be in cache
-	_, err = os.Stat(filepath.Join(suite.cache_path, path))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
 	suite.assert.True(os.IsNotExist(err))
 
 	// File should be in cloud storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 }
 
@@ -910,7 +910,7 @@ func (suite *fileCacheTestSuite) TestWriteFile() {
 	suite.assert.NoError(err)
 	suite.assert.EqualValues(len(data), length)
 	// Check that the local cache updated with data
-	d, _ := os.ReadFile(filepath.Join(suite.cache_path, file))
+	d, _ := os.ReadFile(common.JoinUnixFilepath(suite.cache_path, file))
 	suite.assert.EqualValues(data, d)
 	suite.assert.True(handle.Dirty())
 }
@@ -933,7 +933,7 @@ func (suite *fileCacheTestSuite) TestFlushFileEmpty() {
 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
 
 	// Path should not be in fake storage
-	_, err := os.Stat(filepath.Join(suite.fake_storage_path, file))
+	_, err := os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, file))
 	suite.assert.True(os.IsNotExist(err))
 
 	// Flush the Empty File
@@ -942,7 +942,7 @@ func (suite *fileCacheTestSuite) TestFlushFileEmpty() {
 	suite.assert.False(handle.Dirty())
 
 	// Path should be in fake storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, file))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, file))
 	suite.assert.True(err == nil || os.IsExist(err))
 }
 
@@ -956,7 +956,7 @@ func (suite *fileCacheTestSuite) TestFlushFile() {
 	suite.fileCache.WriteFile(internal.WriteFileOptions{Handle: handle, Offset: 0, Data: data})
 
 	// Path should not be in fake storage
-	_, err := os.Stat(filepath.Join(suite.fake_storage_path, file))
+	_, err := os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, file))
 	suite.assert.True(os.IsNotExist(err))
 
 	// Flush the Empty File
@@ -965,10 +965,10 @@ func (suite *fileCacheTestSuite) TestFlushFile() {
 	suite.assert.False(handle.Dirty())
 
 	// Path should be in fake storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, file))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, file))
 	suite.assert.True(err == nil || os.IsExist(err))
 	// Check that fake_storage updated with data
-	d, _ := os.ReadFile(filepath.Join(suite.fake_storage_path, file))
+	d, _ := os.ReadFile(common.JoinUnixFilepath(suite.fake_storage_path, file))
 	suite.assert.EqualValues(data, d)
 }
 
@@ -1057,10 +1057,10 @@ func (suite *fileCacheTestSuite) TestGetAttrCase4() {
 	suite.assert.NoError(err)
 
 	// Wait  file is evicted
-	_, err = os.Stat(filepath.Join(suite.cache_path, file))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, file))
 	for i := 0; i < 20 && !os.IsNotExist(err); i++ {
 		time.Sleep(time.Second)
-		_, err = os.Stat(filepath.Join(suite.cache_path, file))
+		_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, file))
 	}
 	// TODO: why is check test flaky (on both platforms)?
 	fmt.Println("Skipping TestGetAttrCase4 eviction check (flaky).")
@@ -1097,15 +1097,15 @@ func (suite *fileCacheTestSuite) TestRenameFileNotInCache() {
 	err = suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: handle})
 	suite.assert.NoError(err)
 
-	_, err = os.Stat(filepath.Join(suite.cache_path, src))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, src))
 	for i := 0; i < 10 && !os.IsNotExist(err); i++ {
 		time.Sleep(time.Second)
-		_, err = os.Stat(filepath.Join(suite.cache_path, src))
+		_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, src))
 	}
 	suite.assert.True(os.IsNotExist(err))
 
 	// Path should be in fake storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, src))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, src))
 	suite.assert.True(err == nil || os.IsExist(err))
 
 	// RenameFile
@@ -1113,9 +1113,9 @@ func (suite *fileCacheTestSuite) TestRenameFileNotInCache() {
 	suite.assert.NoError(err)
 
 	// Path in fake storage should be updated
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, src)) // Src does not exist
+	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, src)) // Src does not exist
 	suite.assert.True(os.IsNotExist(err))
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, dst)) // Dst does exist
+	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, dst)) // Dst does exist
 	suite.assert.True(err == nil || os.IsExist(err))
 }
 
@@ -1132,23 +1132,23 @@ func (suite *fileCacheTestSuite) TestRenameFileInCache() {
 	suite.assert.NoError(err)
 
 	// Path should be in the file cache
-	_, err = os.Stat(filepath.Join(suite.cache_path, src))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, src))
 	suite.assert.True(err == nil || os.IsExist(err))
 	// Path should be in fake storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, src))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, src))
 	suite.assert.True(err == nil || os.IsExist(err))
 
 	// RenameFile
 	err = suite.fileCache.RenameFile(internal.RenameFileOptions{Src: src, Dst: dst})
 	suite.assert.NoError(err)
 	// Path in fake storage and file cache should be updated
-	_, err = os.Stat(filepath.Join(suite.cache_path, src)) // Src does not exist
+	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, src)) // Src does not exist
 	suite.assert.True(os.IsNotExist(err))
-	_, err = os.Stat(filepath.Join(suite.cache_path, dst)) // Dst shall exists in cache
+	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, dst)) // Dst shall exists in cache
 	suite.assert.True(err == nil || os.IsExist(err))
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, src)) // Src does not exist
+	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, src)) // Src does not exist
 	suite.assert.True(os.IsNotExist(err))
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, dst)) // Dst does exist
+	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, dst)) // Dst does exist
 	suite.assert.True(err == nil || os.IsExist(err))
 
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: openHandle})
@@ -1166,13 +1166,13 @@ func (suite *fileCacheTestSuite) TestRenameFileCase2() {
 	suite.assert.Equal(syscall.EIO, err)
 
 	// Src should be in local cache (since we failed the operation)
-	_, err = os.Stat(filepath.Join(suite.cache_path, src))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, src))
 	suite.assert.True(err == nil || os.IsExist(err))
 	// Src should not be in fake storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, src))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, src))
 	suite.assert.True(os.IsNotExist(err))
 	// Dst should not be in fake storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, dst))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, dst))
 	suite.assert.True(os.IsNotExist(err))
 }
 
@@ -1191,33 +1191,33 @@ func (suite *fileCacheTestSuite) TestRenameFileAndCacheCleanup() {
 	openHandle, _ := suite.fileCache.OpenFile(internal.OpenFileOptions{Name: src, Mode: 0666})
 
 	// Path should be in the file cache
-	_, err := os.Stat(filepath.Join(suite.cache_path, src))
+	_, err := os.Stat(suite.cache_path + "/" + src)
 	suite.assert.True(err == nil || os.IsExist(err))
 	// Path should be in fake storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, src))
+	_, err = os.Stat(suite.fake_storage_path + "/" + src)
 	suite.assert.True(err == nil || os.IsExist(err))
 
 	// RenameFile
 	err = suite.fileCache.RenameFile(internal.RenameFileOptions{Src: src, Dst: dst})
 	suite.assert.NoError(err)
 	// Path in fake storage and file cache should be updated
-	_, err = os.Stat(filepath.Join(suite.cache_path, src)) // Src does not exist
+	_, err = os.Stat(suite.cache_path + "/" + src) // Src does not exist
 	suite.assert.True(os.IsNotExist(err))
-	_, err = os.Stat(filepath.Join(suite.cache_path, dst)) // Dst shall exists in cache
+	_, err = os.Stat(suite.cache_path + "/" + dst) // Dst shall exists in cache
 	suite.assert.True(err == nil || os.IsExist(err))
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, src)) // Src does not exist
+	_, err = os.Stat(suite.fake_storage_path + "/" + src) // Src does not exist
 	suite.assert.True(os.IsNotExist(err))
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, dst)) // Dst does exist
+	_, err = os.Stat(suite.fake_storage_path + "/" + dst) // Dst does exist
 	suite.assert.True(err == nil || os.IsExist(err))
 
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: openHandle})
 
-	time.Sleep(5 * time.Second)                            // Check once before the cache cleanup that file exists
-	_, err = os.Stat(filepath.Join(suite.cache_path, dst)) // Dst shall exists in cache
+	time.Sleep(5 * time.Second)                    // Check once before the cache cleanup that file exists
+	_, err = os.Stat(suite.cache_path + "/" + dst) // Dst shall exists in cache
 	suite.assert.True(err == nil || os.IsExist(err))
 
-	time.Sleep(8 * time.Second)                            // Wait for the cache cleanup to occur
-	_, err = os.Stat(filepath.Join(suite.cache_path, dst)) // Dst shall not exists in cache
+	time.Sleep(8 * time.Second)                    // Wait for the cache cleanup to occur
+	_, err = os.Stat(suite.cache_path + "/" + dst) // Dst shall not exists in cache
 	suite.assert.True(err == nil || os.IsNotExist(err))
 }
 
@@ -1236,29 +1236,29 @@ func (suite *fileCacheTestSuite) TestRenameFileAndCacheCleanupWithNoTimeout() {
 	openHandle, _ := suite.fileCache.OpenFile(internal.OpenFileOptions{Name: src, Mode: 0666})
 
 	// Path should be in the file cache
-	_, err := os.Stat(filepath.Join(suite.cache_path, src))
+	_, err := os.Stat(suite.cache_path + "/" + src)
 	suite.assert.True(err == nil || os.IsExist(err))
 	// Path should be in fake storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, src))
+	_, err = os.Stat(suite.fake_storage_path + "/" + src)
 	suite.assert.True(err == nil || os.IsExist(err))
 
 	// RenameFile
 	err = suite.fileCache.RenameFile(internal.RenameFileOptions{Src: src, Dst: dst})
 	suite.assert.NoError(err)
 	// Path in fake storage and file cache should be updated
-	_, err = os.Stat(filepath.Join(suite.cache_path, src)) // Src does not exist
+	_, err = os.Stat(suite.cache_path + "/" + src) // Src does not exist
 	suite.assert.True(os.IsNotExist(err))
-	_, err = os.Stat(filepath.Join(suite.cache_path, dst)) // Dst shall exists in cache
+	_, err = os.Stat(suite.cache_path + "/" + dst) // Dst shall exists in cache
 	suite.assert.True(err == nil || os.IsExist(err))
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, src)) // Src does not exist
+	_, err = os.Stat(suite.fake_storage_path + "/" + src) // Src does not exist
 	suite.assert.True(os.IsNotExist(err))
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, dst)) // Dst does exist
+	_, err = os.Stat(suite.fake_storage_path + "/" + dst) // Dst does exist
 	suite.assert.True(err == nil || os.IsExist(err))
 
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: openHandle})
 
-	time.Sleep(1 * time.Second)                            // Wait for the cache cleanup to occur
-	_, err = os.Stat(filepath.Join(suite.cache_path, dst)) // Dst shall not exists in cache
+	time.Sleep(1 * time.Second)                    // Wait for the cache cleanup to occur
+	_, err = os.Stat(suite.cache_path + "/" + dst) // Dst shall not exists in cache
 	suite.assert.True(err == nil || os.IsNotExist(err))
 }
 
@@ -1269,15 +1269,15 @@ func (suite *fileCacheTestSuite) TestTruncateFileNotInCache() {
 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: path, Mode: 0777})
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: handle})
 
-	_, err := os.Stat(filepath.Join(suite.cache_path, path))
+	_, err := os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
 	for i := 0; i < 10 && !os.IsNotExist(err); i++ {
 		time.Sleep(time.Second)
-		_, err = os.Stat(filepath.Join(suite.cache_path, path))
+		_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
 	}
 	suite.assert.True(os.IsNotExist(err))
 
 	// Path should be in fake storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 
 	// Chmod
@@ -1286,7 +1286,7 @@ func (suite *fileCacheTestSuite) TestTruncateFileNotInCache() {
 	suite.assert.NoError(err)
 
 	// Path in fake storage should be updated
-	info, _ := os.Stat(filepath.Join(suite.fake_storage_path, path))
+	info, _ := os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, path))
 	suite.assert.EqualValues(info.Size(), size)
 }
 
@@ -1299,10 +1299,10 @@ func (suite *fileCacheTestSuite) TestTruncateFileInCache() {
 	openHandle, _ := suite.fileCache.OpenFile(internal.OpenFileOptions{Name: path, Mode: 0666})
 
 	// Path should be in the file cache
-	_, err := os.Stat(filepath.Join(suite.cache_path, path))
+	_, err := os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 	// Path should be in fake storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
+	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 
 	// Chmod
@@ -1310,9 +1310,9 @@ func (suite *fileCacheTestSuite) TestTruncateFileInCache() {
 	err = suite.fileCache.TruncateFile(internal.TruncateFileOptions{Name: path, Size: int64(size)})
 	suite.assert.NoError(err)
 	// Path in fake storage and file cache should be updated
-	info, _ := os.Stat(filepath.Join(suite.cache_path, path))
+	info, _ := os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
 	suite.assert.EqualValues(info.Size(), size)
-	info, _ = os.Stat(filepath.Join(suite.fake_storage_path, path))
+	info, _ = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, path))
 	suite.assert.EqualValues(info.Size(), size)
 
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: openHandle})
@@ -1329,13 +1329,13 @@ func (suite *fileCacheTestSuite) TestTruncateFileCase2() {
 	suite.assert.NoError(err)
 
 	// Path should be in the file cache and size should be updated
-	info, err := os.Stat(filepath.Join(suite.cache_path, path))
+	info, err := os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 	suite.assert.EqualValues(info.Size(), size)
 
 	// Path should not be in fake storage
 	// With new changes we always download and then truncate so file will exists in local path
-	// _, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
+	// _, err = os.Stat(suite.fake_storage_path + "/" + path)
 	// suite.assert.True(os.IsNotExist(err))
 }
 

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -458,8 +458,6 @@ func (suite *fileCacheTestSuite) TestRenameDir() {
 	suite.fileCache.CreateDir(internal.CreateDirOptions{Name: src, Mode: 0777})
 	suite.fileCache.CreateFile(internal.CreateFileOptions{Name: path, Mode: 0777})
 	// The file (and directory) is in the cache and storage (see TestCreateFileInDirCreateEmptyFile)
-	// Delete the file since we can only delete empty directories
-	suite.fileCache.DeleteFile(internal.DeleteFileOptions{Name: path})
 
 	// Delete the directory
 	err := suite.fileCache.RenameDir(internal.RenameDirOptions{Src: src, Dst: dst})

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -472,7 +472,7 @@ func (suite *fileCacheTestSuite) TestRenameDir() {
 	suite.assert.NoError(err)
 	suite.assert.False(suite.fileCache.policy.IsCached(src)) // Directory should not be cached
 	// wait for asynchronous deletion
-	time.Sleep(2 * time.Second)
+	time.Sleep(1 * time.Second)
 	// directory should not exist in local filesystem
 	fInfo, err := os.Stat(filepath.Join(suite.cache_path, src))
 	suite.assert.Nil(fInfo)

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -97,8 +97,14 @@ func (suite *fileCacheTestSuite) SetupTest() {
 	log.Debug(defaultConfig)
 
 	// Delete the temp directories created
-	os.RemoveAll(suite.cache_path)
-	os.RemoveAll(suite.fake_storage_path)
+	err = os.RemoveAll(suite.cache_path)
+	if err != nil {
+		fmt.Printf("fileCacheTestSuite::SetupTest : os.RemoveAll(%s) failed [%v]\n", suite.cache_path, err)
+	}
+	err = os.RemoveAll(suite.fake_storage_path)
+	if err != nil {
+		fmt.Printf("fileCacheTestSuite::SetupTest : os.RemoveAll(%s) failed [%v]\n", suite.fake_storage_path, err)
+	}
 	suite.setupTestHelper(defaultConfig)
 }
 
@@ -127,8 +133,14 @@ func (suite *fileCacheTestSuite) cleanupTest() {
 	}
 
 	// Delete the temp directories created
-	os.RemoveAll(suite.cache_path)
-	os.RemoveAll(suite.fake_storage_path)
+	err = os.RemoveAll(suite.cache_path)
+	if err != nil {
+		fmt.Printf("fileCacheTestSuite::cleanupTest : os.RemoveAll(%s) failed [%v]\n", suite.cache_path, err)
+	}
+	err = os.RemoveAll(suite.fake_storage_path)
+	if err != nil {
+		fmt.Printf("fileCacheTestSuite::cleanupTest : os.RemoveAll(%s) failed [%v]\n", suite.fake_storage_path, err)
+	}
 }
 
 // Tests the default configuration of file cache

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -93,8 +93,8 @@ func (suite *fileCacheTestSuite) SetupTest() {
 		panic(fmt.Sprintf("Unable to set silent logger as default: %v", err))
 	}
 	rand := randomString(8)
-	suite.cache_path = common.JoinUnixFilepath(home_dir, "file_cache"+rand)
-	suite.fake_storage_path = common.JoinUnixFilepath(home_dir, "fake_storage"+rand)
+	suite.cache_path = filepath.Join(home_dir, "file_cache"+rand)
+	suite.fake_storage_path = filepath.Join(home_dir, "fake_storage"+rand)
 	defaultConfig := fmt.Sprintf("file_cache:\n  path: %s\n  offload-io: true\n  timeout-sec: 0\n\nloopbackfs:\n  path: %s", suite.cache_path, suite.fake_storage_path)
 	log.Debug(defaultConfig)
 
@@ -306,10 +306,10 @@ func (suite *fileCacheTestSuite) TestCreateDir() {
 	suite.assert.NoError(err)
 
 	// Path should not be added to the file cache
-	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
+	_, err = os.Stat(filepath.Join(suite.cache_path, path))
 	suite.assert.True(os.IsNotExist(err))
 	// Path should be in fake storage
-	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, path))
+	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 }
 
@@ -490,10 +490,10 @@ func (suite *fileCacheTestSuite) TestCreateFile() {
 	suite.assert.True(f.Dirty()) // Handle should be dirty since it was not created in cloud storage
 
 	// Path should be added to the file cache
-	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
+	_, err = os.Stat(filepath.Join(suite.cache_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 	// Path should not be in fake storage
-	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, path))
+	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
 	suite.assert.True(os.IsNotExist(err))
 }
 
@@ -508,12 +508,12 @@ func (suite *fileCacheTestSuite) TestCreateFileInDir() {
 	suite.assert.True(f.Dirty()) // Handle should be dirty since it was not created in cloud storage
 
 	// Path should be added to the file cache, including directory
-	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, dir))
+	_, err = os.Stat(filepath.Join(suite.cache_path, dir))
 	suite.assert.True(err == nil || os.IsExist(err))
-	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
+	_, err = os.Stat(filepath.Join(suite.cache_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 	// Path should not be in fake storage
-	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, path))
+	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
 	suite.assert.True(os.IsNotExist(err))
 }
 
@@ -532,10 +532,10 @@ func (suite *fileCacheTestSuite) TestCreateFileCreateEmptyFile() {
 	suite.assert.False(f.Dirty()) // Handle should not be dirty since it was written to storage
 
 	// Path should be added to the file cache
-	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
+	_, err = os.Stat(filepath.Join(suite.cache_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 	// Path should be in fake storage
-	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, path))
+	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 }
 
@@ -555,14 +555,14 @@ func (suite *fileCacheTestSuite) TestCreateFileInDirCreateEmptyFile() {
 	suite.assert.False(f.Dirty()) // Handle should be dirty since it was not created in cloud storage
 
 	// Path should be added to the file cache, including directory
-	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, dir))
+	_, err = os.Stat(filepath.Join(suite.cache_path, dir))
 	suite.assert.True(err == nil || os.IsExist(err))
-	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
+	_, err = os.Stat(filepath.Join(suite.cache_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 	// Path should be in fake storage, including directory
-	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, dir))
+	_, err = os.Stat(filepath.Join(suite.fake_storage_path, dir))
 	suite.assert.True(err == nil || os.IsExist(err))
-	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, path))
+	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 }
 
@@ -587,7 +587,7 @@ func (suite *fileCacheTestSuite) TestSyncFile() {
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: handle})
 
 	// Path should not be in file cache
-	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
+	_, err = os.Stat(filepath.Join(suite.cache_path, path))
 	suite.assert.True(os.IsNotExist(err))
 
 	path = "file.fsync"
@@ -600,7 +600,7 @@ func (suite *fileCacheTestSuite) TestSyncFile() {
 	err = suite.fileCache.SyncFile(internal.SyncFileOptions{Handle: handle})
 	suite.assert.NoError(err)
 	suite.assert.False(handle.Dirty())
-	_, err = os.Stat(suite.fake_storage_path + "/" + path)
+	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: handle})
@@ -619,10 +619,10 @@ func (suite *fileCacheTestSuite) TestDeleteFile() {
 	suite.assert.NoError(err)
 
 	// Path should not be in file cache
-	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
+	_, err = os.Stat(filepath.Join(suite.cache_path, path))
 	suite.assert.True(os.IsNotExist(err))
 	// Path should not be in fake storage
-	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, path))
+	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
 	suite.assert.True(os.IsNotExist(err))
 }
 
@@ -639,10 +639,10 @@ func (suite *fileCacheTestSuite) TestDeleteFileCase2() {
 	suite.assert.Equal(syscall.EIO, err)
 
 	// Path should not be in local cache (since we failed the operation)
-	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
+	_, err = os.Stat(filepath.Join(suite.cache_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 	// Path should not be in fake storage
-	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, path))
+	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
 	suite.assert.True(os.IsNotExist(err))
 }
 
@@ -664,10 +664,10 @@ func (suite *fileCacheTestSuite) TestOpenFileNotInCache() {
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: handle})
 
 	// loop until file does not exist - done due to async nature of eviction
-	_, err := os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
+	_, err := os.Stat(filepath.Join(suite.cache_path, path))
 	for i := 0; i < 10 && !os.IsNotExist(err); i++ {
 		time.Sleep(time.Second)
-		_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
+		_, err = os.Stat(filepath.Join(suite.cache_path, path))
 	}
 	// TODO: find out why this delayed eviction check fails in CI on Windows sometimes
 	if runtime.GOOS == "windows" {
@@ -683,7 +683,7 @@ func (suite *fileCacheTestSuite) TestOpenFileNotInCache() {
 	suite.assert.False(handle.Dirty())
 
 	// File should exist in cache
-	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
+	_, err = os.Stat(filepath.Join(suite.cache_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 }
 
@@ -703,7 +703,7 @@ func (suite *fileCacheTestSuite) TestOpenFileInCache() {
 	suite.assert.False(handle.Dirty())
 
 	// File should exist in cache
-	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
+	_, err = os.Stat(filepath.Join(suite.cache_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 }
 
@@ -723,19 +723,19 @@ func (suite *fileCacheTestSuite) TestCloseFile() {
 	suite.assert.NoError(err)
 
 	// loop until file does not exist - done due to async nature of eviction
-	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
+	_, err = os.Stat(filepath.Join(suite.cache_path, path))
 	for i := 0; i < 10 && !os.IsNotExist(err); i++ {
 		time.Sleep(time.Second)
-		_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
+		_, err = os.Stat(filepath.Join(suite.cache_path, path))
 	}
 	suite.assert.True(os.IsNotExist(err))
 
 	suite.assert.False(suite.fileCache.policy.IsCached(path)) // File should be invalidated
 	// File should not be in cache
-	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
+	_, err = os.Stat(filepath.Join(suite.cache_path, path))
 	suite.assert.True(os.IsNotExist(err))
 	// File should be in cloud storage
-	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, path))
+	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 }
 
@@ -758,25 +758,25 @@ func (suite *fileCacheTestSuite) TestCloseFileTimeout() {
 	suite.assert.False(suite.fileCache.policy.IsCached(path)) // File should be invalidated
 
 	// File should be in cache
-	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
+	_, err = os.Stat(filepath.Join(suite.cache_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 	// File should be in cloud storage
-	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, path))
+	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 
 	// loop until file does not exist - done due to async nature of eviction
-	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
+	_, err = os.Stat(filepath.Join(suite.cache_path, path))
 	for i := 0; i < (cacheTimeout*3) && !os.IsNotExist(err); i++ {
 		time.Sleep(time.Second)
-		_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
+		_, err = os.Stat(filepath.Join(suite.cache_path, path))
 	}
 
 	// File should not be in cache
-	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
+	_, err = os.Stat(filepath.Join(suite.cache_path, path))
 	suite.assert.True(os.IsNotExist(err))
 
 	// File should be in cloud storage
-	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, path))
+	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 }
 
@@ -910,7 +910,7 @@ func (suite *fileCacheTestSuite) TestWriteFile() {
 	suite.assert.NoError(err)
 	suite.assert.EqualValues(len(data), length)
 	// Check that the local cache updated with data
-	d, _ := os.ReadFile(common.JoinUnixFilepath(suite.cache_path, file))
+	d, _ := os.ReadFile(filepath.Join(suite.cache_path, file))
 	suite.assert.EqualValues(data, d)
 	suite.assert.True(handle.Dirty())
 }
@@ -933,7 +933,7 @@ func (suite *fileCacheTestSuite) TestFlushFileEmpty() {
 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
 
 	// Path should not be in fake storage
-	_, err := os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, file))
+	_, err := os.Stat(filepath.Join(suite.fake_storage_path, file))
 	suite.assert.True(os.IsNotExist(err))
 
 	// Flush the Empty File
@@ -942,7 +942,7 @@ func (suite *fileCacheTestSuite) TestFlushFileEmpty() {
 	suite.assert.False(handle.Dirty())
 
 	// Path should be in fake storage
-	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, file))
+	_, err = os.Stat(filepath.Join(suite.fake_storage_path, file))
 	suite.assert.True(err == nil || os.IsExist(err))
 }
 
@@ -956,7 +956,7 @@ func (suite *fileCacheTestSuite) TestFlushFile() {
 	suite.fileCache.WriteFile(internal.WriteFileOptions{Handle: handle, Offset: 0, Data: data})
 
 	// Path should not be in fake storage
-	_, err := os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, file))
+	_, err := os.Stat(filepath.Join(suite.fake_storage_path, file))
 	suite.assert.True(os.IsNotExist(err))
 
 	// Flush the Empty File
@@ -965,10 +965,10 @@ func (suite *fileCacheTestSuite) TestFlushFile() {
 	suite.assert.False(handle.Dirty())
 
 	// Path should be in fake storage
-	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, file))
+	_, err = os.Stat(filepath.Join(suite.fake_storage_path, file))
 	suite.assert.True(err == nil || os.IsExist(err))
 	// Check that fake_storage updated with data
-	d, _ := os.ReadFile(common.JoinUnixFilepath(suite.fake_storage_path, file))
+	d, _ := os.ReadFile(filepath.Join(suite.fake_storage_path, file))
 	suite.assert.EqualValues(data, d)
 }
 
@@ -1057,10 +1057,10 @@ func (suite *fileCacheTestSuite) TestGetAttrCase4() {
 	suite.assert.NoError(err)
 
 	// Wait  file is evicted
-	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, file))
+	_, err = os.Stat(filepath.Join(suite.cache_path, file))
 	for i := 0; i < 20 && !os.IsNotExist(err); i++ {
 		time.Sleep(time.Second)
-		_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, file))
+		_, err = os.Stat(filepath.Join(suite.cache_path, file))
 	}
 	// TODO: why is check test flaky (on both platforms)?
 	fmt.Println("Skipping TestGetAttrCase4 eviction check (flaky).")
@@ -1097,15 +1097,15 @@ func (suite *fileCacheTestSuite) TestRenameFileNotInCache() {
 	err = suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: handle})
 	suite.assert.NoError(err)
 
-	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, src))
+	_, err = os.Stat(filepath.Join(suite.cache_path, src))
 	for i := 0; i < 10 && !os.IsNotExist(err); i++ {
 		time.Sleep(time.Second)
-		_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, src))
+		_, err = os.Stat(filepath.Join(suite.cache_path, src))
 	}
 	suite.assert.True(os.IsNotExist(err))
 
 	// Path should be in fake storage
-	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, src))
+	_, err = os.Stat(filepath.Join(suite.fake_storage_path, src))
 	suite.assert.True(err == nil || os.IsExist(err))
 
 	// RenameFile
@@ -1113,9 +1113,9 @@ func (suite *fileCacheTestSuite) TestRenameFileNotInCache() {
 	suite.assert.NoError(err)
 
 	// Path in fake storage should be updated
-	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, src)) // Src does not exist
+	_, err = os.Stat(filepath.Join(suite.fake_storage_path, src)) // Src does not exist
 	suite.assert.True(os.IsNotExist(err))
-	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, dst)) // Dst does exist
+	_, err = os.Stat(filepath.Join(suite.fake_storage_path, dst)) // Dst does exist
 	suite.assert.True(err == nil || os.IsExist(err))
 }
 
@@ -1132,23 +1132,23 @@ func (suite *fileCacheTestSuite) TestRenameFileInCache() {
 	suite.assert.NoError(err)
 
 	// Path should be in the file cache
-	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, src))
+	_, err = os.Stat(filepath.Join(suite.cache_path, src))
 	suite.assert.True(err == nil || os.IsExist(err))
 	// Path should be in fake storage
-	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, src))
+	_, err = os.Stat(filepath.Join(suite.fake_storage_path, src))
 	suite.assert.True(err == nil || os.IsExist(err))
 
 	// RenameFile
 	err = suite.fileCache.RenameFile(internal.RenameFileOptions{Src: src, Dst: dst})
 	suite.assert.NoError(err)
 	// Path in fake storage and file cache should be updated
-	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, src)) // Src does not exist
+	_, err = os.Stat(filepath.Join(suite.cache_path, src)) // Src does not exist
 	suite.assert.True(os.IsNotExist(err))
-	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, dst)) // Dst shall exists in cache
+	_, err = os.Stat(filepath.Join(suite.cache_path, dst)) // Dst shall exists in cache
 	suite.assert.True(err == nil || os.IsExist(err))
-	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, src)) // Src does not exist
+	_, err = os.Stat(filepath.Join(suite.fake_storage_path, src)) // Src does not exist
 	suite.assert.True(os.IsNotExist(err))
-	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, dst)) // Dst does exist
+	_, err = os.Stat(filepath.Join(suite.fake_storage_path, dst)) // Dst does exist
 	suite.assert.True(err == nil || os.IsExist(err))
 
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: openHandle})
@@ -1166,13 +1166,13 @@ func (suite *fileCacheTestSuite) TestRenameFileCase2() {
 	suite.assert.Equal(syscall.EIO, err)
 
 	// Src should be in local cache (since we failed the operation)
-	_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, src))
+	_, err = os.Stat(filepath.Join(suite.cache_path, src))
 	suite.assert.True(err == nil || os.IsExist(err))
 	// Src should not be in fake storage
-	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, src))
+	_, err = os.Stat(filepath.Join(suite.fake_storage_path, src))
 	suite.assert.True(os.IsNotExist(err))
 	// Dst should not be in fake storage
-	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, dst))
+	_, err = os.Stat(filepath.Join(suite.fake_storage_path, dst))
 	suite.assert.True(os.IsNotExist(err))
 }
 
@@ -1191,33 +1191,33 @@ func (suite *fileCacheTestSuite) TestRenameFileAndCacheCleanup() {
 	openHandle, _ := suite.fileCache.OpenFile(internal.OpenFileOptions{Name: src, Mode: 0666})
 
 	// Path should be in the file cache
-	_, err := os.Stat(suite.cache_path + "/" + src)
+	_, err := os.Stat(filepath.Join(suite.cache_path, src))
 	suite.assert.True(err == nil || os.IsExist(err))
 	// Path should be in fake storage
-	_, err = os.Stat(suite.fake_storage_path + "/" + src)
+	_, err = os.Stat(filepath.Join(suite.fake_storage_path, src))
 	suite.assert.True(err == nil || os.IsExist(err))
 
 	// RenameFile
 	err = suite.fileCache.RenameFile(internal.RenameFileOptions{Src: src, Dst: dst})
 	suite.assert.NoError(err)
 	// Path in fake storage and file cache should be updated
-	_, err = os.Stat(suite.cache_path + "/" + src) // Src does not exist
+	_, err = os.Stat(filepath.Join(suite.cache_path, src)) // Src does not exist
 	suite.assert.True(os.IsNotExist(err))
-	_, err = os.Stat(suite.cache_path + "/" + dst) // Dst shall exists in cache
+	_, err = os.Stat(filepath.Join(suite.cache_path, dst)) // Dst shall exists in cache
 	suite.assert.True(err == nil || os.IsExist(err))
-	_, err = os.Stat(suite.fake_storage_path + "/" + src) // Src does not exist
+	_, err = os.Stat(filepath.Join(suite.fake_storage_path, src)) // Src does not exist
 	suite.assert.True(os.IsNotExist(err))
-	_, err = os.Stat(suite.fake_storage_path + "/" + dst) // Dst does exist
+	_, err = os.Stat(filepath.Join(suite.fake_storage_path, dst)) // Dst does exist
 	suite.assert.True(err == nil || os.IsExist(err))
 
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: openHandle})
 
-	time.Sleep(5 * time.Second)                    // Check once before the cache cleanup that file exists
-	_, err = os.Stat(suite.cache_path + "/" + dst) // Dst shall exists in cache
+	time.Sleep(5 * time.Second)                            // Check once before the cache cleanup that file exists
+	_, err = os.Stat(filepath.Join(suite.cache_path, dst)) // Dst shall exists in cache
 	suite.assert.True(err == nil || os.IsExist(err))
 
-	time.Sleep(8 * time.Second)                    // Wait for the cache cleanup to occur
-	_, err = os.Stat(suite.cache_path + "/" + dst) // Dst shall not exists in cache
+	time.Sleep(8 * time.Second)                            // Wait for the cache cleanup to occur
+	_, err = os.Stat(filepath.Join(suite.cache_path, dst)) // Dst shall not exists in cache
 	suite.assert.True(err == nil || os.IsNotExist(err))
 }
 
@@ -1236,29 +1236,29 @@ func (suite *fileCacheTestSuite) TestRenameFileAndCacheCleanupWithNoTimeout() {
 	openHandle, _ := suite.fileCache.OpenFile(internal.OpenFileOptions{Name: src, Mode: 0666})
 
 	// Path should be in the file cache
-	_, err := os.Stat(suite.cache_path + "/" + src)
+	_, err := os.Stat(filepath.Join(suite.cache_path, src))
 	suite.assert.True(err == nil || os.IsExist(err))
 	// Path should be in fake storage
-	_, err = os.Stat(suite.fake_storage_path + "/" + src)
+	_, err = os.Stat(filepath.Join(suite.fake_storage_path, src))
 	suite.assert.True(err == nil || os.IsExist(err))
 
 	// RenameFile
 	err = suite.fileCache.RenameFile(internal.RenameFileOptions{Src: src, Dst: dst})
 	suite.assert.NoError(err)
 	// Path in fake storage and file cache should be updated
-	_, err = os.Stat(suite.cache_path + "/" + src) // Src does not exist
+	_, err = os.Stat(filepath.Join(suite.cache_path, src)) // Src does not exist
 	suite.assert.True(os.IsNotExist(err))
-	_, err = os.Stat(suite.cache_path + "/" + dst) // Dst shall exists in cache
+	_, err = os.Stat(filepath.Join(suite.cache_path, dst)) // Dst shall exists in cache
 	suite.assert.True(err == nil || os.IsExist(err))
-	_, err = os.Stat(suite.fake_storage_path + "/" + src) // Src does not exist
+	_, err = os.Stat(filepath.Join(suite.fake_storage_path, src)) // Src does not exist
 	suite.assert.True(os.IsNotExist(err))
-	_, err = os.Stat(suite.fake_storage_path + "/" + dst) // Dst does exist
+	_, err = os.Stat(filepath.Join(suite.fake_storage_path, dst)) // Dst does exist
 	suite.assert.True(err == nil || os.IsExist(err))
 
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: openHandle})
 
-	time.Sleep(1 * time.Second)                    // Wait for the cache cleanup to occur
-	_, err = os.Stat(suite.cache_path + "/" + dst) // Dst shall not exists in cache
+	time.Sleep(1 * time.Second)                            // Wait for the cache cleanup to occur
+	_, err = os.Stat(filepath.Join(suite.cache_path, dst)) // Dst shall not exists in cache
 	suite.assert.True(err == nil || os.IsNotExist(err))
 }
 
@@ -1269,15 +1269,15 @@ func (suite *fileCacheTestSuite) TestTruncateFileNotInCache() {
 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: path, Mode: 0777})
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: handle})
 
-	_, err := os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
+	_, err := os.Stat(filepath.Join(suite.cache_path, path))
 	for i := 0; i < 10 && !os.IsNotExist(err); i++ {
 		time.Sleep(time.Second)
-		_, err = os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
+		_, err = os.Stat(filepath.Join(suite.cache_path, path))
 	}
 	suite.assert.True(os.IsNotExist(err))
 
 	// Path should be in fake storage
-	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, path))
+	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 
 	// Chmod
@@ -1286,7 +1286,7 @@ func (suite *fileCacheTestSuite) TestTruncateFileNotInCache() {
 	suite.assert.NoError(err)
 
 	// Path in fake storage should be updated
-	info, _ := os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, path))
+	info, _ := os.Stat(filepath.Join(suite.fake_storage_path, path))
 	suite.assert.EqualValues(info.Size(), size)
 }
 
@@ -1299,10 +1299,10 @@ func (suite *fileCacheTestSuite) TestTruncateFileInCache() {
 	openHandle, _ := suite.fileCache.OpenFile(internal.OpenFileOptions{Name: path, Mode: 0666})
 
 	// Path should be in the file cache
-	_, err := os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
+	_, err := os.Stat(filepath.Join(suite.cache_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 	// Path should be in fake storage
-	_, err = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, path))
+	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 
 	// Chmod
@@ -1310,9 +1310,9 @@ func (suite *fileCacheTestSuite) TestTruncateFileInCache() {
 	err = suite.fileCache.TruncateFile(internal.TruncateFileOptions{Name: path, Size: int64(size)})
 	suite.assert.NoError(err)
 	// Path in fake storage and file cache should be updated
-	info, _ := os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
+	info, _ := os.Stat(filepath.Join(suite.cache_path, path))
 	suite.assert.EqualValues(info.Size(), size)
-	info, _ = os.Stat(common.JoinUnixFilepath(suite.fake_storage_path, path))
+	info, _ = os.Stat(filepath.Join(suite.fake_storage_path, path))
 	suite.assert.EqualValues(info.Size(), size)
 
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: openHandle})
@@ -1329,13 +1329,13 @@ func (suite *fileCacheTestSuite) TestTruncateFileCase2() {
 	suite.assert.NoError(err)
 
 	// Path should be in the file cache and size should be updated
-	info, err := os.Stat(common.JoinUnixFilepath(suite.cache_path, path))
+	info, err := os.Stat(filepath.Join(suite.cache_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))
 	suite.assert.EqualValues(info.Size(), size)
 
 	// Path should not be in fake storage
 	// With new changes we always download and then truncate so file will exists in local path
-	// _, err = os.Stat(suite.fake_storage_path + "/" + path)
+	// _, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
 	// suite.assert.True(os.IsNotExist(err))
 }
 

--- a/component/file_cache/file_cache_windows_test.go
+++ b/component/file_cache/file_cache_windows_test.go
@@ -65,8 +65,14 @@ func (suite *fileCacheWindowsTestSuite) SetupTest() {
 	log.Debug(defaultConfig)
 
 	// Delete the temp directories created
-	os.RemoveAll(suite.cache_path)
-	os.RemoveAll(suite.fake_storage_path)
+	err = os.RemoveAll(suite.cache_path)
+	if err != nil {
+		fmt.Printf("fileCacheWindowsTestSuite::SetupTest : os.RemoveAll(%s) failed [%v]\n", suite.cache_path, err)
+	}
+	err = os.RemoveAll(suite.fake_storage_path)
+	if err != nil {
+		fmt.Printf("fileCacheWindowsTestSuite::SetupTest : os.RemoveAll(%s) failed [%v]\n", suite.fake_storage_path, err)
+	}
 	suite.setupTestHelper(defaultConfig)
 }
 
@@ -92,8 +98,14 @@ func (suite *fileCacheWindowsTestSuite) cleanupTest() {
 	}
 
 	// Delete the temp directories created
-	os.RemoveAll(suite.cache_path)
-	os.RemoveAll(suite.fake_storage_path)
+	err = os.RemoveAll(suite.cache_path)
+	if err != nil {
+		fmt.Printf("fileCacheWindowsTestSuite::cleanupTest : os.RemoveAll(%s) failed [%v]\n", suite.cache_path, err)
+	}
+	err = os.RemoveAll(suite.fake_storage_path)
+	if err != nil {
+		fmt.Printf("fileCacheWindowsTestSuite::cleanupTest : os.RemoveAll(%s) failed [%v]\n", suite.fake_storage_path, err)
+	}
 }
 
 func (suite *fileCacheWindowsTestSuite) TestChownNotInCache() {

--- a/component/file_cache/lfu_policy_test.go
+++ b/component/file_cache/lfu_policy_test.go
@@ -29,11 +29,13 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/Seagate/cloudfuse/common"
 	"github.com/Seagate/cloudfuse/common/log"
+	"github.com/Seagate/cloudfuse/internal"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -81,6 +83,67 @@ func (suite *lfuPolicyTestSuite) cleanupTest() {
 	if err != nil {
 		fmt.Printf("lfuPolicyTestSuite::cleanupTest : os.RemoveAll(%s) failed [%v]\n", cache_path, err)
 	}
+}
+
+// add named item to local cache filesystem, and cache policy data structure
+func (suite *lfuPolicyTestSuite) createLocalPath(localPath string, isDir bool) {
+	var err error
+	suite.policy.CacheValid(localPath)
+	if isDir {
+		err = os.Mkdir(localPath, os.FileMode(0777))
+		suite.assert.NoError(err)
+	} else {
+		fh, err := os.Create(localPath)
+		suite.assert.NoError(err)
+		err = fh.Close()
+		suite.assert.NoError(err)
+	}
+}
+
+// Generate hierarchy:
+// a/
+//
+//	 a/c1/
+//	  a/c1/gc1
+//		a/c2
+//
+// ab/
+//
+//	ab/c1
+//
+// ac
+func (suite *lfuPolicyTestSuite) generateNestedDirectory(aPath string) ([]string, []string, []string) {
+	localBasePath := filepath.Join(suite.policy.tmpPath, internal.TruncateDirName(aPath))
+	suite.createLocalPath(localBasePath, true)
+	c1 := filepath.Join(localBasePath, "c1")
+	suite.createLocalPath(c1, true)
+	gc1 := filepath.Join(c1, "gc1")
+	suite.createLocalPath(gc1, false)
+	c2 := filepath.Join(localBasePath, "c2")
+	suite.createLocalPath(c2, false)
+	aPaths := []string{localBasePath, c1, gc1, c2}
+
+	abPath := localBasePath + "b"
+	suite.createLocalPath(abPath, true)
+	abc1 := filepath.Join(abPath, "c1")
+	suite.createLocalPath(abc1, false)
+	abPaths := []string{abPath, abc1}
+
+	acPath := localBasePath + "c"
+	suite.createLocalPath(acPath, false)
+	acPaths := []string{acPath}
+
+	var allPaths []string
+	copy(allPaths, aPaths)
+	allPaths = append(allPaths, abPaths...)
+	allPaths = append(allPaths, acPaths...)
+	// Validate the paths were setup correctly and all paths exist
+	for _, path := range allPaths {
+		_, err := os.Stat(path)
+		suite.assert.NoError(err)
+	}
+
+	return aPaths, abPaths, acPaths
 }
 
 func (suite *lfuPolicyTestSuite) TestDefault() {
@@ -181,11 +244,37 @@ func (suite *lfuPolicyTestSuite) TestCacheInvalidateTimeout() {
 
 func (suite *lfuPolicyTestSuite) TestCachePurge() {
 	defer suite.cleanupTest()
+	// test policy cache data
 	suite.policy.CacheValid("temp")
 	suite.policy.CachePurge("temp")
 
 	node := suite.policy.list.get("temp")
 	suite.assert.Nil(node)
+
+	// test asynchronous file and folder deletion
+	// purge all aPaths, in reverse order
+	aPaths, abPaths, acPaths := suite.generateNestedDirectory("temp")
+	for i := len(aPaths) - 1; i >= 0; i-- {
+		suite.policy.CachePurge(aPaths[i])
+	}
+
+	// wait for asynchronous deletions
+	// in local testing, 1ms was enough
+	time.Sleep(1 * time.Second)
+	// validate all aPaths were deleted
+	for _, path := range aPaths {
+		_, err := os.Stat(path)
+		suite.assert.Error(err)
+		suite.assert.True(os.IsNotExist(err))
+	}
+	// validate other paths were not touched
+	var otherPaths []string
+	copy(otherPaths, abPaths)
+	otherPaths = append(otherPaths, acPaths...)
+	for _, path := range otherPaths {
+		_, err := os.Stat(path)
+		suite.assert.NoError(err)
+	}
 }
 
 func (suite *lfuPolicyTestSuite) TestIsCached() {

--- a/component/file_cache/lfu_policy_test.go
+++ b/component/file_cache/lfu_policy_test.go
@@ -47,7 +47,7 @@ type lfuPolicyTestSuite struct {
 	policy *lfuPolicy
 }
 
-var cache_path = common.JoinUnixFilepath(home_dir, "file_cache")
+var cache_path = filepath.Join(home_dir, "file_cache")
 
 func (suite *lfuPolicyTestSuite) SetupTest() {
 	err := log.SetDefaultLogger("silent", common.LogConfig{Level: common.ELogLevel.LOG_DEBUG()})

--- a/component/file_cache/lfu_policy_test.go
+++ b/component/file_cache/lfu_policy_test.go
@@ -77,7 +77,10 @@ func (suite *lfuPolicyTestSuite) setupTestHelper(config cachePolicyConfig) {
 func (suite *lfuPolicyTestSuite) cleanupTest() {
 	suite.policy.ShutdownPolicy()
 
-	os.RemoveAll(cache_path)
+	err := os.RemoveAll(cache_path)
+	if err != nil {
+		fmt.Printf("lfuPolicyTestSuite::cleanupTest : os.RemoveAll(%s) failed [%v]\n", cache_path, err)
+	}
 }
 
 func (suite *lfuPolicyTestSuite) TestDefault() {

--- a/component/file_cache/lfu_policy_test.go
+++ b/component/file_cache/lfu_policy_test.go
@@ -47,7 +47,7 @@ type lfuPolicyTestSuite struct {
 	policy *lfuPolicy
 }
 
-var cache_path = filepath.Join(home_dir, "file_cache")
+var cache_path = common.JoinUnixFilepath(home_dir, "file_cache")
 
 func (suite *lfuPolicyTestSuite) SetupTest() {
 	err := log.SetDefaultLogger("silent", common.LogConfig{Level: common.ELogLevel.LOG_DEBUG()})

--- a/component/file_cache/lru_policy_test.go
+++ b/component/file_cache/lru_policy_test.go
@@ -29,10 +29,12 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/Seagate/cloudfuse/common"
+	"github.com/Seagate/cloudfuse/internal"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -79,6 +81,67 @@ func (suite *lruPolicyTestSuite) cleanupTest() {
 	if err != nil {
 		fmt.Printf("lruPolicyTestSuite::cleanupTest : os.RemoveAll(%s) failed [%v]\n", cache_path, err)
 	}
+}
+
+// add named item to local cache filesystem, and cache policy data structure
+func (suite *lruPolicyTestSuite) createLocalPath(localPath string, isDir bool) {
+	var err error
+	suite.policy.CacheValid(localPath)
+	if isDir {
+		err = os.Mkdir(localPath, os.FileMode(0777))
+		suite.assert.NoError(err)
+	} else {
+		fh, err := os.Create(localPath)
+		suite.assert.NoError(err)
+		err = fh.Close()
+		suite.assert.NoError(err)
+	}
+}
+
+// Generate hierarchy:
+// a/
+//
+//	 a/c1/
+//	  a/c1/gc1
+//		a/c2
+//
+// ab/
+//
+//	ab/c1
+//
+// ac
+func (suite *lruPolicyTestSuite) generateNestedDirectory(aPath string) ([]string, []string, []string) {
+	localBasePath := filepath.Join(suite.policy.tmpPath, internal.TruncateDirName(aPath))
+	suite.createLocalPath(localBasePath, true)
+	c1 := filepath.Join(localBasePath, "c1")
+	suite.createLocalPath(c1, true)
+	gc1 := filepath.Join(c1, "gc1")
+	suite.createLocalPath(gc1, false)
+	c2 := filepath.Join(localBasePath, "c2")
+	suite.createLocalPath(c2, false)
+	aPaths := []string{localBasePath, c1, gc1, c2}
+
+	abPath := localBasePath + "b"
+	suite.createLocalPath(abPath, true)
+	abc1 := filepath.Join(abPath, "c1")
+	suite.createLocalPath(abc1, false)
+	abPaths := []string{abPath, abc1}
+
+	acPath := localBasePath + "c"
+	suite.createLocalPath(acPath, false)
+	acPaths := []string{acPath}
+
+	var allPaths []string
+	copy(allPaths, aPaths)
+	allPaths = append(allPaths, abPaths...)
+	allPaths = append(allPaths, acPaths...)
+	// Validate the paths were setup correctly and all paths exist
+	for _, path := range allPaths {
+		_, err := os.Stat(path)
+		suite.assert.NoError(err)
+	}
+
+	return aPaths, abPaths, acPaths
 }
 
 func (suite *lruPolicyTestSuite) TestDefault() {
@@ -165,12 +228,38 @@ func (suite *lruPolicyTestSuite) TestCacheInvalidateTimeout() {
 
 func (suite *lruPolicyTestSuite) TestCachePurge() {
 	defer suite.cleanupTest()
+	// test policy cache data
 	suite.policy.CacheValid("temp")
 	suite.policy.CachePurge("temp")
 
 	n, ok := suite.policy.nodeMap.Load("temp")
 	suite.assert.False(ok)
 	suite.assert.Nil(n)
+
+	// test asynchronous file and folder deletion
+	// purge all aPaths, in reverse order
+	aPaths, abPaths, acPaths := suite.generateNestedDirectory("temp")
+	for i := len(aPaths) - 1; i >= 0; i-- {
+		suite.policy.CachePurge(aPaths[i])
+	}
+
+	// wait for asynchronous deletions
+	// in local testing, 1ms was enough
+	time.Sleep(1 * time.Second)
+	// validate all aPaths were deleted
+	for _, path := range aPaths {
+		_, err := os.Stat(path)
+		suite.assert.Error(err)
+		suite.assert.True(os.IsNotExist(err))
+	}
+	// validate other paths were not touched
+	var otherPaths []string
+	copy(otherPaths, abPaths)
+	otherPaths = append(otherPaths, acPaths...)
+	for _, path := range otherPaths {
+		_, err := os.Stat(path)
+		suite.assert.NoError(err)
+	}
 }
 
 func (suite *lruPolicyTestSuite) TestIsCached() {

--- a/component/file_cache/lru_policy_test.go
+++ b/component/file_cache/lru_policy_test.go
@@ -75,7 +75,10 @@ func (suite *lruPolicyTestSuite) setupTestHelper(config cachePolicyConfig) {
 func (suite *lruPolicyTestSuite) cleanupTest() {
 	suite.policy.ShutdownPolicy()
 
-	os.RemoveAll(cache_path)
+	err := os.RemoveAll(cache_path)
+	if err != nil {
+		fmt.Printf("lruPolicyTestSuite::cleanupTest : os.RemoveAll(%s) failed [%v]\n", cache_path, err)
+	}
 }
 
 func (suite *lruPolicyTestSuite) TestDefault() {


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief
Change file cache `invalidateDirectory` to delete files in order (children first)
Also added error logging for `os.RemoveAll`

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [x] Added tests

### Related Issues

- Related Issue #
- Closes #