### PR TITLE
Fix symlink support

### DIFF
--- a/component/attr_cache/attr_cache.go
+++ b/component/attr_cache/attr_cache.go
@@ -845,6 +845,20 @@ func (ac *AttrCache) TruncateFile(options internal.TruncateFileOptions) error {
 	return err
 }
 
+// Update attribute cache when CopyToFile returns that a file doesn't exist
+func (ac *AttrCache) CopyToFile(options internal.CopyToFileOptions) error {
+	log.Trace("AttrCache::CopyToFile : %s", options.Name)
+
+	err := ac.NextComponent().CopyToFile(options)
+	if err != nil {
+		entry, found := ac.cache.get(options.Name)
+		if found {
+			entry.markDeleted(time.Now())
+		}
+	}
+	return err
+}
+
 // CopyFromFile : Upload file and update cache entry
 func (ac *AttrCache) CopyFromFile(options internal.CopyFromFileOptions) error {
 	log.Trace("AttrCache::CopyFromFile : %s", options.Name)

--- a/component/attr_cache/attr_cache.go
+++ b/component/attr_cache/attr_cache.go
@@ -983,10 +983,6 @@ func (ac *AttrCache) GetAttr(options internal.GetAttrOptions) (*internal.ObjAttr
 
 // CreateLink : Mark the new link invalid
 func (ac *AttrCache) CreateLink(options internal.CreateLinkOptions) error {
-	if !ac.enableSymlinks {
-		log.Err("AttrCache::CreateLink : %s -> %s - symlinks are disabled", options.Name, options.Target)
-		return syscall.ENOTSUP
-	}
 	log.Trace("AttrCache::CreateLink : Create symlink %s -> %s", options.Name, options.Target)
 
 	err := ac.NextComponent().CreateLink(options)

--- a/component/attr_cache/attr_cache_test.go
+++ b/component/attr_cache/attr_cache_test.go
@@ -1641,22 +1641,6 @@ func (suite *attrCacheTestSuite) TestCreateLink() {
 	suite.assertUntouched(path)
 }
 
-// Tests CreateLink when enable-symlinks is false
-func (suite *attrCacheTestSuite) TestCreateLinkNoSymlinks() {
-	defer suite.cleanupTest()
-	link := "a.lnk"
-	path := "a"
-
-	options := internal.CreateLinkOptions{Name: link, Target: path}
-
-	// symlinks are disabled by default
-	// cloud should not be called
-	suite.mock.EXPECT().CreateLink(options).MaxTimes(0)
-	err := suite.attrCache.CreateLink(options)
-
-	suite.assert.EqualError(err, syscall.ENOTSUP.Error())
-}
-
 // Tests Chmod
 func (suite *attrCacheTestSuite) TestChmod() {
 	defer suite.cleanupTest()

--- a/component/azstorage/azstorage.go
+++ b/component/azstorage/azstorage.go
@@ -457,6 +457,10 @@ func (az *AzStorage) CopyFromFile(options internal.CopyFromFileOptions) error {
 
 // Symlink operations
 func (az *AzStorage) CreateLink(options internal.CreateLinkOptions) error {
+	if az.stConfig.disableSymlink {
+		log.Err("AzStorage::CreateLink : %s -> %s - Symlink support not enabled", options.Name, options.Target)
+		return syscall.ENOTSUP
+	}
 	log.Trace("AzStorage::CreateLink : Create symlink %s -> %s", options.Name, options.Target)
 	err := az.storage.CreateLink(options.Name, options.Target)
 
@@ -469,6 +473,10 @@ func (az *AzStorage) CreateLink(options internal.CreateLinkOptions) error {
 }
 
 func (az *AzStorage) ReadLink(options internal.ReadLinkOptions) (string, error) {
+	if az.stConfig.disableSymlink {
+		log.Err("AzStorage::ReadLink : %s - Symlink support not enabled", options.Name)
+		return "", syscall.ENOENT
+	}
 	log.Trace("AzStorage::ReadLink : Read symlink %s", options.Name)
 	data, err := az.storage.ReadBuffer(options.Name, 0, 0)
 

--- a/component/azstorage/block_blob_test.go
+++ b/component/azstorage/block_blob_test.go
@@ -2211,9 +2211,11 @@ func (s *blockBlobTestSuite) TestGetAttrFile() {
 
 func (s *blockBlobTestSuite) TestGetAttrLink() {
 	defer s.cleanupTest()
-	vdConfig := fmt.Sprintf("azstorage:\n  account-name: %s\n  endpoint: %s\n  type: block\n  account-key: %s\n  mode: key\n  container: %s\n  fail-unsupported-op: true\n  virtual-directory: true",
+	// enable symlinks in config
+	config := s.config + "\nattr_cache:\n  enable-symlinks: true"
+	vdConfig := fmt.Sprintf("azstorage:\n  account-name: %s\n  endpoint: %s\n  type: block\n  account-key: %s\n  mode: key\n  container: %s\n  fail-unsupported-op: true\n  virtual-directory: true\nattr_cache:\n  enable-symlinks: true",
 		storageTestConfigurationParameters.BlockAccount, storageTestConfigurationParameters.Endpoint, storageTestConfigurationParameters.BlockKey, s.container)
-	configs := []string{"", vdConfig}
+	configs := []string{config, vdConfig}
 	for _, c := range configs {
 		// This is a little janky but required since testify suite does not support running setup or clean up for subtests.
 		s.tearDownTestHelper(false)

--- a/component/azstorage/block_blob_test.go
+++ b/component/azstorage/block_blob_test.go
@@ -2008,6 +2008,10 @@ func (s *blockBlobTestSuite) TestCopyFromFileWindowsNameConvert() {
 
 func (s *blockBlobTestSuite) TestCreateLink() {
 	defer s.cleanupTest()
+	// enable symlinks in config
+	config := s.config + "\nattr_cache:\n  enable-symlinks: true\n"
+	s.setupTestHelper(config, s.container, true)
+	s.assert.False(s.az.stConfig.disableSymlink)
 	// Setup
 	target := generateFileName()
 	s.az.CreateFile(internal.CreateFileOptions{Name: target})
@@ -2030,8 +2034,30 @@ func (s *blockBlobTestSuite) TestCreateLink() {
 	s.assert.EqualValues(target, data)
 }
 
+func (s *blockBlobTestSuite) TestCreateLinkDisabled() {
+	defer s.cleanupTest()
+	// Setup
+	target := generateFileName()
+	s.az.CreateFile(internal.CreateFileOptions{Name: target})
+	name := generateFileName()
+
+	err := s.az.CreateLink(internal.CreateLinkOptions{Name: name, Target: target})
+	s.assert.Error(err)
+	s.assert.EqualError(err, syscall.ENOTSUP.Error())
+
+	// Link should not be in the account
+	link := s.containerUrl.NewBlobURL(name)
+	props, err := link.GetProperties(ctx, azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{})
+	s.assert.Nil(props)
+	s.assert.Error(err)
+}
+
 func (s *blockBlobTestSuite) TestReadLink() {
 	defer s.cleanupTest()
+	// enable symlinks in config
+	config := s.config + "\nattr_cache:\n  enable-symlinks: true\n"
+	s.setupTestHelper(config, s.container, true)
+	s.assert.False(s.az.stConfig.disableSymlink)
 	// Setup
 	target := generateFileName()
 	s.az.CreateFile(internal.CreateFileOptions{Name: target})
@@ -2044,6 +2070,20 @@ func (s *blockBlobTestSuite) TestReadLink() {
 }
 
 func (s *blockBlobTestSuite) TestReadLinkError() {
+	defer s.cleanupTest()
+	// enable symlinks in config
+	config := s.config + "\nattr_cache:\n  enable-symlinks: true\n"
+	s.setupTestHelper(config, s.container, true)
+	s.assert.False(s.az.stConfig.disableSymlink)
+	// Setup
+	name := generateFileName()
+
+	_, err := s.az.ReadLink(internal.ReadLinkOptions{Name: name})
+	s.assert.Error(err)
+	s.assert.EqualValues(syscall.ENOENT, err)
+}
+
+func (s *blockBlobTestSuite) TestReadLinkDisabled() {
 	defer s.cleanupTest()
 	// Setup
 	name := generateFileName()

--- a/component/azstorage/config.go
+++ b/component/azstorage/config.go
@@ -184,7 +184,7 @@ type AzStorageOptions struct {
 	CaCertFile     string `config:"ca-cert-file" yaml:"-"`
 }
 
-// RegisterEnvVariables : Register environment varilables
+// RegisterEnvVariables : Register environment variables
 func RegisterEnvVariables() {
 	config.BindEnv("azstorage.account-name", EnvAzStorageAccount)
 	config.BindEnv("azstorage.type", EnvAzStorageAccountType)
@@ -555,16 +555,16 @@ func ParseAndReadDynamicConfig(az *AzStorage, opt AzStorageOptions, reload bool)
 		az.stConfig.honourACL = false
 	}
 
-	if config.IsSet("attr_cache.no-symlinks") {
-		err := config.UnmarshalKey("attr_cache.no-symlinks", &az.stConfig.disableSymlink)
+	// by default symlink will be disabled
+	enableSymlinks := false
+	if config.IsSet("attr_cache.enable-symlinks") {
+		err := config.UnmarshalKey("attr_cache.enable-symlinks", &enableSymlinks)
 		if err != nil {
-			az.stConfig.disableSymlink = true
-			log.Err("ParseAndReadDynamicConfig : Failed to unmarshal attr_cache.no-symlinks")
+			enableSymlinks = false
+			log.Err("ParseAndReadDynamicConfig : Failed to unmarshal attr_cache.enable-symlinks")
 		}
-	} else {
-		// by default symlink will be disabled
-		az.stConfig.disableSymlink = true
 	}
+	az.stConfig.disableSymlink = !enableSymlinks
 
 	// Auth related reconfig
 	switch opt.AuthMode {

--- a/component/azstorage/config.go
+++ b/component/azstorage/config.go
@@ -486,6 +486,18 @@ func ParseAndValidateConfig(az *AzStorage, opt AzStorageOptions) error {
 		az.stConfig.maxRetryDelay = opt.MaxRetryDelay
 	}
 
+	// by default symlink will be disabled
+	enableSymlinks := false
+	// Borrow enable-symlinks flag from attribute cache
+	if config.IsSet("attr_cache.enable-symlinks") {
+		err := config.UnmarshalKey("attr_cache.enable-symlinks", &enableSymlinks)
+		if err != nil {
+			enableSymlinks = false
+			log.Err("ParseAndReadDynamicConfig : Failed to unmarshal attr_cache.enable-symlinks")
+		}
+	}
+	az.stConfig.disableSymlink = !enableSymlinks
+
 	if config.IsSet(compName + ".set-content-type") {
 		log.Warn("unsupported v1 CLI parameter: set-content-type is always true in cloudfuse.")
 	}

--- a/component/azstorage/datalake.go
+++ b/component/azstorage/datalake.go
@@ -552,7 +552,7 @@ func (dl *Datalake) List(prefix string, marker *string, count int32) ([]*interna
 		// to fetch metadata properties.
 		// Any method that populates the metadata should set the attribute flag.
 		// Alternatively, if you want Datalake list paths to return metadata/properties as well.
-		// pass CLI parameter --no-symlinks=false in the mount command.
+		// pass CLI parameter --enable-symlinks=true in the mount command.
 		pathList = append(pathList, attr)
 	}
 

--- a/component/s3storage/client.go
+++ b/component/s3storage/client.go
@@ -380,12 +380,12 @@ func (cl *Client) GetAttr(name string) (*internal.ObjAttr, error) {
 
 // Get attributes for the given file path.
 // Return ENOENT if there is no corresponding object in the bucket.
-// name should not have a trailing slash (nothing will be found!).
+// name should not have a trailing slash (or nothing will be found!).
 func (cl *Client) getFileAttr(name string) (*internal.ObjAttr, error) {
 	log.Trace("Client::getFileAttr : name %s", name)
 	isSymlink := false
 	object, err := cl.headObject(name, isSymlink)
-	if err == syscall.ENOENT {
+	if err == syscall.ENOENT && !cl.Config.disableSymlink {
 		isSymlink = true
 		return cl.headObject(name, isSymlink)
 	}

--- a/component/s3storage/config.go
+++ b/component/s3storage/config.go
@@ -30,6 +30,7 @@ import (
 	"fmt"
 
 	"github.com/Seagate/cloudfuse/common"
+	"github.com/Seagate/cloudfuse/common/config"
 	"github.com/Seagate/cloudfuse/common/log"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
@@ -152,6 +153,18 @@ func ParseAndReadDynamicConfig(s3 *S3Storage, opt Options, reload bool) error {
 		s3.stConfig.uploadCutoff = opt.UploadCutoffMb * common.MbToBytes
 	}
 	s3.stConfig.concurrency = opt.Concurrency
+
+	// Borrow no-symlinks flag from attribute cache
+	if config.IsSet("attr_cache.no-symlinks") {
+		err := config.UnmarshalKey("attr_cache.no-symlinks", &s3.stConfig.disableSymlink)
+		if err != nil {
+			s3.stConfig.disableSymlink = true
+			log.Err("ParseAndReadDynamicConfig : Failed to unmarshal attr_cache.no-symlinks")
+		}
+	} else {
+		// by default symlink will be disabled
+		s3.stConfig.disableSymlink = true
+	}
 
 	return nil
 }

--- a/component/s3storage/config.go
+++ b/component/s3storage/config.go
@@ -154,17 +154,17 @@ func ParseAndReadDynamicConfig(s3 *S3Storage, opt Options, reload bool) error {
 	}
 	s3.stConfig.concurrency = opt.Concurrency
 
-	// Borrow no-symlinks flag from attribute cache
-	if config.IsSet("attr_cache.no-symlinks") {
-		err := config.UnmarshalKey("attr_cache.no-symlinks", &s3.stConfig.disableSymlink)
+	// by default symlink will be disabled
+	enableSymlinks := false
+	// Borrow enable-symlinks flag from attribute cache
+	if config.IsSet("attr_cache.enable-symlinks") {
+		err := config.UnmarshalKey("attr_cache.enable-symlinks", &enableSymlinks)
 		if err != nil {
-			s3.stConfig.disableSymlink = true
-			log.Err("ParseAndReadDynamicConfig : Failed to unmarshal attr_cache.no-symlinks")
+			enableSymlinks = false
+			log.Err("ParseAndReadDynamicConfig : Failed to unmarshal attr_cache.enable-symlinks")
 		}
-	} else {
-		// by default symlink will be disabled
-		s3.stConfig.disableSymlink = true
 	}
+	s3.stConfig.disableSymlink = !enableSymlinks
 
 	return nil
 }

--- a/component/s3storage/config.go
+++ b/component/s3storage/config.go
@@ -130,6 +130,18 @@ func ParseAndValidateConfig(s3 *S3Storage, opt Options) error {
 		s3.stConfig.checksumAlgorithm = opt.ChecksumAlgorithm
 	}
 
+	// by default symlink will be disabled
+	enableSymlinks := false
+	// Borrow enable-symlinks flag from attribute cache
+	if config.IsSet("attr_cache.enable-symlinks") {
+		err := config.UnmarshalKey("attr_cache.enable-symlinks", &enableSymlinks)
+		if err != nil {
+			enableSymlinks = false
+			log.Err("ParseAndReadDynamicConfig : Failed to unmarshal attr_cache.enable-symlinks")
+		}
+	}
+	s3.stConfig.disableSymlink = !enableSymlinks
+
 	// TODO: add more config options to customize AWS SDK behavior and import them here
 
 	return nil

--- a/component/s3storage/connection.go
+++ b/component/s3storage/connection.go
@@ -51,6 +51,7 @@ type Config struct {
 	enableChecksum            bool
 	checksumAlgorithm         types.ChecksumAlgorithm
 	usePathStyle              bool
+	disableSymlink            bool
 }
 
 // TODO: move s3AuthConfig to s3auth.go

--- a/component/s3storage/s3storage.go
+++ b/component/s3storage/s3storage.go
@@ -443,7 +443,7 @@ func (s3 *S3Storage) CreateLink(options internal.CreateLinkOptions) error {
 func (s3 *S3Storage) ReadLink(options internal.ReadLinkOptions) (string, error) {
 	if s3.stConfig.disableSymlink {
 		log.Err("S3Storage::ReadLink : %s - Symlink support not enabled", options.Name)
-		return "", syscall.ENOTSUP
+		return "", syscall.ENOENT
 	}
 	log.Trace("S3Storage::ReadLink : Read symlink %s", options.Name)
 

--- a/component/s3storage/s3storage.go
+++ b/component/s3storage/s3storage.go
@@ -425,6 +425,10 @@ func (s3 *S3Storage) CopyFromFile(options internal.CopyFromFileOptions) error {
 
 // Symlink operations
 func (s3 *S3Storage) CreateLink(options internal.CreateLinkOptions) error {
+	if s3.stConfig.disableSymlink {
+		log.Err("S3Storage::CreateLink : %s -> %s - Symlink support not enabled", options.Name, options.Target)
+		return syscall.ENOTSUP
+	}
 	log.Trace("S3Storage::CreateLink : Create symlink %s -> %s", options.Name, options.Target)
 	err := s3.storage.CreateLink(options.Name, options.Target, true)
 
@@ -437,6 +441,10 @@ func (s3 *S3Storage) CreateLink(options internal.CreateLinkOptions) error {
 }
 
 func (s3 *S3Storage) ReadLink(options internal.ReadLinkOptions) (string, error) {
+	if s3.stConfig.disableSymlink {
+		log.Err("S3Storage::ReadLink : %s - Symlink support not enabled", options.Name)
+		return "", syscall.ENOTSUP
+	}
 	log.Trace("S3Storage::ReadLink : Read symlink %s", options.Name)
 
 	data, err := s3.storage.ReadBuffer(options.Name, 0, 0, true)

--- a/component/s3storage/s3storage_test.go
+++ b/component/s3storage/s3storage_test.go
@@ -2391,6 +2391,10 @@ func (s *s3StorageTestSuite) TestGetAttrFile() {
 
 func (s *s3StorageTestSuite) TestGetAttrLink() {
 	defer s.cleanupTest()
+	// enable symlinks in config
+	config := generateConfigYaml(storageTestConfigurationParameters) + "attr_cache:\n  enable-symlinks: true\n"
+	s.setupTestHelper(config, s.bucket, true)
+	s.assert.False(s.s3Storage.stConfig.disableSymlink)
 	// Setup
 	target := generateFileName()
 	s.s3Storage.CreateFile(internal.CreateFileOptions{Name: target})

--- a/component/s3storage/s3storage_test.go
+++ b/component/s3storage/s3storage_test.go
@@ -2301,7 +2301,7 @@ func (s *s3StorageTestSuite) TestReadLinkDisabled() {
 
 	_, err := s.s3Storage.ReadLink(internal.ReadLinkOptions{Name: name})
 	s.assert.Error(err)
-	s.assert.EqualValues(syscall.ENOTSUP, err)
+	s.assert.EqualValues(syscall.ENOENT, err)
 }
 
 func (s *s3StorageTestSuite) TestGetAttrDir() {

--- a/component/s3storage/s3storage_test.go
+++ b/component/s3storage/s3storage_test.go
@@ -740,8 +740,8 @@ func (s *s3StorageTestSuite) TestStreamDirWindowsNameConvert() {
 		return
 	}
 	storageTestConfigurationParameters.RestrictedCharsWin = true
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	s.setupTestHelper(vdConfig, s.bucket, true)
+	config := generateConfigYaml(storageTestConfigurationParameters)
+	s.setupTestHelper(config, s.bucket, true)
 	defer s.cleanupTest()
 	// Setup
 	name := generateDirectoryName()
@@ -935,8 +935,8 @@ func (s *s3StorageTestSuite) TestCreateFileWindowsNameConvert() {
 		return
 	}
 	storageTestConfigurationParameters.RestrictedCharsWin = true
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	s.setupTestHelper(vdConfig, s.bucket, true)
+	config := generateConfigYaml(storageTestConfigurationParameters)
+	s.setupTestHelper(config, s.bucket, true)
 	defer s.cleanupTest()
 	// Setup
 	// Test with characters in folder and filepath
@@ -1133,8 +1133,8 @@ func (s *s3StorageTestSuite) TestCopyFromFileWindowsNameConvert() {
 		return
 	}
 	storageTestConfigurationParameters.RestrictedCharsWin = true
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	s.setupTestHelper(vdConfig, s.bucket, true)
+	config := generateConfigYaml(storageTestConfigurationParameters)
+	s.setupTestHelper(config, s.bucket, true)
 	defer s.cleanupTest()
 	// Setup
 	name := generateFileName()
@@ -1325,8 +1325,8 @@ func (s *s3StorageTestSuite) TestWriteFileMultipartUpload() {
 	defer s.cleanupTest()
 	storageTestConfigurationParameters.PartSizeMb = 5
 	storageTestConfigurationParameters.UploadCutoffMb = 5
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	s.setupTestHelper(vdConfig, s.bucket, true)
+	config := generateConfigYaml(storageTestConfigurationParameters)
+	s.setupTestHelper(config, s.bucket, true)
 
 	// Setup
 	name := generateFileName()
@@ -1371,8 +1371,8 @@ func (s *s3StorageTestSuite) TestWriteFileWindowsNameConvert() {
 		return
 	}
 	storageTestConfigurationParameters.RestrictedCharsWin = true
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	s.setupTestHelper(vdConfig, s.bucket, true)
+	config := generateConfigYaml(storageTestConfigurationParameters)
+	s.setupTestHelper(config, s.bucket, true)
 	defer s.cleanupTest()
 	// Setup
 	// Test with characters in folder and filepath
@@ -1436,8 +1436,8 @@ func (s *s3StorageTestSuite) TestTruncateSmallFileSmallerWindowsNameConvert() {
 		return
 	}
 	storageTestConfigurationParameters.RestrictedCharsWin = true
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	s.setupTestHelper(vdConfig, s.bucket, true)
+	config := generateConfigYaml(storageTestConfigurationParameters)
+	s.setupTestHelper(config, s.bucket, true)
 	defer s.cleanupTest()
 	// Setup
 	name := generateFileName()
@@ -1816,8 +1816,8 @@ func (s *s3StorageTestSuite) TestOverwriteBlocks() {
 	blockSizeMB := 5
 	storageTestConfigurationParameters.PartSizeMb = int64(blockSizeMB)
 	storageTestConfigurationParameters.UploadCutoffMb = 5
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	s.setupTestHelper(vdConfig, s.bucket, true)
+	config := generateConfigYaml(storageTestConfigurationParameters)
+	s.setupTestHelper(config, s.bucket, true)
 
 	// Setup
 	name := generateFileName()
@@ -1858,8 +1858,8 @@ func (s *s3StorageTestSuite) TestOverwriteAndAppendBlocks() {
 	blockSizeMB := 5
 	storageTestConfigurationParameters.PartSizeMb = int64(blockSizeMB)
 	storageTestConfigurationParameters.UploadCutoffMb = 5
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	s.setupTestHelper(vdConfig, s.bucket, true)
+	config := generateConfigYaml(storageTestConfigurationParameters)
+	s.setupTestHelper(config, s.bucket, true)
 
 	// Setup
 	name := generateFileName()
@@ -1898,8 +1898,8 @@ func (s *s3StorageTestSuite) TestAppendBlocks() {
 	blockSizeMB := 5
 	storageTestConfigurationParameters.PartSizeMb = int64(blockSizeMB)
 	storageTestConfigurationParameters.UploadCutoffMb = 5
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	s.setupTestHelper(vdConfig, s.bucket, true)
+	config := generateConfigYaml(storageTestConfigurationParameters)
+	s.setupTestHelper(config, s.bucket, true)
 
 	// Setup
 	name := generateFileName()
@@ -1938,8 +1938,8 @@ func (s *s3StorageTestSuite) TestOverwriteAndAppendBlocksLargeFile() {
 	blockSizeMB := 5
 	storageTestConfigurationParameters.PartSizeMb = int64(blockSizeMB)
 	storageTestConfigurationParameters.UploadCutoffMb = 5
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	s.setupTestHelper(vdConfig, s.bucket, true)
+	config := generateConfigYaml(storageTestConfigurationParameters)
+	s.setupTestHelper(config, s.bucket, true)
 
 	// Setup
 	name := generateFileName()
@@ -1978,8 +1978,8 @@ func (s *s3StorageTestSuite) TestOverwriteAndAppendBlocksMiddleLargeFile() {
 	blockSizeMB := 5
 	storageTestConfigurationParameters.PartSizeMb = int64(blockSizeMB)
 	storageTestConfigurationParameters.UploadCutoffMb = 5
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	s.setupTestHelper(vdConfig, s.bucket, true)
+	config := generateConfigYaml(storageTestConfigurationParameters)
+	s.setupTestHelper(config, s.bucket, true)
 
 	// Setup
 	name := generateFileName()
@@ -2155,8 +2155,8 @@ func (s *s3StorageTestSuite) TestRenameFileWindowsNameConvert() {
 		return
 	}
 	storageTestConfigurationParameters.RestrictedCharsWin = true
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	s.setupTestHelper(vdConfig, s.bucket, true)
+	config := generateConfigYaml(storageTestConfigurationParameters)
+	s.setupTestHelper(config, s.bucket, true)
 	defer s.cleanupTest()
 	// Setup
 	src := generateFileName()
@@ -2215,6 +2215,10 @@ func (s *s3StorageTestSuite) TestRenameFileError() {
 
 func (s *s3StorageTestSuite) TestCreateLink() {
 	defer s.cleanupTest()
+	// enable symlinks in config
+	config := generateConfigYaml(storageTestConfigurationParameters) + "attr_cache:\n  enable-symlinks: true\n"
+	s.setupTestHelper(config, s.bucket, true)
+	s.assert.False(s.s3Storage.stConfig.disableSymlink)
 	// Setup
 	target := generateFileName()
 	s.s3Storage.CreateFile(internal.CreateFileOptions{Name: target})
@@ -2237,8 +2241,31 @@ func (s *s3StorageTestSuite) TestCreateLink() {
 	s.assert.Equal(target, result)
 }
 
+func (s *s3StorageTestSuite) TestCreateLinkDisabled() {
+	defer s.cleanupTest()
+	// Setup
+	target := generateFileName()
+	s.s3Storage.CreateFile(internal.CreateFileOptions{Name: target})
+	name := generateFileName()
+	notSupported := syscall.ENOTSUP
+
+	err := s.s3Storage.CreateLink(internal.CreateLinkOptions{Name: name, Target: target})
+	s.assert.Error(err)
+	s.assert.EqualError(err, notSupported.Error())
+
+	// link should not exist
+	attr, err := s.s3Storage.GetAttr(internal.GetAttrOptions{Name: name})
+	s.assert.Nil(attr)
+	s.assert.Error(err)
+	s.assert.True(os.IsNotExist(err))
+}
+
 func (s *s3StorageTestSuite) TestReadLink() {
 	defer s.cleanupTest()
+	// enable symlinks in config
+	config := generateConfigYaml(storageTestConfigurationParameters) + "attr_cache:\n  enable-symlinks: true\n"
+	s.setupTestHelper(config, s.bucket, true)
+	s.assert.False(s.s3Storage.stConfig.disableSymlink)
 	// Setup
 	target := generateFileName()
 
@@ -2255,6 +2282,10 @@ func (s *s3StorageTestSuite) TestReadLink() {
 
 func (s *s3StorageTestSuite) TestReadLinkError() {
 	defer s.cleanupTest()
+	// enable symlinks in config
+	config := generateConfigYaml(storageTestConfigurationParameters) + "attr_cache:\n  enable-symlinks: true\n"
+	s.setupTestHelper(config, s.bucket, true)
+	s.assert.False(s.s3Storage.stConfig.disableSymlink)
 	// Setup
 	name := generateFileName()
 
@@ -2263,44 +2294,37 @@ func (s *s3StorageTestSuite) TestReadLinkError() {
 	s.assert.EqualValues(syscall.ENOENT, err)
 }
 
+func (s *s3StorageTestSuite) TestReadLinkDisabled() {
+	defer s.cleanupTest()
+	// Setup
+	name := generateFileName()
+
+	_, err := s.s3Storage.ReadLink(internal.ReadLinkOptions{Name: name})
+	s.assert.Error(err)
+	s.assert.EqualValues(syscall.ENOTSUP, err)
+}
+
 func (s *s3StorageTestSuite) TestGetAttrDir() {
 	defer s.cleanupTest()
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	configs := []string{"", vdConfig}
-	for _, c := range configs {
-		// This is a little janky but required since testify suite does not support running setup or clean up for subtests.
-		s.tearDownTestHelper(false)
-		s.setupTestHelper(c, s.bucket, true)
-		testName := ""
-		if c != "" {
-			testName = "virtual-directory"
-		}
-		s.Run(testName, func() {
-			// Setup
-			dirName := generateDirectoryName()
-			err := s.s3Storage.CreateDir(internal.CreateDirOptions{Name: dirName})
-			s.assert.NoError(err)
-			// since CreateDir doesn't do anything, let's put an object with that prefix
-			filename := dirName + "/" + generateFileName()
-			_, err = s.s3Storage.CreateFile(internal.CreateFileOptions{Name: filename})
-			s.assert.NoError(err)
-			// Now we should be able to see the directory
-			props, err := s.s3Storage.GetAttr(internal.GetAttrOptions{Name: dirName})
-			deleteError := s.s3Storage.DeleteFile(internal.DeleteFileOptions{Name: filename})
-			s.assert.NoError(err)
-			s.assert.NotNil(props)
-			s.assert.True(props.IsDir())
-			s.assert.NoError(deleteError)
-		})
-	}
+	// Setup
+	dirName := generateDirectoryName()
+	err := s.s3Storage.CreateDir(internal.CreateDirOptions{Name: dirName})
+	s.assert.NoError(err)
+	// since CreateDir doesn't do anything, let's put an object with that prefix
+	filename := dirName + "/" + generateFileName()
+	_, err = s.s3Storage.CreateFile(internal.CreateFileOptions{Name: filename})
+	s.assert.NoError(err)
+	// Now we should be able to see the directory
+	props, err := s.s3Storage.GetAttr(internal.GetAttrOptions{Name: dirName})
+	deleteError := s.s3Storage.DeleteFile(internal.DeleteFileOptions{Name: filename})
+	s.assert.NoError(err)
+	s.assert.NotNil(props)
+	s.assert.True(props.IsDir())
+	s.assert.NoError(deleteError)
 }
 
 func (s *s3StorageTestSuite) TestGetAttrVirtualDir() {
 	defer s.cleanupTest()
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	// This is a little janky but required since testify suite does not support running setup or clean up for subtests.
-	s.tearDownTestHelper(false)
-	s.setupTestHelper(vdConfig, s.bucket, true)
 	// Setup
 	dirName := generateFileName()
 	name := dirName + "/" + generateFileName()
@@ -2323,10 +2347,6 @@ func (s *s3StorageTestSuite) TestGetAttrVirtualDir() {
 
 func (s *s3StorageTestSuite) TestGetAttrVirtualDirSubDir() {
 	defer s.cleanupTest()
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	// This is a little janky but required since testify suite does not support running setup or clean up for subtests.
-	s.tearDownTestHelper(false)
-	s.setupTestHelper(vdConfig, s.bucket, true)
 	// Setup
 	dirName := generateFileName()
 	subDirName := dirName + "/" + generateFileName()
@@ -2357,154 +2377,89 @@ func (s *s3StorageTestSuite) TestGetAttrVirtualDirSubDir() {
 
 func (s *s3StorageTestSuite) TestGetAttrFile() {
 	defer s.cleanupTest()
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	configs := []string{"", vdConfig}
-	for _, c := range configs {
-		// This is a little janky but required since testify suite does not support running setup or clean up for subtests.
-		s.tearDownTestHelper(false)
-		s.setupTestHelper(c, s.bucket, true)
-		testName := ""
-		if c != "" {
-			testName = "virtual-directory"
-		}
-		s.Run(testName, func() {
-			// Setup
-			name := generateFileName()
-			_, err := s.s3Storage.CreateFile(internal.CreateFileOptions{Name: name})
-			s.assert.NoError(err)
+	// Setup
+	name := generateFileName()
+	_, err := s.s3Storage.CreateFile(internal.CreateFileOptions{Name: name})
+	s.assert.NoError(err)
 
-			props, err := s.s3Storage.GetAttr(internal.GetAttrOptions{Name: name})
-			s.assert.NoError(err)
-			s.assert.NotNil(props)
-			s.assert.False(props.IsDir())
-			s.assert.False(props.IsSymlink())
-		})
-	}
+	props, err := s.s3Storage.GetAttr(internal.GetAttrOptions{Name: name})
+	s.assert.NoError(err)
+	s.assert.NotNil(props)
+	s.assert.False(props.IsDir())
+	s.assert.False(props.IsSymlink())
 }
 
 func (s *s3StorageTestSuite) TestGetAttrLink() {
 	defer s.cleanupTest()
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	configs := []string{"", vdConfig}
-	for _, c := range configs {
-		// This is a little janky but required since testify suite does not support running setup or clean up for subtests.
-		s.tearDownTestHelper(false)
-		s.setupTestHelper(c, s.bucket, true)
-		testName := ""
-		if c != "" {
-			testName = "virtual-directory"
-		}
-		s.Run(testName, func() {
-			// Setup
-			target := generateFileName()
-			s.s3Storage.CreateFile(internal.CreateFileOptions{Name: target})
-			name := generateFileName()
-			s.s3Storage.CreateLink(internal.CreateLinkOptions{Name: name, Target: target})
+	// Setup
+	target := generateFileName()
+	s.s3Storage.CreateFile(internal.CreateFileOptions{Name: target})
+	name := generateFileName()
+	s.s3Storage.CreateLink(internal.CreateLinkOptions{Name: name, Target: target})
 
-			props, err := s.s3Storage.GetAttr(internal.GetAttrOptions{Name: name})
-			s.assert.NoError(err)
-			s.assert.NotNil(props)
-			s.assert.True(props.IsSymlink())
-			s.assert.NotEmpty(props.Metadata)
-			s.assert.Contains(props.Metadata, symlinkKey)
-			s.assert.EqualValues("true", props.Metadata[symlinkKey])
-		})
-	}
+	props, err := s.s3Storage.GetAttr(internal.GetAttrOptions{Name: name})
+	s.assert.NoError(err)
+	s.assert.NotNil(props)
+	s.assert.True(props.IsSymlink())
+	s.assert.NotEmpty(props.Metadata)
+	s.assert.Contains(props.Metadata, symlinkKey)
+	s.assert.EqualValues("true", props.Metadata[symlinkKey])
 }
 
 func (s *s3StorageTestSuite) TestGetAttrFileSize() {
 	defer s.cleanupTest()
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	configs := []string{"", vdConfig}
-	for _, c := range configs {
-		// This is a little janky but required since testify suite does not support running setup or clean up for subtests.
-		s.tearDownTestHelper(false)
-		s.setupTestHelper(c, s.bucket, true)
-		testName := ""
-		if c != "" {
-			testName = "virtual-directory"
-		}
-		s.Run(testName, func() {
-			// Setup
-			name := generateFileName()
-			h, err := s.s3Storage.CreateFile(internal.CreateFileOptions{Name: name})
-			s.assert.NoError(err)
-			testData := "test data"
-			data := []byte(testData)
-			_, err = s.s3Storage.WriteFile(internal.WriteFileOptions{Handle: h, Offset: 0, Data: data})
-			s.assert.NoError(err)
+	// Setup
+	name := generateFileName()
+	h, err := s.s3Storage.CreateFile(internal.CreateFileOptions{Name: name})
+	s.assert.NoError(err)
+	testData := "test data"
+	data := []byte(testData)
+	_, err = s.s3Storage.WriteFile(internal.WriteFileOptions{Handle: h, Offset: 0, Data: data})
+	s.assert.NoError(err)
 
-			props, err := s.s3Storage.GetAttr(internal.GetAttrOptions{Name: name})
-			s.assert.NoError(err)
-			s.assert.NotNil(props)
-			s.assert.False(props.IsDir())
-			s.assert.False(props.IsSymlink())
-			s.assert.EqualValues(len(testData), props.Size)
-		})
-	}
+	props, err := s.s3Storage.GetAttr(internal.GetAttrOptions{Name: name})
+	s.assert.NoError(err)
+	s.assert.NotNil(props)
+	s.assert.False(props.IsDir())
+	s.assert.False(props.IsSymlink())
+	s.assert.EqualValues(len(testData), props.Size)
 }
 
 func (s *s3StorageTestSuite) TestGetAttrFileTime() {
 	defer s.cleanupTest()
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	configs := []string{"", vdConfig}
-	for _, c := range configs {
-		// This is a little janky but required since testify suite does not support running setup or clean up for subtests.
-		s.tearDownTestHelper(false)
-		s.setupTestHelper(c, s.bucket, true)
-		testName := ""
-		if c != "" {
-			testName = "virtual-directory"
-		}
-		s.Run(testName, func() {
-			// Setup
-			name := generateFileName()
-			h, err := s.s3Storage.CreateFile(internal.CreateFileOptions{Name: name})
-			s.assert.NoError(err)
-			testData := "test data"
-			data := []byte(testData)
-			_, err = s.s3Storage.WriteFile(internal.WriteFileOptions{Handle: h, Offset: 0, Data: data})
-			s.assert.NoError(err)
+	// Setup
+	name := generateFileName()
+	h, err := s.s3Storage.CreateFile(internal.CreateFileOptions{Name: name})
+	s.assert.NoError(err)
+	testData := "test data"
+	data := []byte(testData)
+	_, err = s.s3Storage.WriteFile(internal.WriteFileOptions{Handle: h, Offset: 0, Data: data})
+	s.assert.NoError(err)
 
-			before, err := s.s3Storage.GetAttr(internal.GetAttrOptions{Name: name})
-			s.assert.NoError(err)
-			s.assert.NotNil(before.Mtime)
+	before, err := s.s3Storage.GetAttr(internal.GetAttrOptions{Name: name})
+	s.assert.NoError(err)
+	s.assert.NotNil(before.Mtime)
 
-			time.Sleep(time.Second * 3) // Wait 3 seconds and then modify the file again
+	time.Sleep(time.Second * 3) // Wait 3 seconds and then modify the file again
 
-			_, err = s.s3Storage.WriteFile(internal.WriteFileOptions{Handle: h, Offset: 0, Data: data})
-			s.assert.NoError(err)
+	_, err = s.s3Storage.WriteFile(internal.WriteFileOptions{Handle: h, Offset: 0, Data: data})
+	s.assert.NoError(err)
 
-			after, err := s.s3Storage.GetAttr(internal.GetAttrOptions{Name: name})
-			s.assert.NoError(err)
-			s.assert.NotNil(after.Mtime)
+	after, err := s.s3Storage.GetAttr(internal.GetAttrOptions{Name: name})
+	s.assert.NoError(err)
+	s.assert.NotNil(after.Mtime)
 
-			s.assert.True(after.Mtime.After(before.Mtime))
-		})
-	}
+	s.assert.True(after.Mtime.After(before.Mtime))
 }
 
 func (s *s3StorageTestSuite) TestGetAttrError() {
 	defer s.cleanupTest()
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	configs := []string{"", vdConfig}
-	for _, c := range configs {
-		// This is a little janky but required since testify suite does not support running setup or clean up for subtests.
-		s.tearDownTestHelper(false)
-		s.setupTestHelper(c, s.bucket, true)
-		testName := ""
-		if c != "" {
-			testName = "virtual-directory"
-		}
-		s.Run(testName, func() {
-			// Setup
-			name := generateFileName()
+	// Setup
+	name := generateFileName()
 
-			_, err := s.s3Storage.GetAttr(internal.GetAttrOptions{Name: name})
-			s.assert.Error(err)
-			s.assert.EqualValues(syscall.ENOENT, err)
-		})
-	}
+	_, err := s.s3Storage.GetAttr(internal.GetAttrOptions{Name: name})
+	s.assert.Error(err)
+	s.assert.EqualValues(syscall.ENOENT, err)
 }
 
 // uploads data from a temp file and downloads the full object and tests the correct data was received
@@ -2647,8 +2602,8 @@ func (s *s3StorageTestSuite) TestGetFileBlockOffsetsSmallFile() {
 	defer s.cleanupTest()
 	blockSizeMB := 5
 	storageTestConfigurationParameters.PartSizeMb = int64(blockSizeMB)
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	s.setupTestHelper(vdConfig, s.bucket, true)
+	config := generateConfigYaml(storageTestConfigurationParameters)
+	s.setupTestHelper(config, s.bucket, true)
 
 	// Setup
 	name := generateFileName()
@@ -2670,8 +2625,8 @@ func (s *s3StorageTestSuite) TestGetFileBlockOffsetsChunkedFile() {
 	defer s.cleanupTest()
 	blockSizeMB := 5
 	storageTestConfigurationParameters.PartSizeMb = int64(blockSizeMB)
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	s.setupTestHelper(vdConfig, s.bucket, true)
+	config := generateConfigYaml(storageTestConfigurationParameters)
+	s.setupTestHelper(config, s.bucket, true)
 
 	// Setup
 	name := generateFileName()
@@ -2698,8 +2653,8 @@ func (s *s3StorageTestSuite) TestGetFileBlockOffsetsError() {
 	defer s.cleanupTest()
 	blockSizeMB := 5
 	storageTestConfigurationParameters.PartSizeMb = int64(blockSizeMB)
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	s.setupTestHelper(vdConfig, s.bucket, true)
+	config := generateConfigYaml(storageTestConfigurationParameters)
+	s.setupTestHelper(config, s.bucket, true)
 	// Setup
 	name := generateFileName()
 
@@ -2712,8 +2667,8 @@ func (s *s3StorageTestSuite) TestFlushFileEmptyFile() {
 	defer s.cleanupTest()
 	blockSizeMB := 5
 	storageTestConfigurationParameters.PartSizeMb = int64(blockSizeMB)
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	s.setupTestHelper(vdConfig, s.bucket, true)
+	config := generateConfigYaml(storageTestConfigurationParameters)
+	s.setupTestHelper(config, s.bucket, true)
 
 	// Setup
 	name := generateFileName()
@@ -2735,8 +2690,8 @@ func (s *s3StorageTestSuite) TestFlushFileChunkedFile() {
 	defer s.cleanupTest()
 	blockSizeMB := 5
 	storageTestConfigurationParameters.PartSizeMb = int64(blockSizeMB)
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	s.setupTestHelper(vdConfig, s.bucket, true)
+	config := generateConfigYaml(storageTestConfigurationParameters)
+	s.setupTestHelper(config, s.bucket, true)
 
 	// Setup
 	name := generateFileName()
@@ -2765,8 +2720,8 @@ func (s *s3StorageTestSuite) TestFlushFileUpdateChunkedFile() {
 	blockSizeMB := 5
 	blockSizeBytes := blockSizeMB * common.MbToBytes
 	storageTestConfigurationParameters.PartSizeMb = int64(blockSizeMB)
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	s.setupTestHelper(vdConfig, s.bucket, true)
+	config := generateConfigYaml(storageTestConfigurationParameters)
+	s.setupTestHelper(config, s.bucket, true)
 
 	// Setup
 	name := generateFileName()
@@ -2804,8 +2759,8 @@ func (s *s3StorageTestSuite) TestFlushFileTruncateUpdateChunkedFile() {
 	blockSizeMB := 5
 	blockSizeBytes := blockSizeMB * common.MbToBytes
 	storageTestConfigurationParameters.PartSizeMb = int64(blockSizeMB)
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	s.setupTestHelper(vdConfig, s.bucket, true)
+	config := generateConfigYaml(storageTestConfigurationParameters)
+	s.setupTestHelper(config, s.bucket, true)
 
 	// Setup
 	name := generateFileName()
@@ -2843,8 +2798,8 @@ func (s *s3StorageTestSuite) TestFlushFileAppendBlocksEmptyFile() {
 	blockSizeMB := 5
 	blockSizeBytes := blockSizeMB * common.MbToBytes
 	storageTestConfigurationParameters.PartSizeMb = int64(blockSizeMB)
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	s.setupTestHelper(vdConfig, s.bucket, true)
+	config := generateConfigYaml(storageTestConfigurationParameters)
+	s.setupTestHelper(config, s.bucket, true)
 
 	// Setup
 	name := generateFileName()
@@ -2902,8 +2857,8 @@ func (s *s3StorageTestSuite) TestFlushFileAppendBlocksChunkedFile() {
 	blockSizeMB := 5
 	blockSizeBytes := blockSizeMB * common.MbToBytes
 	storageTestConfigurationParameters.PartSizeMb = int64(blockSizeMB)
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	s.setupTestHelper(vdConfig, s.bucket, true)
+	config := generateConfigYaml(storageTestConfigurationParameters)
+	s.setupTestHelper(config, s.bucket, true)
 
 	// Setup
 	name := generateFileName()
@@ -2968,8 +2923,8 @@ func (s *s3StorageTestSuite) TestFlushFileTruncateBlocksEmptyFile() {
 	blockSizeMB := 5
 	blockSizeBytes := blockSizeMB * common.MbToBytes
 	storageTestConfigurationParameters.PartSizeMb = int64(blockSizeMB)
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	s.setupTestHelper(vdConfig, s.bucket, true)
+	config := generateConfigYaml(storageTestConfigurationParameters)
+	s.setupTestHelper(config, s.bucket, true)
 
 	// Setup
 	name := generateFileName()
@@ -3020,8 +2975,8 @@ func (s *s3StorageTestSuite) TestFlushFileTruncateBlocksChunkedFile() {
 	blockSizeMB := 5
 	blockSizeBytes := blockSizeMB * common.MbToBytes
 	storageTestConfigurationParameters.PartSizeMb = int64(blockSizeMB)
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	s.setupTestHelper(vdConfig, s.bucket, true)
+	config := generateConfigYaml(storageTestConfigurationParameters)
+	s.setupTestHelper(config, s.bucket, true)
 
 	// Setup
 	name := generateFileName()
@@ -3079,8 +3034,8 @@ func (s *s3StorageTestSuite) TestFlushFileAppendAndTruncateBlocksEmptyFile() {
 	blockSizeMB := 7
 	blockSizeBytes := blockSizeMB * common.MbToBytes
 	storageTestConfigurationParameters.PartSizeMb = int64(blockSizeMB)
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	s.setupTestHelper(vdConfig, s.bucket, true)
+	config := generateConfigYaml(storageTestConfigurationParameters)
+	s.setupTestHelper(config, s.bucket, true)
 
 	// Setup
 	name := generateFileName()
@@ -3135,8 +3090,8 @@ func (s *s3StorageTestSuite) TestFlushFileAppendAndTruncateBlocksChunkedFile() {
 	blockSizeMB := 7
 	blockSizeBytes := blockSizeMB * common.MbToBytes
 	storageTestConfigurationParameters.PartSizeMb = int64(blockSizeMB)
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
-	s.setupTestHelper(vdConfig, s.bucket, true)
+	config := generateConfigYaml(storageTestConfigurationParameters)
+	s.setupTestHelper(config, s.bucket, true)
 
 	// Setup
 	name := generateFileName()
@@ -3230,9 +3185,9 @@ func (s *s3StorageTestSuite) UtilityFunctionTestTruncateFileToSmaller(size int, 
 	// Setup
 	storageTestConfigurationParameters.PartSizeMb = 5
 	storageTestConfigurationParameters.UploadCutoffMb = 5
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
+	config := generateConfigYaml(storageTestConfigurationParameters)
 	s.tearDownTestHelper(false)
-	s.setupTestHelper(vdConfig, s.bucket, true)
+	s.setupTestHelper(config, s.bucket, true)
 	// // This is a little janky but required since testify suite does not support running setup or clean up for subtests.
 
 	name := generateFileName()
@@ -3264,9 +3219,9 @@ func (s *s3StorageTestSuite) UtilityFunctionTruncateFileToLarger(size int, trunc
 	// Setup
 	storageTestConfigurationParameters.PartSizeMb = 5
 	storageTestConfigurationParameters.UploadCutoffMb = 5
-	vdConfig := generateConfigYaml(storageTestConfigurationParameters)
+	config := generateConfigYaml(storageTestConfigurationParameters)
 	s.tearDownTestHelper(false)
-	s.setupTestHelper(vdConfig, s.bucket, true)
+	s.setupTestHelper(config, s.bucket, true)
 
 	name := generateFileName()
 	h, err := s.s3Storage.CreateFile(internal.CreateFileOptions{Name: name})

--- a/component/s3storage/s3wrappers.go
+++ b/component/s3storage/s3wrappers.go
@@ -494,7 +494,7 @@ func (cl *Client) getFile(name string) (string, bool) {
 	isSymLink := false
 
 	//todo: write a test the catches the out of bounds issue.
-	if strings.HasSuffix(name, symlinkStr) {
+	if !cl.Config.disableSymlink && strings.HasSuffix(name, symlinkStr) {
 		isSymLink = true
 		name = name[:len(name)-len(symlinkStr)]
 	}

--- a/component/s3storage/s3wrappers_test.go
+++ b/component/s3storage/s3wrappers_test.go
@@ -103,7 +103,24 @@ func (s *s3wrapperTestSuite) TestGetFileSymlink() {
 	s.assert.Equal(expectedName, newName)
 }
 
+func (s *s3wrapperTestSuite) TestGetFileSymlinkDisabled() {
+	s.client.Config.disableSymlink = true
+	fileName := "test" + symlinkStr
+	newName, isSymLink := s.client.getFile(fileName)
+	s.assert.False(isSymLink)
+	s.assert.Equal(fileName, newName)
+}
+
 func (s *s3wrapperTestSuite) TestGetKeySymlink() {
+	fileName := "test"
+	expectedName := "test" + symlinkStr
+	isSymLink := true
+	newName := s.client.getKey(fileName, isSymLink)
+	s.assert.Equal(expectedName, newName)
+}
+
+func (s *s3wrapperTestSuite) TestGetKeySymlinkDisabled() {
+	s.client.Config.disableSymlink = true
 	fileName := "test"
 	expectedName := "test" + symlinkStr
 	isSymLink := true

--- a/doc/cloudfuse_mount.md
+++ b/doc/cloudfuse_mount.md
@@ -47,7 +47,7 @@ cloudfuse mount [path] [flags]
       --negative-timeout uint32           The negative entry timeout in seconds.
       --network-share                     Run as a network share. Only supported on Windows.
       --no-cache-dirs                     whether or not empty directories should be cached
-      --no-symlinks                       whether or not symlinks should be supported
+      --enable-symlinks                       whether or not symlinks should be supported
       --passphrase string                 Key to decrypt config file. Can also be specified by env-variable CLOUDFUSE_SECURE_CONFIG_PASSPHRASE.
                                           Key length shall be 16 (AES-128), 24 (AES-192), or 32 (AES-256) bytes in length.
       --read-only                         Mount the system in read only mode. Default value false.

--- a/doc/cloudfuse_mount.md
+++ b/doc/cloudfuse_mount.md
@@ -47,7 +47,7 @@ cloudfuse mount [path] [flags]
       --negative-timeout uint32           The negative entry timeout in seconds.
       --network-share                     Run as a network share. Only supported on Windows.
       --no-cache-dirs                     whether or not empty directories should be cached
-      --enable-symlinks                       whether or not symlinks should be supported
+      --enable-symlinks                   whether or not symlinks should be supported
       --passphrase string                 Key to decrypt config file. Can also be specified by env-variable CLOUDFUSE_SECURE_CONFIG_PASSPHRASE.
                                           Key length shall be 16 (AES-128), 24 (AES-192), or 32 (AES-256) bytes in length.
       --read-only                         Mount the system in read only mode. Default value false.

--- a/doc/cloudfuse_mount_all.md
+++ b/doc/cloudfuse_mount_all.md
@@ -52,7 +52,7 @@ cloudfuse mount all [path] <flags> [flags]
       --negative-timeout uint32           The negative entry timeout in seconds.
       --network-share                     Run as a network share. Only supported on Windows.
       --no-cache-dirs                     whether or not empty directories should be cached
-      --no-symlinks                       whether or not symlinks should be supported
+      --enable-symlinks                       whether or not symlinks should be supported
       --passphrase string                 Key to decrypt config file. Can also be specified by env-variable CLOUDFUSE_SECURE_CONFIG_PASSPHRASE.
                                           Key length shall be 16 (AES-128), 24 (AES-192), or 32 (AES-256) bytes in length.
       --read-only                         Mount the system in read only mode. Default value false.

--- a/doc/cloudfuse_mount_list.md
+++ b/doc/cloudfuse_mount_list.md
@@ -58,7 +58,7 @@ cloudfuse mount list
       --negative-timeout uint32           The negative entry timeout in seconds.
       --network-share                     Run as a network share. Only supported on Windows.
       --no-cache-dirs                     whether or not empty directories should be cached
-      --no-symlinks                       whether or not symlinks should be supported
+      --enable-symlinks                       whether or not symlinks should be supported
       --passphrase string                 Key to decrypt config file. Can also be specified by env-variable CLOUDFUSE_SECURE_CONFIG_PASSPHRASE.
                                           Key length shall be 16 (AES-128), 24 (AES-192), or 32 (AES-256) bytes in length.
       --read-only                         Mount the system in read only mode. Default value false.

--- a/gui/common_qt_functions.py
+++ b/gui/common_qt_functions.py
@@ -39,13 +39,13 @@ class defaultSettingsManager():
         super().__init__()
         self.settings = QSettings(QSettings.Format.IniFormat,QSettings.Scope.UserScope,"CloudFUSE", "settings")
         self.setAllDefaultSettings()
-        
-        
+
+
     def setAllDefaultSettings(self):
         self.setS3Settings()
         self.setAzureSettings()
         self.setComponentSettings()
-        
+
     def setS3Settings(self):
         # REFER TO ~/setup/baseConfig.yaml for explanations of what these settings are
         self.settings.setValue('s3storage',{
@@ -66,7 +66,7 @@ class defaultSettingsManager():
             'checksum-algorithm': 'SHA1',
             'usePathStyle': False,
         })
-    
+
     def setAzureSettings(self):
         # REFER TO ~/setup/baseConfig.yaml for explanations of what these settings are
         self.settings.setValue('azstorage',{
@@ -109,12 +109,12 @@ class defaultSettingsManager():
             'telemetry': '',
             'honour-acl': False
         })
-    
+
     def setComponentSettings(self):
         # REFER TO ~/setup/baseConfig.yaml for explanations of what these settings are
-        
+
         self.settings.setValue('foreground',False)
-        
+
         # Common
         self.settings.setValue('allow-other',False)
         self.settings.setValue('read-only',False)
@@ -130,10 +130,10 @@ class defaultSettingsManager():
         self.settings.setValue('libfuse',{
             'default-permission' : 0o777,
             'attribute-expiration-sec': 120,
-            'entry-expiration-sec' : 120,   
+            'entry-expiration-sec' : 120,
             'negative-entry-expiration-sec' : 120,
             'fuse-trace' : False,
-            'extension' : '', 
+            'extension' : '',
             'disable-writeback-cache' : False,
             'ignore-open-flags' : True,
             'max-fuse-threads': 128,
@@ -178,7 +178,7 @@ class defaultSettingsManager():
         self.settings.setValue('attr_cache',{
             'timeout-sec': 120,
             'no-cache-on-list': False,
-            'no-symlinks': True,
+            'enable-symlinks': False,
             # the following attr_cache settings are not exposed in the GUI
             'max-files': 5000000,
             'no-cache-dirs': False
@@ -186,7 +186,7 @@ class defaultSettingsManager():
         self.settings.setValue('loopbackfs',{
             'path': ''
         })
-        
+
         self.settings.setValue('mountall',{
             'container-allowlist': [],
             'container-denylist': []
@@ -200,25 +200,25 @@ class defaultSettingsManager():
         })
         self.settings.setValue('logging',{
             'type' : 'syslog',
-            'level' : 'log_err',        
-            'file-path' : '$HOME/.cloudfuse/cloudfuse.log',         
-            'max-file-size-mb' : 512,                                       
-            'file-count' : 10 ,                                             
-            'track-time' : False                                            
+            'level' : 'log_err',
+            'file-path' : '$HOME/.cloudfuse/cloudfuse.log',
+            'max-file-size-mb' : 512,
+            'file-count' : 10 ,
+            'track-time' : False
             })
-    
+
 class widgetCustomFunctions(QWidget):
     def __init__(self):
         super().__init__()
-        
+
     def exitWindow(self):
         self.close()
-        
+
     def exitWindowCleanup(self):
     # Save this specific window's size and position
         self.myWindow.setValue("window size", self.size())
         self.myWindow.setValue("window position", self.pos())
-            
+
     def popupDoubleCheckReset(self):
         checkMsg = QtWidgets.QMessageBox()
         checkMsg.setWindowTitle("Are you sure?")
@@ -227,9 +227,9 @@ class widgetCustomFunctions(QWidget):
         checkMsg.setDefaultButton(QtWidgets.QMessageBox.Cancel)
         choice = checkMsg.exec()
         return choice
-            
+
     # Overrides the closeEvent function from parent class to enable this custom behavior
-    # TODO: Nice to have - keep track of changes to user makes and only trigger the 'are you sure?' message 
+    # TODO: Nice to have - keep track of changes to user makes and only trigger the 'are you sure?' message
     #   when changes have been made
     def closeEvent(self, event):
         msg = QtWidgets.QMessageBox()
@@ -239,7 +239,7 @@ class widgetCustomFunctions(QWidget):
         msg.setStandardButtons(QtWidgets.QMessageBox.Discard | QtWidgets.QMessageBox.Cancel | QtWidgets.QMessageBox.Save)
         msg.setDefaultButton(QtWidgets.QMessageBox.Cancel)
         ret = msg.exec()
-        
+
         if ret == QtWidgets.QMessageBox.Discard:
             self.exitWindowCleanup()
             event.accept()
@@ -252,14 +252,14 @@ class widgetCustomFunctions(QWidget):
                 event.accept()
             else:
                 event.ignore()
-        
+
     def constructDictForConfig(self):
         optionKeys = self.settings.allKeys()
         configDict = {}
         for key in optionKeys:
             configDict[key] = self.settings.value(key)
         return configDict
-    
+
     def updateSettingsFromUIChoices(self):
         # Each individual widget will need to override this function
         pass
@@ -288,7 +288,7 @@ class widgetCustomFunctions(QWidget):
             msg.setInformativeText("Writing the config file failed. Check file permissions and try again.")
             msg.exec()
             return False
-            
+
     def getConfigs(self,useDefault=False):
         workingDir = self.getWorkingDir()
         if useDefault:
@@ -309,13 +309,13 @@ class widgetCustomFunctions(QWidget):
                     configs = yaml.safe_load(file)
                     if configs is None:
                        # The configs file exists, but is empty, use default settings
-                       configs = self.getConfigs(True) 
+                       configs = self.getConfigs(True)
             except:
                 # Could not open or config file does not exist, use default settings
                 configs = self.getConfigs(True)
         return configs
-    
-    
+
+
     def initWindowSizePos(self):
         try:
             self.resize(self.myWindow.value("window size"))
@@ -325,9 +325,9 @@ class widgetCustomFunctions(QWidget):
             myWindowGeometry = self.frameGeometry()
             myWindowGeometry.moveCenter(desktopCenter)
             self.move(myWindowGeometry.topLeft())
-        
+
     # defaultSettingsManager has set the settings to all default, now the code needs to pull in
-    #   all the changes from the config file the user provides. This may not include all the 
+    #   all the changes from the config file the user provides. This may not include all the
     #   settings defined in defaultSettingManager.
     def initSettingsFromConfig(self):
         dictForConfigs = self.getConfigs()
@@ -346,7 +346,7 @@ class widgetCustomFunctions(QWidget):
             else:
                 self.settings.setValue(option,dictForConfigs[option])
 
-    # Check for a true/false setting and set the checkbox state as appropriate. 
+    # Check for a true/false setting and set the checkbox state as appropriate.
     #   Note, Checked/UnChecked are NOT True/False data types, hence the need to check what the values are.
     #   The default values for True/False settings are False, which is why Unchecked is the default state if the value doesn't equate to True.
     #   Explicitly check for True for clarity
@@ -358,18 +358,18 @@ class widgetCustomFunctions(QWidget):
 
     def updateMultiUser(self):
         self.settings.setValue('allow-other',self.checkBox_multiUser.isChecked())
-        
+
     def updateNonEmtpyDir(self):
-        self.settings.setValue('nonempty',self.checkBox_nonEmptyDir.isChecked())        
-    
+        self.settings.setValue('nonempty',self.checkBox_nonEmptyDir.isChecked())
+
     def updateDaemonForeground(self):
         self.settings.setValue('foreground',self.checkBox_daemonForeground.isChecked())
-    
+
     def updateReadOnly(self):
         self.settings.setValue('read-only',self.checkBox_readOnly.isChecked())
-    
-    # Update Libfuse re-writes everything in the Libfuse because of how setting.setValue works - 
-    #   it will not append, so the code makes a copy of the dictionary and updates the sub-keys. 
+
+    # Update Libfuse re-writes everything in the Libfuse because of how setting.setValue works -
+    #   it will not append, so the code makes a copy of the dictionary and updates the sub-keys.
     #   When the user updates the sub-option through the GUI, it will trigger Libfuse to update;
     #   it's written this way to save on lines of code.
     def updateLibfuse(self):
@@ -396,12 +396,12 @@ class widgetCustomFunctions(QWidget):
         stream['buffer-size-mb'] = self.spinBox_streaming_buffSize.value()
         stream['max-buffers'] = self.spinBox_streaming_maxBuff.value()
         self.settings.setValue('stream',stream)
-     
+
     def updateFileCachePath(self):
         filePath = self.settings.value('file_cache')
         filePath['path'] = self.lineEdit_fileCache_path.text()
         self.settings.setValue('file_cache',filePath)
-        
+
     def updateOptionalFileCache(self):
         fileCache = self.settings.value('file_cache')
         fileCache['allow-non-empty-temp'] = self.checkBox_fileCache_allowNonEmptyTmp.isChecked()
@@ -410,13 +410,13 @@ class widgetCustomFunctions(QWidget):
         fileCache['cleanup-on-start'] = self.checkBox_fileCache_cleanupStart.isChecked()
         fileCache['offload-io'] = self.checkBox_fileCache_offloadIO.isChecked()
         fileCache['sync-to-flush'] = self.checkBox_fileCache_syncToFlush.isChecked()
-        
+
         fileCache['timeout-sec'] = self.spinBox_fileCache_evictionTimeout.value()
         fileCache['max-eviction'] = self.spinBox_fileCache_maxEviction.value()
         fileCache['max-size-mb'] = self.spinBox_fileCache_maxCacheSize.value()
         fileCache['high-threshold'] = self.spinBox_fileCache_evictMaxThresh.value()
         fileCache['low-threshold'] = self.spinBox_fileCache_evictMinThresh.value()
         fileCache['refresh-sec'] = self.spinBox_fileCache_refreshSec.value()
-        
+
         fileCache['policy'] = file_cache_eviction_choices[self.dropDown_fileCache_evictionPolicy.currentIndex()]
         self.settings.setValue('file_cache',fileCache)

--- a/sampleFileCacheConfigAzure.yaml
+++ b/sampleFileCacheConfigAzure.yaml
@@ -20,7 +20,6 @@ file_cache:
 
 attr_cache:
   timeout-sec: 7200
-  no-symlinks: true
 
 azstorage:
   type: block

--- a/sampleFileCacheConfigS3.yaml
+++ b/sampleFileCacheConfigS3.yaml
@@ -20,7 +20,6 @@ file_cache:
 
 attr_cache:
   timeout-sec: 7200
-  no-symlinks: true
 
 s3storage:
   bucket-name: <ACCOUNT_NAME>

--- a/sampleFileCacheWithSASConfigAzure.yaml
+++ b/sampleFileCacheWithSASConfigAzure.yaml
@@ -20,7 +20,6 @@ file_cache:
 
 attr_cache:
   timeout-sec: 7200
-  no-symlinks: true
 
 azstorage:
   type: block
@@ -29,4 +28,3 @@ azstorage:
   endpoint: https://<ACCOUNT_NAME>.blob.core.windows.net
   mode: sas
   container: <CONTAINER_NAME>
- 

--- a/sampleStreamingConfigAzure.yaml
+++ b/sampleStreamingConfigAzure.yaml
@@ -22,7 +22,6 @@ stream:
 
 attr_cache:
   timeout-sec: 7200
-  no-symlinks: true
 
 azstorage:
   type: block

--- a/sampleStreamingConfigS3.yaml
+++ b/sampleStreamingConfigS3.yaml
@@ -22,7 +22,6 @@ stream:
 
 attr_cache:
   timeout-sec: 7200
-  no-symlinks: true
 
 s3storage:
   bucket-name: <ACCOUNT_NAME>

--- a/setup/baseConfig.yaml
+++ b/setup/baseConfig.yaml
@@ -1,24 +1,24 @@
-# MUST READ : 
-#   If you are creating a cloudfuse config file using this kindly take care of below points 
-#   1. All boolean configs (true|false config) (except ignore-open-flags, virtual-directory, sync-to-flush) are set to 'false' by default. 
+# MUST READ :
+#   If you are creating a cloudfuse config file using this kindly take care of below points
+#   1. All boolean configs (true|false config) (except ignore-open-flags, virtual-directory, sync-to-flush) are set to 'false' by default.
 #      No need to mention them in your config file unless you are setting them to true.
 #   2. 'loopbackfs' is purely for testing and shall not be used in production configuration.
 #   3. 'stream' and 'file_cache' can not co-exist and config file shall have only one of them based on your use case.
-#   4. By default log level is set to 'log_warning' level and are redirected to syslog. 
+#   4. By default log level is set to 'log_warning' level and are redirected to syslog.
 #      Either use 'base' logging or syslog filters to redirect logs to separate file.
-#      To install syslog filter follow below steps:        
+#      To install syslog filter follow below steps:
 #         sudo cp setup/11-cloudfuse.conf /etc/rsyslog.d/
 #         sudo cp setup/cloudfuse-logrotate /etc/logrotate.d/
 #         sudo service rsyslog restart
-#   5. For non-HNS (flat namespace) accounts blobfuse expects special directory marker files to 
-#      exists in container to identify a directory. 
+#   5. For non-HNS (flat namespace) accounts blobfuse expects special directory marker files to
+#      exists in container to identify a directory.
 #      If these files do not exist in container, then 'virtual-directory: true' in 'azstorage' section is required
 #   6. By default 'writeback-cache' is enabled for libfuse3 and this may result in append/write operations to fail.
 #      Either you can disable 'writeback-cache', which might hurt the performance
 #      or you can configure cloudfuse to ignore open flags given by user and make it work with ''writeback-cache'.
 #      'libfuse' section below has both the configurations.
-#   7. If are you using 'allow-other: true' config then make sure user_allow_other is enabled in /etc/fuse.conf file as 
-#      well otherwise mount will fail. By default /etc/fuse.conf will have this option disabled we just need to 
+#   7. If are you using 'allow-other: true' config then make sure user_allow_other is enabled in /etc/fuse.conf file as
+#      well otherwise mount will fail. By default /etc/fuse.conf will have this option disabled we just need to
 #      enable it and save the file.
 #   8. If data in your storage account (non-HNS) is created using Blobfuse or AzCopy then there are marker files present
 #      in your container to mark a directory. In such cases you can optimize your listing by setting 'virtual-directory'
@@ -72,10 +72,10 @@ libfuse:
   max-fuse-threads: <number of threads allowed at libfuse layer for highly parallel operations, Default is 128>
   direct-io: true|false <enable to bypass the kernel cache>
   network-share: true|false <runs as a network share. may improve performance when latency to cloud is high. only supported on Windows.
- 
+
   # Streaming configuration
 stream:
-  # If block-size-mb, max-buffers or buffer-size-mb are 0, the stream component will not cache blocks. 
+  # If block-size-mb, max-buffers or buffer-size-mb are 0, the stream component will not cache blocks.
   block-size-mb: <for read only mode size of each block to be cached in memory while streaming (in MB). For read/write size of newly created blocks. Default - 0 MB>
   max-buffers: <total number of buffers to store blocks in. Default - 0>
   buffer-size-mb: <size for each buffer. Default - 0 MB>
@@ -89,16 +89,16 @@ block_cache:
   disk-size-mb: <maximum disk cache size allowed. Default - 4192 MB>
   disk-timeout-sec: <default disk cache eviction timeout (in sec). Default - 120 sec>
   prefetch: <number of blocks to be prefetched in serial read case. Min - 11>
-  parallelism: <number of parallel threads downloading the data and writing to disk cache. Default - 128> 
-  prefetch-on-open: true|false <prefetch blocks on open. This shall be used only when user application is going to read file from offset 0> 
+  parallelism: <number of parallel threads downloading the data and writing to disk cache. Default - 128>
+  prefetch-on-open: true|false <prefetch blocks on open. This shall be used only when user application is going to read file from offset 0>
 
 # Disk cache related configuration
 file_cache:
   # Required
   path: <path to local disk cache>
 
-  # Optional 
-  policy: lru|lfu <eviction policy to be engaged for cache eviction. lru = least recently used file to be deleted, lfu = least frequently used file to be deleted. Default - lru> 
+  # Optional
+  policy: lru|lfu <eviction policy to be engaged for cache eviction. lru = least recently used file to be deleted, lfu = least frequently used file to be deleted. Default - lru>
   timeout-sec: <default cache eviction timeout (in sec). Default - 120 sec>
   max-eviction: <number of files that can be evicted at once. Default - 5000>
   max-size-mb: <maximum cache size allowed. Default - 0 (unlimited)>
@@ -113,15 +113,15 @@ file_cache:
   refresh-sec: <number of seconds after which compare lmt of file in local cache and container and refresh file if container has the latest copy>
   ignore-sync: true|false <sync call will be ignored and locally cached file will not be deleted>
   hard-limit: true|false <if set to true, file-cache will not allow read/writes to file which exceed the configured limits>
-  
+
 # Attribute cache related configuration
 attr_cache:
   timeout-sec: <time attributes and directory contents can be cached (in sec). Default - 120 sec>
   no-cache-on-list: true|false <do not cache attributes or directory contents during listing. Enabling this flag may cause performance problems.>
-  no-symlinks: true|false <to improve performance disable symlink support. symlinks will be treated like regular files.>
+  no-symlinks: true|false <to improve performance disable symlink support. symlinks will be treated like regular files. Default - true>
   max-files: <maximum number of files in the attribute cache at a time. Default - 5000000>
   no-cache-dirs: true|false <to prevent double-listing directories and to make timestamps accurate, disable caching directories. Breaks s3storage.>
-  
+
 # Loopback configuration
 loopbackfs:
   path: <path to local directory>

--- a/setup/baseConfig.yaml
+++ b/setup/baseConfig.yaml
@@ -117,8 +117,8 @@ file_cache:
 # Attribute cache related configuration
 attr_cache:
   timeout-sec: <time attributes and directory contents can be cached (in sec). Default - 120 sec>
-  no-cache-on-list: true|false <do not cache attributes or directory contents during listing. Enabling this flag may cause performance problems.>
-  no-symlinks: true|false <to improve performance disable symlink support. symlinks will be treated like regular files. Default - true>
+  no-cache-on-list: true|false <do not cache attributes or directory contents during listing. Enabling may cause performance problems.>
+  enable-symlinks: true|false <enable symlink support. When false, symlinks will be treated like regular files. Enabling may cause performance problems.>
   max-files: <maximum number of files in the attribute cache at a time. Default - 5000000>
   no-cache-dirs: true|false <to prevent double-listing directories and to make timestamps accurate, disable caching directories. Breaks s3storage.>
 

--- a/test/e2e_tests/data_validation_test.go
+++ b/test/e2e_tests/data_validation_test.go
@@ -147,8 +147,8 @@ func (suite *dataValidationTestSuite) TestFileOverwriteWithEchoCommand() {
 // data validation for small sized files
 func (suite *dataValidationTestSuite) TestSmallFileData() {
 	fileName := "small_data.txt"
-	localFilePath := suite.testLocalPath + "/" + fileName
-	remoteFilePath := suite.testMntPath + "/" + fileName
+	localFilePath := filepath.Join(suite.testLocalPath, fileName)
+	remoteFilePath := filepath.Join(suite.testMntPath, fileName)
 
 	// create the file in local directory
 	srcFile, err := os.OpenFile(localFilePath, os.O_CREATE, 0777)
@@ -176,8 +176,8 @@ func (suite *dataValidationTestSuite) TestMediumFileData() {
 		return
 	}
 	fileName := "medium_data.txt"
-	localFilePath := suite.testLocalPath + "/" + fileName
-	remoteFilePath := suite.testMntPath + "/" + fileName
+	localFilePath := filepath.Join(suite.testLocalPath, fileName)
+	remoteFilePath := filepath.Join(suite.testMntPath, fileName)
 
 	// create the file in local directory
 	srcFile, err := os.OpenFile(localFilePath, os.O_CREATE, 0777)
@@ -205,8 +205,8 @@ func (suite *dataValidationTestSuite) TestLargeFileData() {
 		return
 	}
 	fileName := "large_data.txt"
-	localFilePath := suite.testLocalPath + "/" + fileName
-	remoteFilePath := suite.testMntPath + "/" + fileName
+	localFilePath := filepath.Join(suite.testLocalPath, fileName)
+	remoteFilePath := filepath.Join(suite.testMntPath, fileName)
 
 	// create the file in local directory
 	srcFile, err := os.OpenFile(localFilePath, os.O_CREATE, 0777)
@@ -230,8 +230,8 @@ func (suite *dataValidationTestSuite) TestLargeFileData() {
 // negative test case for data validation where the local file is updated
 func (suite *dataValidationTestSuite) TestDataValidationNegative() {
 	fileName := "updated_data.txt"
-	localFilePath := suite.testLocalPath + "/" + fileName
-	remoteFilePath := suite.testMntPath + "/" + fileName
+	localFilePath := filepath.Join(suite.testLocalPath, fileName)
+	remoteFilePath := filepath.Join(suite.testMntPath, fileName)
 
 	// create the file in local directory
 	srcFile, err := os.OpenFile(localFilePath, os.O_CREATE, 0777)
@@ -269,8 +269,8 @@ func (suite *dataValidationTestSuite) TestDataValidationNegative() {
 func validateMultipleFilesData(jobs <-chan int, results chan<- string, fileSize string, suite *dataValidationTestSuite) {
 	for i := range jobs {
 		fileName := fileSize + strconv.Itoa(i) + ".txt"
-		localFilePath := suite.testLocalPath + "/" + fileName
-		remoteFilePath := suite.testMntPath + "/" + fileName
+		localFilePath := filepath.Join(suite.testLocalPath, fileName)
+		remoteFilePath := filepath.Join(suite.testMntPath, fileName)
 		fmt.Println("Local file path: " + localFilePath)
 
 		// create the file in local directory
@@ -295,10 +295,10 @@ func validateMultipleFilesData(jobs <-chan int, results chan<- string, fileSize 
 		suite.NoError(err)
 
 		suite.copyToMountDir(localFilePath, remoteFilePath)
-		suite.dataValidationTestCleanup([]string{suite.testCachePath + "/" + fileName})
+		suite.dataValidationTestCleanup([]string{filepath.Join(suite.testCachePath, fileName)})
 		suite.validateData(localFilePath, remoteFilePath)
 
-		suite.dataValidationTestCleanup([]string{localFilePath, suite.testCachePath + "/" + fileName})
+		suite.dataValidationTestCleanup([]string{localFilePath, filepath.Join(suite.testCachePath, fileName)})
 
 		results <- remoteFilePath
 	}
@@ -403,13 +403,13 @@ func TestDataValidationTestSuite(t *testing.T) {
 	testDirName := getDataValidationTestDirName(10)
 
 	// Create directory for testing the End to End test on mount path
-	dataValidationTest.testMntPath = dataValidationMntPathPtr + "/" + testDirName
+	dataValidationTest.testMntPath = filepath.Join(dataValidationMntPathPtr, testDirName)
 	fmt.Println(dataValidationTest.testMntPath)
 
 	dataValidationTest.testLocalPath, _ = filepath.Abs(dataValidationMntPathPtr + "/..")
 	fmt.Println(dataValidationTest.testLocalPath)
 
-	dataValidationTest.testCachePath = dataValidationTempPathPtr + "/" + testDirName
+	dataValidationTest.testCachePath = filepath.Join(dataValidationTempPathPtr, testDirName)
 	fmt.Println(dataValidationTest.testCachePath)
 
 	if dataValidationAdlsPtr == "true" || dataValidationAdlsPtr == "True" {

--- a/test/e2e_tests/dir_test.go
+++ b/test/e2e_tests/dir_test.go
@@ -99,7 +99,7 @@ func (suite *dirTestSuite) dirTestCleanup(toRemove []string) {
 
 // # Create Directory with a simple name
 func (suite *dirTestSuite) TestDirCreateSimple() {
-	dirName := suite.testPath + "/test1"
+	dirName := filepath.Join(suite.testPath, "test1")
 	err := os.Mkdir(dirName, 0777)
 	suite.NoError(err)
 
@@ -109,7 +109,7 @@ func (suite *dirTestSuite) TestDirCreateSimple() {
 
 // # Create Directory that already exists
 func (suite *dirTestSuite) TestDirCreateDuplicate() {
-	dirName := suite.testPath + "/test1"
+	dirName := filepath.Join(suite.testPath, "test1")
 	err := os.Mkdir(dirName, 0777)
 	suite.NoError(err)
 	// duplicate dir - we expect to throw
@@ -131,7 +131,7 @@ func (suite *dirTestSuite) TestDirCreateSplChar() {
 		fmt.Println("Skipping TestDirCreateSplChar on Windows")
 		return
 	}
-	dirName := suite.testPath + "/" + "@#$^&*()_+=-{}[]|?><.,~"
+	dirName := filepath.Join(suite.testPath, "@#$^&*()_+=-{}[]|?><.,~")
 	err := os.Mkdir(dirName, 0777)
 	suite.NoError(err)
 
@@ -145,7 +145,7 @@ func (suite *dirTestSuite) TestDirCreateSlashChar() {
 		fmt.Println("Skipping TestDirCreateSlashChar on Windows")
 		return
 	}
-	dirName := suite.testPath + "/" + "PRQ\\STUV"
+	dirName := filepath.Join(suite.testPath, "PRQ\\STUV")
 	err := os.Mkdir(dirName, 0777)
 	suite.NoError(err)
 
@@ -155,11 +155,11 @@ func (suite *dirTestSuite) TestDirCreateSlashChar() {
 
 // # Rename a directory
 func (suite *dirTestSuite) TestDirRename() {
-	dirName := suite.testPath + "/test1"
+	dirName := filepath.Join(suite.testPath, "test1")
 	err := os.Mkdir(dirName, 0777)
 	suite.NoError(err)
 
-	newName := suite.testPath + "/test1_new"
+	newName := filepath.Join(suite.testPath, "test1_new")
 	err = os.Rename(dirName, newName)
 	suite.NoError(err)
 
@@ -172,15 +172,15 @@ func (suite *dirTestSuite) TestDirRename() {
 
 // # Move an empty directory
 func (suite *dirTestSuite) TestDirMoveEmpty() {
-	dir2Name := suite.testPath + "/test2"
+	dir2Name := filepath.Join(suite.testPath, "test2")
 	err := os.Mkdir(dir2Name, 0777)
 	suite.NoError(err)
 
-	dir3Name := suite.testPath + "/test3"
+	dir3Name := filepath.Join(suite.testPath, "test3")
 	err = os.Mkdir(dir3Name, 0777)
 	suite.NoError(err)
 
-	err = os.Rename(dir2Name, dir3Name+"/test2")
+	err = os.Rename(dir2Name, filepath.Join(dir3Name, "test2"))
 	time.Sleep(1 * time.Second)
 	suite.NoError(err)
 
@@ -190,23 +190,23 @@ func (suite *dirTestSuite) TestDirMoveEmpty() {
 
 // # Move an non-empty directory
 func (suite *dirTestSuite) TestDirMoveNonEmpty() {
-	dir2Name := suite.testPath + "/test2NE"
+	dir2Name := filepath.Join(suite.testPath, "test2NE")
 	err := os.Mkdir(dir2Name, 0777)
 	suite.NoError(err)
 
-	file1Name := dir2Name + "/test.txt"
+	file1Name := filepath.Join(dir2Name, "test.txt")
 	f, err := os.Create(file1Name)
 	suite.NoError(err)
 	f.Close()
 
-	dir3Name := suite.testPath + "/test3NE"
+	dir3Name := filepath.Join(suite.testPath, "test3NE")
 	err = os.Mkdir(dir3Name, 0777)
 	suite.NoError(err)
 
-	err = os.Mkdir(dir3Name+"/abcdTest", 0777)
+	err = os.Mkdir(filepath.Join(dir3Name, "abcdTest"), 0777)
 	suite.NoError(err)
 
-	err = os.Rename(dir2Name, dir3Name+"/test2")
+	err = os.Rename(dir2Name, filepath.Join(dir3Name, "test2"))
 	time.Sleep(1 * time.Second)
 	suite.NoError(err)
 
@@ -216,7 +216,7 @@ func (suite *dirTestSuite) TestDirMoveNonEmpty() {
 
 // # Delete non-empty directory
 func (suite *dirTestSuite) TestDirDeleteEmpty() {
-	dirName := suite.testPath + "/test1_new"
+	dirName := filepath.Join(suite.testPath, "test1_new")
 	err := os.Mkdir(dirName, 0777)
 	suite.NoError(err)
 
@@ -225,11 +225,11 @@ func (suite *dirTestSuite) TestDirDeleteEmpty() {
 
 // # Delete non-empty directory
 func (suite *dirTestSuite) TestDirDeleteNonEmpty() {
-	dir3Name := suite.testPath + "/test3NE"
+	dir3Name := filepath.Join(suite.testPath, "test3NE")
 	err := os.Mkdir(dir3Name, 0777)
 	suite.NoError(err)
 
-	err = os.Mkdir(dir3Name+"/abcdTest", 0777)
+	err = os.Mkdir(filepath.Join(dir3Name, "abcdTest"), 0777)
 	suite.NoError(err)
 
 	err = os.Remove(dir3Name)
@@ -247,21 +247,21 @@ func (suite *dirTestSuite) TestDirDeleteNonEmpty() {
 
 // // # Delete non-empty directory recursively
 // func (suite *dirTestSuite) TestDirDeleteRecursive() {
-// 	dirName := suite.testPath + "/testREC"
+// 	dirName := filepath.Join(suite.testPath, "testREC")
 
 // 	err := os.Mkdir(dirName, 0777)
 // 	suite.Equal(nil, err)
 
-// 	err = os.Mkdir(dirName+"/level1", 0777)
+// 	err = os.Mkdir(filepath.Join(dirName, "level1"), 0777)
 // 	suite.Equal(nil, err)
 
-// 	err = os.Mkdir(dirName+"/level2", 0777)
+// 	err = os.Mkdir(filepath.Join(dirName, "level2"), 0777)
 // 	suite.Equal(nil, err)
 
-// 	err = os.Mkdir(dirName+"/level1/l1", 0777)
+// 	err = os.Mkdir(filepath.Join(dirName, "level1", "l1"), 0777)
 // 	suite.Equal(nil, err)
 
-// 	srcFile, err := os.OpenFile(dirName+"/level2/abc.txt", os.O_CREATE, 0777)
+// 	srcFile, err := os.OpenFile(filepath.Join(dirName, "level2", "abc.txt"), os.O_CREATE, 0777)
 // 	suite.Equal(nil, err)
 // 	srcFile.Close()
 
@@ -270,7 +270,7 @@ func (suite *dirTestSuite) TestDirDeleteNonEmpty() {
 
 // # Get stats of a directory
 func (suite *dirTestSuite) TestDirGetStats() {
-	dirName := suite.testPath + "/test3"
+	dirName := filepath.Join(suite.testPath, "test3")
 	err := os.Mkdir(dirName, 0777)
 	suite.NoError(err)
 	// time.Sleep(2 * time.Second)
@@ -294,7 +294,7 @@ func (suite *dirTestSuite) TestDirGetStats() {
 // TODO: Fix Failing Test with ADLS
 // func (suite *dirTestSuite) TestDirChmod() {
 // 	if suite.adlsTest == true {
-// 		dirName := suite.testPath + "/test3"
+// 		dirName := filepath.Join(suite.testPath, "test3")
 // 		err := os.Mkdir(dirName, 0777)
 // 		suite.Equal(nil, err)
 
@@ -311,21 +311,21 @@ func (suite *dirTestSuite) TestDirGetStats() {
 
 // # List directory
 func (suite *dirTestSuite) TestDirList() {
-	testDir := suite.testPath + "/bigTestDir"
+	testDir := filepath.Join(suite.testPath, "bigTestDir")
 	err := os.Mkdir(testDir, 0777)
 	suite.NoError(err)
 
-	dir := filepath.Join(testDir + "/Dir1")
+	dir := filepath.Join(testDir, "Dir1")
 	err = os.Mkdir(dir, 0777)
 	suite.NoError(err)
-	dir = filepath.Join(testDir + "/Dir2")
+	dir = filepath.Join(testDir, "Dir2")
 	err = os.Mkdir(dir, 0777)
 	suite.NoError(err)
-	dir = filepath.Join(testDir + "/Dir3")
+	dir = filepath.Join(testDir, "Dir3")
 	err = os.Mkdir(dir, 0777)
 	suite.NoError(err)
 
-	srcFile, err := os.OpenFile(testDir+"/abc.txt", os.O_CREATE, 0777)
+	srcFile, err := os.OpenFile(filepath.Join(testDir, "abc.txt"), os.O_CREATE, 0777)
 	suite.NoError(err)
 	srcFile.Close()
 
@@ -339,23 +339,23 @@ func (suite *dirTestSuite) TestDirList() {
 
 // // # List directory recursively
 // func (suite *dirTestSuite) TestDirListRecursive() {
-// 	testDir := suite.testPath + "/bigTestDir"
+// 	testDir := filepath.Join(suite.testPath, "bigTestDir")
 // 	err := os.Mkdir(testDir, 0777)
 // 	suite.Equal(nil, err)
 
-// 	dir := filepath.Join(testDir + "/Dir1")
+// 	dir := filepath.Join(testDir, "Dir1")
 // 	err = os.Mkdir(dir, 0777)
 // 	suite.Equal(nil, err)
 
-// 	dir = filepath.Join(testDir + "/Dir2")
+// 	dir = filepath.Join(testDir, "Dir2")
 // 	err = os.Mkdir(dir, 0777)
 // 	suite.Equal(nil, err)
 
-// 	dir = filepath.Join(testDir + "/Dir3")
+// 	dir = filepath.Join(testDir, "Dir3")
 // 	err = os.Mkdir(dir, 0777)
 // 	suite.Equal(nil, err)
 
-// 	srcFile, err := os.OpenFile(testDir+"/abc.txt", os.O_CREATE, 0777)
+// 	srcFile, err := os.OpenFile(filepath.Join(testDir, "abc.txt"), os.O_CREATE, 0777)
 // 	suite.Equal(nil, err)
 // 	srcFile.Close()
 
@@ -380,14 +380,14 @@ func (suite *dirTestSuite) TestDirRenameFull() {
 		fmt.Println("Skipping this test case for stream direct")
 		return
 	}
-	dirName := suite.testPath + "/full_dir"
-	newName := suite.testPath + "/full_dir_rename"
-	fileName := dirName + "/test_file_"
+	dirName := filepath.Join(suite.testPath, "full_dir")
+	newName := filepath.Join(suite.testPath, "full_dir_rename")
+	fileName := filepath.Join(dirName, "test_file_")
 
 	err := os.Mkdir(dirName, 0777)
 	suite.NoError(err)
 
-	err = os.Mkdir(dirName+"/tmp", 0777)
+	err = os.Mkdir(filepath.Join(dirName, "tmp"), 0777)
 	suite.NoError(err)
 
 	for i := 0; i < 10; i++ {
@@ -421,8 +421,8 @@ func (suite *dirTestSuite) TestGitStash() {
 		return
 	}
 	if clonePtr == "true" || clonePtr == "True" {
-		dirName := suite.testPath + "/stash"
-		tarName := suite.testPath + "/tardir.tar.gz"
+		dirName := filepath.Join(suite.testPath, "stash")
+		tarName := filepath.Join(suite.testPath, "tardir.tar.gz")
 
 		cmd := exec.Command("git", "clone", "https://github.com/wastore/azure-storage-samples-for-net", dirName)
 		_, err := cmd.Output()
@@ -515,11 +515,11 @@ func (suite *dirTestSuite) TestReadDirLink() {
 		return
 	}
 
-	dirName := suite.testPath + "/test_hns"
+	dirName := filepath.Join(suite.testPath, "test_hns")
 	err := os.Mkdir(dirName, 0777)
 	suite.NoError(err)
 
-	fileName := dirName + "/small_file.txt"
+	fileName := filepath.Join(dirName, "small_file.txt")
 	f, err := os.Create(fileName)
 	suite.NoError(err)
 	f.Close()
@@ -527,7 +527,7 @@ func (suite *dirTestSuite) TestReadDirLink() {
 	err = os.WriteFile(fileName, suite.minBuff, 0777)
 	suite.NoError(err)
 
-	symName := suite.testPath + "/dirlink.lnk"
+	symName := filepath.Join(suite.testPath, "dirlink.lnk")
 	err = os.Symlink(dirName, symName)
 	suite.NoError(err)
 
@@ -552,14 +552,14 @@ func (suite *dirTestSuite) TestReadDirLink() {
 	}
 
 	// temp cache cleanup
-	suite.dirTestCleanup([]string{suite.testCachePath + "/test_hns/small_file.txt", suite.testCachePath + "/dirlink.lnk"})
+	suite.dirTestCleanup([]string{filepath.Join(suite.testCachePath, "test_hns", "small_file.txt"), filepath.Join(suite.testCachePath, "dirlink.lnk")})
 
-	data1, err := os.ReadFile(symName + "/small_file.txt")
+	data1, err := os.ReadFile(filepath.Join(symName, "small_file.txt"))
 	suite.NoError(err)
 	suite.Equal(len(data1), len(suite.minBuff))
 
 	// temp cache cleanup
-	suite.dirTestCleanup([]string{suite.testCachePath + "/test_hns/small_file.txt", suite.testCachePath + "/dirlink.lnk"})
+	suite.dirTestCleanup([]string{filepath.Join(suite.testCachePath, "test_hns", "small_file.txt"), filepath.Join(suite.testCachePath, "dirlink.lnk")})
 
 	data2, err := os.ReadFile(fileName)
 	suite.NoError(err)
@@ -587,10 +587,10 @@ func TestDirTestSuite(t *testing.T) {
 	fmt.Println(testDirName)
 
 	// Create directory for testing the End to End test on mount path
-	dirTest.testPath = pathPtr + "/" + testDirName
+	dirTest.testPath = filepath.Join(pathPtr, testDirName)
 	fmt.Println(dirTest.testPath)
 
-	dirTest.testCachePath = tempPathPtr + "/" + testDirName
+	dirTest.testCachePath = filepath.Join(tempPathPtr, testDirName)
 	fmt.Println(dirTest.testCachePath)
 
 	if adlsPtr == "true" || adlsPtr == "True" {

--- a/test/e2e_tests/dir_test.go
+++ b/test/e2e_tests/dir_test.go
@@ -329,6 +329,7 @@ func (suite *dirTestSuite) TestDirList() {
 	suite.NoError(err)
 	srcFile.Close()
 
+	time.Sleep(1 * time.Second)
 	files, err := os.ReadDir(testDir)
 	suite.NoError(err)
 	suite.Len(files, 4)

--- a/test/e2e_tests/file_test.go
+++ b/test/e2e_tests/file_test.go
@@ -34,6 +34,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -101,7 +102,7 @@ func (suite *fileTestSuite) fileTestCleanup(toRemove []string) {
 
 // # Create file test
 func (suite *fileTestSuite) TestFileCreate() {
-	fileName := suite.testPath + "/small_write.txt"
+	fileName := filepath.Join(suite.testPath, "small_write.txt")
 	srcFile, err := os.OpenFile(fileName, os.O_CREATE, 0777)
 	suite.NoError(err)
 	srcFile.Close()
@@ -110,7 +111,7 @@ func (suite *fileTestSuite) TestFileCreate() {
 }
 
 func (suite *fileTestSuite) TestFileCreateUtf8Char() {
-	fileName := suite.testPath + "/भारत.txt"
+	fileName := filepath.Join(suite.testPath, "भारत.txt")
 	srcFile, err := os.OpenFile(fileName, os.O_CREATE, 0777)
 	suite.NoError(err)
 	srcFile.Close()
@@ -127,7 +128,7 @@ func (suite *fileTestSuite) TestFileCreatSpclChar() {
 	fmt.Println("Skipping TestFileCreatSpclChar (flaky)")
 	return
 	speclChar := "abcd%23ABCD%34123-._~!$&'()*+,;=!@ΣΑΠΦΩ$भारत.txt"
-	fileName := suite.testPath + "/" + speclChar
+	fileName := filepath.Join(suite.testPath, speclChar)
 
 	srcFile, err := os.OpenFile(fileName, os.O_CREATE, 0777)
 	suite.NoError(err)
@@ -155,7 +156,7 @@ func (suite *fileTestSuite) TestFileCreatSpclChar() {
 
 func (suite *fileTestSuite) TestFileCreateEncodeChar() {
 	speclChar := "%282%29+class_history_by_item.log"
-	fileName := suite.testPath + "/" + speclChar
+	fileName := filepath.Join(suite.testPath, speclChar)
 
 	srcFile, err := os.OpenFile(fileName, os.O_CREATE, 0777)
 	suite.NoError(err)
@@ -187,9 +188,9 @@ func (suite *fileTestSuite) TestFileCreateMultiSpclCharWithinSpclDir() {
 		return
 	}
 	speclChar := "abcd%23ABCD%34123-._~!$&'()*+,;=!@ΣΑΠΦΩ$भारत.txt"
-	speclDirName := suite.testPath + "/" + "abc%23%24%25efg-._~!$&'()*+,;=!@ΣΑΠΦΩ$भारत"
-	secFile := speclDirName + "/" + "abcd123~!@#$%^&*()_+=-{}][\":;'?><,.|abcd123~!@#$%^&*()_+=-{}][\":;'?><,.|.txt"
-	fileName := speclDirName + "/" + speclChar
+	speclDirName := filepath.Join(suite.testPath, "abc%23%24%25efg-._~!$&'()*+,;=!@ΣΑΠΦΩ$भारत")
+	secFile := filepath.Join(speclDirName, "abcd123~!@#$%^&*()_+=-{}][\":;'?><,.|abcd123~!@#$%^&*()_+=-{}][\":;'?><,.|.txt")
+	fileName := filepath.Join(speclDirName, speclChar)
 
 	err := os.Mkdir(speclDirName, 0777)
 	suite.NoError(err)
@@ -222,7 +223,7 @@ func (suite *fileTestSuite) TestFileCreateMultiSpclCharWithinSpclDir() {
 }
 
 func (suite *fileTestSuite) TestFileCreateLongName() {
-	fileName := suite.testPath + "/Higher Call_ An Incredible True Story of Combat and Chivalry in the War-Torn Skies of World War II, A - Adam Makos & Larry Alexander.epub"
+	fileName := filepath.Join(suite.testPath, "Higher Call_ An Incredible True Story of Combat and Chivalry in the War-Torn Skies of World War II, A - Adam Makos & Larry Alexander.epub")
 	srcFile, err := os.OpenFile(fileName, os.O_CREATE, 0777)
 	suite.NoError(err)
 	srcFile.Close()
@@ -237,17 +238,17 @@ func (suite *fileTestSuite) TestFileCreateSlashName() {
 		return
 	}
 
-	fileName := suite.testPath + "/abcd\\efg.txt"
+	fileName := filepath.Join(suite.testPath, "abcd\\efg.txt")
 
 	srcFile, err := os.OpenFile(fileName, os.O_CREATE, 0777)
 	suite.NoError(err)
 	srcFile.Close()
 
-	suite.fileTestCleanup([]string{fileName, suite.testPath + "/abcd"})
+	suite.fileTestCleanup([]string{fileName, filepath.Join(suite.testPath, "abcd")})
 }
 
 func (suite *fileTestSuite) TestFileCreateLabel() {
-	fileName := suite.testPath + "/chunk_f13c48d4-5c1e-11ea-b41d-000d3afe1867.label"
+	fileName := filepath.Join(suite.testPath, "chunk_f13c48d4-5c1e-11ea-b41d-000d3afe1867.label")
 
 	srcFile, err := os.OpenFile(fileName, os.O_CREATE, 0777)
 	suite.NoError(err)
@@ -258,7 +259,7 @@ func (suite *fileTestSuite) TestFileCreateLabel() {
 
 // # Write a small file
 func (suite *fileTestSuite) TestFileWriteSmall() {
-	fileName := suite.testPath + "/small_write.txt"
+	fileName := filepath.Join(suite.testPath, "small_write.txt")
 	srcFile, err := os.OpenFile(fileName, os.O_CREATE, 0777)
 	suite.NoError(err)
 	srcFile.Close()
@@ -271,7 +272,7 @@ func (suite *fileTestSuite) TestFileWriteSmall() {
 
 // # Read a small file
 func (suite *fileTestSuite) TestFileReadSmall() {
-	fileName := suite.testPath + "/small_write.txt"
+	fileName := filepath.Join(suite.testPath, "small_write.txt")
 	srcFile, err := os.OpenFile(fileName, os.O_CREATE, 0777)
 	suite.NoError(err)
 	srcFile.Close()
@@ -288,7 +289,7 @@ func (suite *fileTestSuite) TestFileReadSmall() {
 
 // # Create duplicate file
 func (suite *fileTestSuite) TestFileCreateDuplicate() {
-	fileName := suite.testPath + "/small_write.txt"
+	fileName := filepath.Join(suite.testPath, "small_write.txt")
 	f, err := os.OpenFile(fileName, os.O_CREATE, 0777)
 	suite.NoError(err)
 	f.Close()
@@ -302,7 +303,7 @@ func (suite *fileTestSuite) TestFileCreateDuplicate() {
 
 // # Truncate a file
 func (suite *fileTestSuite) TestFileTruncate() {
-	fileName := suite.testPath + "/small_write.txt"
+	fileName := filepath.Join(suite.testPath, "small_write.txt")
 	f, err := os.Create(fileName)
 	suite.NoError(err)
 	f.Close()
@@ -319,8 +320,8 @@ func (suite *fileTestSuite) TestFileTruncate() {
 
 // # Create file matching directory name
 func (suite *fileTestSuite) TestFileNameConflict() {
-	dirName := suite.testPath + "/test"
-	fileName := suite.testPath + "/test.txt"
+	dirName := filepath.Join(suite.testPath, "test")
+	fileName := filepath.Join(suite.testPath, "test.txt")
 
 	err := os.Mkdir(dirName, 0777)
 	suite.NoError(err)
@@ -335,9 +336,9 @@ func (suite *fileTestSuite) TestFileNameConflict() {
 
 // # Copy file from once directory to another
 func (suite *fileTestSuite) TestFileCopy() {
-	dirName := suite.testPath + "/test123"
-	fileName := suite.testPath + "/test"
-	dstFileName := dirName + "/test_copy.txt"
+	dirName := filepath.Join(suite.testPath, "test123")
+	fileName := filepath.Join(suite.testPath, "test")
+	dstFileName := filepath.Join(dirName, "test_copy.txt")
 
 	err := os.Mkdir(dirName, 0777)
 	suite.NoError(err)
@@ -359,7 +360,7 @@ func (suite *fileTestSuite) TestFileCopy() {
 
 // # Get stats of a file
 func (suite *fileTestSuite) TestFileGetStat() {
-	fileName := suite.testPath + "/test"
+	fileName := filepath.Join(suite.testPath, "test")
 	f, err := os.Create(fileName)
 	suite.NoError(err)
 	f.Close()
@@ -384,7 +385,7 @@ func (suite *fileTestSuite) TestFileChmod() {
 		return
 	}
 	if suite.adlsTest {
-		fileName := suite.testPath + "/test"
+		fileName := filepath.Join(suite.testPath, "test")
 		f, err := os.Create(fileName)
 		suite.NoError(err)
 		f.Close()
@@ -405,10 +406,10 @@ func (suite *fileTestSuite) TestFileCreateMulti() {
 		fmt.Println("Skipping this test case for stream direct")
 		return
 	}
-	dirName := suite.testPath + "/multi_dir"
+	dirName := filepath.Join(suite.testPath, "multi_dir")
 	err := os.Mkdir(dirName, 0777)
 	suite.NoError(err)
-	fileName := dirName + "/multi"
+	fileName := filepath.Join(dirName, "multi")
 	for i := 0; i < 10; i++ {
 		newFile := fileName + strconv.Itoa(i)
 		err := os.WriteFile(newFile, suite.medBuff, 0777)
@@ -420,7 +421,7 @@ func (suite *fileTestSuite) TestFileCreateMulti() {
 // TODO: this test would always pass since its dependent on above tests - resources should be created only for it
 // # Delete single files
 func (suite *fileTestSuite) TestFileDeleteSingle() {
-	fileName := suite.testPath + "/multi0"
+	fileName := filepath.Join(suite.testPath, "multi0")
 	f, err := os.Create(fileName)
 	suite.NoError(err)
 	f.Close()
@@ -437,11 +438,11 @@ func (suite *fileTestSuite) TestLinkCreate() {
 		return
 	}
 
-	fileName := suite.testPath + "/small_write1.txt"
+	fileName := filepath.Join(suite.testPath, "small_write1.txt")
 	f, err := os.Create(fileName)
 	suite.NoError(err)
 	f.Close()
-	symName := suite.testPath + "/small.lnk"
+	symName := filepath.Join(suite.testPath, "small.lnk")
 	err = os.WriteFile(fileName, suite.minBuff, 0777)
 	suite.NoError(err)
 
@@ -460,12 +461,12 @@ func (suite *fileTestSuite) TestLinkRead() {
 		return
 	}
 
-	fileName := suite.testPath + "/small_write1.txt"
+	fileName := filepath.Join(suite.testPath, "small_write1.txt")
 	f, err := os.Create(fileName)
 	suite.NoError(err)
 	f.Close()
 
-	symName := suite.testPath + "/small.lnk"
+	symName := filepath.Join(suite.testPath, "small.lnk")
 	err = os.Symlink(fileName, symName)
 	suite.NoError(err)
 
@@ -487,11 +488,11 @@ func (suite *fileTestSuite) TestLinkWrite() {
 		return
 	}
 
-	targetName := suite.testPath + "/small_write1.txt"
+	targetName := filepath.Join(suite.testPath, "small_write1.txt")
 	f, err := os.Create(targetName)
 	suite.NoError(err)
 	f.Close()
-	symName := suite.testPath + "/small.lnk"
+	symName := filepath.Join(suite.testPath, "small.lnk")
 	err = os.Symlink(targetName, symName)
 	suite.NoError(err)
 
@@ -512,15 +513,15 @@ func (suite *fileTestSuite) TestLinkRenameTarget() {
 		return
 	}
 
-	fileName := suite.testPath + "/small_write1.txt"
-	symName := suite.testPath + "/small.lnk"
+	fileName := filepath.Join(suite.testPath, "small_write1.txt")
+	symName := filepath.Join(suite.testPath, "small.lnk")
 	f, err := os.Create(fileName)
 	suite.NoError(err)
 	f.Close()
 	err = os.Symlink(fileName, symName)
 	suite.NoError(err)
 
-	fileNameNew := suite.testPath + "/small_write_new.txt"
+	fileNameNew := filepath.Join(suite.testPath, "small_write_new.txt")
 	err = os.Rename(fileName, fileNameNew)
 	suite.NoError(err)
 
@@ -545,8 +546,8 @@ func (suite *fileTestSuite) TestLinkDeleteReadTarget() {
 		return
 	}
 
-	fileName := suite.testPath + "/small_write1.txt"
-	symName := suite.testPath + "/small.lnk"
+	fileName := filepath.Join(suite.testPath, "small_write1.txt")
+	symName := filepath.Join(suite.testPath, "small.lnk")
 	f, err := os.Create(fileName)
 	suite.NoError(err)
 	f.Close()
@@ -580,7 +581,7 @@ func (suite *fileTestSuite) TestListDirReadLink() {
 		return
 	}
 
-	fileName := suite.testPath + "/small_hns.txt"
+	fileName := filepath.Join(suite.testPath, "small_hns.txt")
 	f, err := os.Create(fileName)
 	suite.NoError(err)
 	f.Close()
@@ -588,7 +589,7 @@ func (suite *fileTestSuite) TestListDirReadLink() {
 	err = os.WriteFile(fileName, suite.minBuff, 0777)
 	suite.NoError(err)
 
-	symName := suite.testPath + "/small_hns.lnk"
+	symName := filepath.Join(suite.testPath, "small_hns.lnk")
 	err = os.Symlink(fileName, symName)
 	suite.NoError(err)
 
@@ -597,14 +598,14 @@ func (suite *fileTestSuite) TestListDirReadLink() {
 	suite.NotEmpty(dl)
 
 	// temp cache cleanup
-	suite.fileTestCleanup([]string{suite.testCachePath + "/small_hns.txt", suite.testCachePath + "/small_hns.lnk"})
+	suite.fileTestCleanup([]string{filepath.Join(suite.testCachePath, "small_hns.txt"), filepath.Join(suite.testCachePath, "small_hns.lnk")})
 
 	data1, err := os.ReadFile(symName)
 	suite.NoError(err)
 	suite.Equal(len(data1), len(suite.minBuff))
 
 	// temp cache cleanup
-	suite.fileTestCleanup([]string{suite.testCachePath + "/small_hns.txt", suite.testCachePath + "/small_hns.lnk"})
+	suite.fileTestCleanup([]string{filepath.Join(suite.testCachePath, "small_hns.txt"), filepath.Join(suite.testCachePath, "small_hns.lnk")})
 
 	data2, err := os.ReadFile(fileName)
 	suite.NoError(err)
@@ -621,7 +622,7 @@ func (suite *fileTestSuite) TestListDirReadLink() {
 /*
 func (suite *fileTestSuite) TestReadOnlyFile() {
 	if suite.adlsTest == true {
-		fileName := suite.testPath + "/readOnlyFile.txt"
+		fileName := filepath.Join(suite.testPath, "readOnlyFile.txt")
 		srcFile, err := os.Create(fileName)
 		suite.Equal(nil, err)
 		srcFile.Close()
@@ -643,7 +644,7 @@ func (suite *fileTestSuite) TestCreateReadOnlyFile() {
 		return
 	}
 	if suite.adlsTest == true {
-		fileName := suite.testPath + "/createReadOnlyFile.txt"
+		fileName := filepath.Join(suite.testPath, "createReadOnlyFile.txt")
 		srcFile, err := os.OpenFile(fileName, os.O_CREATE, 0444)
 		srcFile.Close()
 		suite.NoError(err)
@@ -661,10 +662,10 @@ func (suite *fileTestSuite) TestRenameSpecial() {
 		return
 	}
 
-	dirName := suite.testPath + "/" + "Alcaldía"
-	newDirName := suite.testPath + "/" + "Alδaδcaldía"
-	fileName := dirName + "/" + "भारत.txt"
-	newFileName := dirName + "/" + "भारतabcd.txt"
+	dirName := filepath.Join(suite.testPath, "Alcaldía")
+	newDirName := filepath.Join(suite.testPath, "Alδaδcaldía")
+	fileName := filepath.Join(dirName, "भारत.txt")
+	newFileName := filepath.Join(dirName, "भारतabcd.txt")
 
 	err := os.Mkdir(dirName, 0777)
 	suite.NoError(err)
@@ -699,10 +700,10 @@ func TestFileTestSuite(t *testing.T) {
 	testDirName := getFileTestDirName(10)
 
 	// Create directory for testing the End to End test on mount path
-	fileTest.testPath = fileTestPathPtr + "/" + testDirName
+	fileTest.testPath = filepath.Join(fileTestPathPtr, testDirName)
 	fmt.Println(fileTest.testPath)
 
-	fileTest.testCachePath = fileTestTempPathPtr + "/" + testDirName
+	fileTest.testCachePath = filepath.Join(fileTestTempPathPtr, testDirName)
 	fmt.Println(fileTest.testCachePath)
 
 	if fileTestAdlsPtr == "true" || fileTestAdlsPtr == "True" {

--- a/testdata/config/azure_block_perf.yaml
+++ b/testdata/config/azure_block_perf.yaml
@@ -26,7 +26,8 @@ block_cache:
 
 attr_cache:
   timeout-sec: 7200
-  
+  enable-symlinks: true
+
 azstorage:
   type: { ACCOUNT_TYPE }
   endpoint: { ACCOUNT_ENDPOINT }

--- a/testdata/config/azure_key.yaml
+++ b/testdata/config/azure_key.yaml
@@ -24,7 +24,8 @@ file_cache:
 
 attr_cache:
   timeout-sec: 3600
-  
+  enable-symlinks: true
+
 azstorage:
   type: { ACCOUNT_TYPE }
   endpoint: { ACCOUNT_ENDPOINT }

--- a/testdata/config/azure_key_bc.yaml
+++ b/testdata/config/azure_key_bc.yaml
@@ -18,9 +18,9 @@ libfuse:
 block_cache:
   block-size-mb: 8
   mem-size-mb: 4192
-  
+
   path: block_cache
-  disk-size-mb: 4192  
+  disk-size-mb: 4192
   disk-timeout-sec: 30
 
   prefetch: 120
@@ -28,7 +28,8 @@ block_cache:
 
 attr_cache:
   timeout-sec: 3600
-  
+  enable-symlinks: true
+
 azstorage:
   type: { ACCOUNT_TYPE }
   endpoint: { ACCOUNT_ENDPOINT }

--- a/testdata/config/azure_key_bc.yaml
+++ b/testdata/config/azure_key_bc.yaml
@@ -1,6 +1,6 @@
 logging:
   level: log_debug
-  file-path: "blobfuse2-logs.txt"
+  file-path: "cloudfuse-logs.txt"
   type: base
 
 components:

--- a/testdata/config/azure_key_emptyfile.yaml
+++ b/testdata/config/azure_key_emptyfile.yaml
@@ -25,7 +25,8 @@ file_cache:
 
 attr_cache:
   timeout-sec: 3600
-  
+  enable-symlinks: true
+
 azstorage:
   type: { ACCOUNT_TYPE }
   endpoint: { ACCOUNT_ENDPOINT }

--- a/testdata/config/azure_key_hmon.yaml
+++ b/testdata/config/azure_key_hmon.yaml
@@ -24,7 +24,8 @@ file_cache:
 
 attr_cache:
   timeout-sec: 3600
-  
+  enable-symlinks: true
+
 azstorage:
   type: { ACCOUNT_TYPE }
   endpoint: { ACCOUNT_ENDPOINT }

--- a/testdata/config/azure_key_huge.yaml
+++ b/testdata/config/azure_key_huge.yaml
@@ -14,18 +14,19 @@ libfuse:
   entry-expiration-sec: 120
   negative-entry-expiration-sec: 120
   ignore-open-flags: true
-  
-  
+
+
 file_cache:
   path: { 1 }
   timeout-sec: 30
   max-size-mb: 2048
   allow-non-empty-temp: true
   cleanup-on-start: true
-  
+
 attr_cache:
   timeout-sec: 3600
   no-cache-on-list: false
+  enable-symlinks: true
 
 azstorage:
   type: { ACCOUNT_TYPE }

--- a/testdata/config/azure_key_lfu.yaml
+++ b/testdata/config/azure_key_lfu.yaml
@@ -24,7 +24,8 @@ file_cache:
 
 attr_cache:
   timeout-sec: 3600
-  
+  enable-symlinks: true
+
 azstorage:
   type: { ACCOUNT_TYPE }
   endpoint: { ACCOUNT_ENDPOINT }

--- a/testdata/config/azure_key_lru_purge.yaml
+++ b/testdata/config/azure_key_lru_purge.yaml
@@ -23,7 +23,8 @@ file_cache:
 
 attr_cache:
   timeout-sec: 3600
-  
+  enable-symlinks: true
+
 azstorage:
   type: { ACCOUNT_TYPE }
   endpoint: { ACCOUNT_ENDPOINT }

--- a/testdata/config/azure_key_perf.yaml
+++ b/testdata/config/azure_key_perf.yaml
@@ -25,7 +25,8 @@ file_cache:
 
 attr_cache:
   timeout-sec: 7200
-  
+  enable-symlinks: true
+
 azstorage:
   type: { ACCOUNT_TYPE }
   endpoint: { ACCOUNT_ENDPOINT }

--- a/testdata/config/azure_key_proxy.yaml
+++ b/testdata/config/azure_key_proxy.yaml
@@ -24,7 +24,8 @@ file_cache:
 
 attr_cache:
   timeout-sec: 3600
-  
+  enable-symlinks: true
+
 azstorage:
   type: { ACCOUNT_TYPE }
   endpoint: { ACCOUNT_ENDPOINT }

--- a/testdata/config/azure_key_symlink.yaml
+++ b/testdata/config/azure_key_symlink.yaml
@@ -24,8 +24,8 @@ file_cache:
 
 attr_cache:
   timeout-sec: 3600
-  no-symlinks: false
-  
+  enable-symlinks: true
+
 azstorage:
   type: { ACCOUNT_TYPE }
   endpoint: { ACCOUNT_ENDPOINT }

--- a/testdata/config/azure_key_symlink.yaml
+++ b/testdata/config/azure_key_symlink.yaml
@@ -1,6 +1,6 @@
 logging:
   level: log_debug
-  file-path: "blobfuse2-logs.txt"
+  file-path: "cloudfuse-logs.txt"
   type: base
 
 components:

--- a/testdata/config/azure_msi.yaml
+++ b/testdata/config/azure_msi.yaml
@@ -24,6 +24,7 @@ file_cache:
 
 attr_cache:
   timeout-sec: 3600
+  enable-symlinks: true
 
 azstorage:
   type: { ACCOUNT_TYPE }

--- a/testdata/config/azure_msi_sysid.yaml
+++ b/testdata/config/azure_msi_sysid.yaml
@@ -24,6 +24,7 @@ file_cache:
 
 attr_cache:
   timeout-sec: 3600
+  enable-symlinks: true
 
 azstorage:
   type: { ACCOUNT_TYPE }

--- a/testdata/config/azure_sas.yaml
+++ b/testdata/config/azure_sas.yaml
@@ -24,7 +24,8 @@ file_cache:
 
 attr_cache:
   timeout-sec: 3600
-  
+  enable-symlinks: true
+
 azstorage:
   type: { ACCOUNT_TYPE }
   endpoint: { ACCOUNT_ENDPOINT }

--- a/testdata/config/azure_sas_proxy.yaml
+++ b/testdata/config/azure_sas_proxy.yaml
@@ -24,6 +24,7 @@ file_cache:
 
 attr_cache:
   timeout-sec: 3600
+  enable-symlinks: true
 
 azstorage:
   type: block
@@ -36,4 +37,3 @@ azstorage:
   tier: hot
   https-proxy: 127.0.0.1:8080
   sdk-trace: { VERBOSE_LOG }
-  

--- a/testdata/config/azure_spn.yaml
+++ b/testdata/config/azure_spn.yaml
@@ -24,6 +24,7 @@ file_cache:
 
 attr_cache:
   timeout-sec: 3600
+  enable-symlinks: true
 
 azstorage:
   type: { ACCOUNT_TYPE }

--- a/testdata/config/azure_spn_proxy.yaml
+++ b/testdata/config/azure_spn_proxy.yaml
@@ -24,6 +24,7 @@ file_cache:
 
 attr_cache:
   timeout-sec: 3600
+  enable-symlinks: true
 
 azstorage:
   type: block

--- a/testdata/config/azure_stream.yaml
+++ b/testdata/config/azure_stream.yaml
@@ -22,7 +22,8 @@ stream:
 
 attr_cache:
   timeout-sec: 3600
-  
+  enable-symlinks: true
+
 azstorage:
   type: { ACCOUNT_TYPE }
   endpoint: { ACCOUNT_ENDPOINT }

--- a/testdata/config/azure_stream_direct.yaml
+++ b/testdata/config/azure_stream_direct.yaml
@@ -20,6 +20,7 @@ stream:
 
 attr_cache:
   timeout-sec: 3600
+  enable-symlinks: true
 
 azstorage:
   type: { ACCOUNT_TYPE }

--- a/testdata/config/azure_stream_filename.yaml
+++ b/testdata/config/azure_stream_filename.yaml
@@ -23,7 +23,8 @@ stream:
 
 attr_cache:
   timeout-sec: 3600
-  
+  enable-symlinks: true
+
 azstorage:
   type: { ACCOUNT_TYPE }
   endpoint: { ACCOUNT_ENDPOINT }

--- a/testdata/config/azure_stream_filename_direct.yaml
+++ b/testdata/config/azure_stream_filename_direct.yaml
@@ -21,6 +21,7 @@ stream:
 
 attr_cache:
   timeout-sec: 3600
+  enable-symlinks: true
 
 azstorage:
   type: { ACCOUNT_TYPE }

--- a/testdata/config/s3_key.yaml
+++ b/testdata/config/s3_key.yaml
@@ -24,6 +24,7 @@ file_cache:
 
 attr_cache:
   timeout-sec: 3600
+  enable-symlinks: true
 
 s3storage:
   bucket-name: { S3_BUCKET_NAME }

--- a/testdata/config/s3_key_lfu.yaml
+++ b/testdata/config/s3_key_lfu.yaml
@@ -24,7 +24,8 @@ file_cache:
 
 attr_cache:
   timeout-sec: 3600
-  
+  enable-symlinks: true
+
 s3storage:
   bucket-name: { S3_BUCKET_NAME }
   endpoint: { S3_ENDPOINT }


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief
Change `no-symlinks` config option to `enable-symlinks` and change default to disable symlinks.
Always pull symlink option from `attr_cache` into cloud storage component.
Clean up s3storage tests.
Return `syscall.ENOTSUP` on `CreateLink` and `ReadLink` when symlinks are disabled.
**`azstorage` was not changed (will not return `syscall.ENOTSUP` on link calls). This may need to change (please review).**

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [x] Added tests

### Related Issues

- Related Issue #
- Closes #