### PR TITLE
Use new syntax for go version in go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Seagate/cloudfuse
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/Azure/azure-pipeline-go v0.2.4-0.20220425205405-09e6f201e1e4


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief

This fixes our go.mod file to use the newer 1.N.P syntax https://go.dev/doc/toolchain#version to specify the version of Go being used. This now will use a 1.22.0 toolchain to build Go. This also fixes a warning from CodeQL and an issue with Mend.

### Checklist

- [ ] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #