### PR TITLE
Support case3 for StreamDir

### DIFF
--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -434,7 +434,7 @@ func pos(s []*internal.ObjAttr, e string) int {
 	return -1
 }
 
-func (suite *fileCacheTestSuite) TestReadDirMixed() {
+func (suite *fileCacheTestSuite) TestStreamDirMixed() {
 	defer suite.cleanupTest()
 	// Setup
 	name := "dir"

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -30,7 +30,6 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"syscall"
@@ -394,10 +393,10 @@ func (suite *fileCacheTestSuite) TestStreamDirCase3() {
 	defer suite.cleanupTest()
 	// Setup
 	name := "dir"
-	subdir := filepath.Join(name, "subdir")
-	file1 := filepath.Join(name, "file1")
-	file2 := filepath.Join(name, "file2")
-	file3 := filepath.Join(name, "file3")
+	subdir := name + "/subdir"
+	file1 := name + "/file1"
+	file2 := name + "/file2"
+	file3 := name + "/file3"
 	suite.fileCache.CreateDir(internal.CreateDirOptions{Name: name, Mode: 0777})
 	suite.fileCache.CreateDir(internal.CreateDirOptions{Name: subdir, Mode: 0777})
 	// By default createEmptyFile is false, so we will not create these files in storage until they are closed.
@@ -439,11 +438,11 @@ func (suite *fileCacheTestSuite) TestReadDirMixed() {
 	defer suite.cleanupTest()
 	// Setup
 	name := "dir"
-	subdir := filepath.Join(name, "subdir")
-	file1 := filepath.Join(name, "file1") // case 1
-	file2 := filepath.Join(name, "file2") // case 2
-	file3 := filepath.Join(name, "file3") // case 3
-	file4 := filepath.Join(name, "file4") // case 4
+	subdir := name + "/subdir"
+	file1 := name + "/file1" // case 1
+	file2 := name + "/file2" // case 2
+	file3 := name + "/file3" // case 3
+	file4 := name + "/file4" // case 4
 
 	suite.fileCache.CreateDir(internal.CreateDirOptions{Name: name, Mode: 0777})
 	suite.fileCache.CreateDir(internal.CreateDirOptions{Name: subdir, Mode: 0777})

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -30,6 +30,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"syscall"
@@ -363,7 +364,6 @@ func (suite *fileCacheTestSuite) TestStreamDirCase1() {
 	suite.assert.EqualValues(subdir, dir[3].Path)
 }
 
-// TODO: case3 requires more thought due to the way loopback fs is designed, specifically getAttr and streamDir
 func (suite *fileCacheTestSuite) TestStreamDirCase2() {
 	defer suite.cleanupTest()
 	// Setup
@@ -388,6 +388,97 @@ func (suite *fileCacheTestSuite) TestStreamDirCase2() {
 	suite.assert.EqualValues(file1, dir[1].Path)
 	suite.assert.EqualValues(file2, dir[2].Path)
 	suite.assert.EqualValues(file3, dir[3].Path)
+}
+
+func (suite *fileCacheTestSuite) TestStreamDirCase3() {
+	defer suite.cleanupTest()
+	// Setup
+	name := "dir"
+	subdir := filepath.Join(name, "subdir")
+	file1 := filepath.Join(name, "file1")
+	file2 := filepath.Join(name, "file2")
+	file3 := filepath.Join(name, "file3")
+	suite.fileCache.CreateDir(internal.CreateDirOptions{Name: name, Mode: 0777})
+	suite.fileCache.CreateDir(internal.CreateDirOptions{Name: subdir, Mode: 0777})
+	// By default createEmptyFile is false, so we will not create these files in storage until they are closed.
+	suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file1, Mode: 0777})
+	suite.fileCache.TruncateFile(internal.TruncateFileOptions{Name: file1, Size: 1024})
+	suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file2, Mode: 0777})
+	suite.fileCache.TruncateFile(internal.TruncateFileOptions{Name: file2, Size: 1024})
+	suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file3, Mode: 0777})
+	suite.fileCache.TruncateFile(internal.TruncateFileOptions{Name: file3, Size: 1024})
+	// Create the files in fake_storage and simulate different sizes
+	suite.loopback.CreateFile(internal.CreateFileOptions{Name: file1, Mode: 0777}) // Length is default 0
+	suite.loopback.CreateFile(internal.CreateFileOptions{Name: file2, Mode: 0777})
+	suite.loopback.CreateFile(internal.CreateFileOptions{Name: file3, Mode: 0777})
+
+	// Read the Directory
+	dir, _, err := suite.fileCache.StreamDir(internal.StreamDirOptions{Name: name})
+	suite.assert.NoError(err)
+	suite.assert.NotEmpty(dir)
+	suite.assert.Len(dir, 4)
+	suite.assert.EqualValues(file1, dir[0].Path)
+	suite.assert.EqualValues(1024, dir[0].Size)
+	suite.assert.EqualValues(file2, dir[1].Path)
+	suite.assert.EqualValues(1024, dir[1].Size)
+	suite.assert.EqualValues(file3, dir[2].Path)
+	suite.assert.EqualValues(1024, dir[2].Size)
+	suite.assert.EqualValues(subdir, dir[3].Path)
+}
+
+func pos(s []*internal.ObjAttr, e string) int {
+	for i, v := range s {
+		if v.Path == e {
+			return i
+		}
+	}
+	return -1
+}
+
+func (suite *fileCacheTestSuite) TestReadDirMixed() {
+	defer suite.cleanupTest()
+	// Setup
+	name := "dir"
+	subdir := filepath.Join(name, "subdir")
+	file1 := filepath.Join(name, "file1") // case 1
+	file2 := filepath.Join(name, "file2") // case 2
+	file3 := filepath.Join(name, "file3") // case 3
+	file4 := filepath.Join(name, "file4") // case 4
+
+	suite.fileCache.CreateDir(internal.CreateDirOptions{Name: name, Mode: 0777})
+	suite.fileCache.CreateDir(internal.CreateDirOptions{Name: subdir, Mode: 0777})
+
+	// By default createEmptyFile is false, so we will not create these files in storage until they are closed.
+	suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file2, Mode: 0777})
+	suite.fileCache.TruncateFile(internal.TruncateFileOptions{Name: file2, Size: 1024})
+	suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file3, Mode: 0777})
+	suite.fileCache.TruncateFile(internal.TruncateFileOptions{Name: file3, Size: 1024})
+
+	// Create the files in fake_storage and simulate different sizes
+	suite.loopback.CreateFile(internal.CreateFileOptions{Name: file1, Mode: 0777}) // Length is default 0
+	suite.loopback.CreateFile(internal.CreateFileOptions{Name: file3, Mode: 0777})
+
+	suite.loopback.CreateFile(internal.CreateFileOptions{Name: file4, Mode: 0777})
+	suite.fileCache.TruncateFile(internal.TruncateFileOptions{Name: file4, Size: 1024})
+	suite.fileCache.TruncateFile(internal.TruncateFileOptions{Name: file4, Size: 0})
+
+	// Read the Directory
+	dir, _, err := suite.fileCache.StreamDir(internal.StreamDirOptions{Name: name})
+	suite.assert.NoError(err)
+	suite.assert.NotEmpty(dir)
+
+	var i int
+	i = pos(dir, file1)
+	suite.assert.EqualValues(0, dir[i].Size)
+
+	i = pos(dir, file3)
+	suite.assert.EqualValues(1024, dir[i].Size)
+
+	i = pos(dir, file2)
+	suite.assert.EqualValues(1024, dir[i].Size)
+
+	i = pos(dir, file4)
+	suite.assert.EqualValues(0, dir[i].Size)
 }
 
 func (suite *fileCacheTestSuite) TestFileUsed() {


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief

We now support case 3 for StreamDir, when a file exists in local storage and in the cloud. We will serve the correct modify time and size of the file based on the local cache. This has an additional cost of about 4ms per call to StreamDir. So for 10,000 items in our test bucket, it takes an extra 40ms to support this, which is not great but not too bad either. Let me know if you think this should be behind a flag in the file cache.

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [x] Added tests

### Related Issues

- Related Issue #
- Closes #