### PR TITLE
Don't log getattr calls in libfuse, attr_cache, or file_cache

### DIFF
--- a/component/attr_cache/attr_cache.go
+++ b/component/attr_cache/attr_cache.go
@@ -926,7 +926,9 @@ func (ac *AttrCache) SyncDir(options internal.SyncDirOptions) error {
 
 // GetAttr : Try to serve the request from the attribute cache, otherwise cache attributes of the path returned by next component
 func (ac *AttrCache) GetAttr(options internal.GetAttrOptions) (*internal.ObjAttr, error) {
-	log.Trace("AttrCache::GetAttr : %s", options.Name)
+	// Don't log these by default, as it noticibly affects performance
+	// log.Trace("AttrCache::GetAttr : %s", options.Name)
+
 	ac.cacheLock.RLock()
 	value, found := ac.cache.get(options.Name)
 	ac.cacheLock.RUnlock()
@@ -942,7 +944,6 @@ func (ac *AttrCache) GetAttr(options internal.GetAttrOptions) (*internal.ObjAttr
 		// options.RetrieveMetadata is set by CopyFromFile and WriteFile which need metadata to ensure it is preserved.
 		if value.attr.IsMetadataRetrieved() || (ac.noSymlinks && !options.RetrieveMetadata) {
 			// path exists and we have all the metadata required or we do not care about metadata
-			log.Debug("AttrCache::GetAttr : %s served from cache", options.Name)
 			return value.attr, nil
 		}
 	}

--- a/component/attr_cache/attr_cache.go
+++ b/component/attr_cache/attr_cache.go
@@ -926,7 +926,7 @@ func (ac *AttrCache) SyncDir(options internal.SyncDirOptions) error {
 
 // GetAttr : Try to serve the request from the attribute cache, otherwise cache attributes of the path returned by next component
 func (ac *AttrCache) GetAttr(options internal.GetAttrOptions) (*internal.ObjAttr, error) {
-	// Don't log these by default, as it noticibly affects performance
+	// Don't log these by default, as it noticeably affects performance
 	// log.Trace("AttrCache::GetAttr : %s", options.Name)
 
 	ac.cacheLock.RLock()

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -1082,7 +1082,8 @@ func (fc *FileCache) FlushFile(options internal.FlushFileOptions) error {
 
 // GetAttr: Consolidate attributes from storage and local cache
 func (fc *FileCache) GetAttr(options internal.GetAttrOptions) (*internal.ObjAttr, error) {
-	log.Trace("FileCache::GetAttr : %s", options.Name)
+	// Don't log these by default, as it noticibly affects performance
+	// log.Trace("FileCache::GetAttr : %s", options.Name)
 
 	// For get attr, there are three different path situations we have to potentially handle.
 	// 1. Path in cloud storage but not in local cache

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -1082,7 +1082,7 @@ func (fc *FileCache) FlushFile(options internal.FlushFileOptions) error {
 
 // GetAttr: Consolidate attributes from storage and local cache
 func (fc *FileCache) GetAttr(options internal.GetAttrOptions) (*internal.ObjAttr, error) {
-	// Don't log these by default, as it noticibly affects performance
+	// Don't log these by default, as it noticeably affects performance
 	// log.Trace("FileCache::GetAttr : %s", options.Name)
 
 	// For get attr, there are three different path situations we have to potentially handle.

--- a/component/libfuse/libfuse2_handler.go
+++ b/component/libfuse/libfuse2_handler.go
@@ -248,7 +248,7 @@ func (cf *CgofuseFS) Getattr(path string, stat *fuse.Stat_t, fh uint64) int {
 	name := trimFusePath(path)
 	name = common.NormalizeObjectName(name)
 
-	// Don't log these by default, as it noticibly affects performance
+	// Don't log these by default, as it noticeably affects performance
 	// log.Trace("Libfuse::Getattr : %s", name)
 
 	// Return the default configuration for the root

--- a/component/libfuse/libfuse2_handler.go
+++ b/component/libfuse/libfuse2_handler.go
@@ -247,7 +247,9 @@ func (cf *CgofuseFS) Getattr(path string, stat *fuse.Stat_t, fh uint64) int {
 	// TODO: Currently not using filehandle
 	name := trimFusePath(path)
 	name = common.NormalizeObjectName(name)
-	log.Trace("Libfuse::Getattr : %s", name)
+
+	// Don't log these by default, as it noticibly affects performance
+	// log.Trace("Libfuse::Getattr : %s", name)
 
 	// Return the default configuration for the root
 	if name == "" {


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

### Describe your changes in brief

Disable certain logs for GetAttr calls which noticeably affect performance.

### Checklist

- [ ] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #