### PR TITLE
Use zig as c compiler for cross platform builds

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -199,6 +199,7 @@ jobs:
       - name: Install Zig
         run: |
           curl -L https://ziglang.org/download/${{ env.zig }}/zig-linux-x86_64-${{ env.zig }}.tar.xz -o zig.tar.xz
+          mkdir -r $HOME/.local/bin
           tar -xf zig.tar.xz -C $HOME/.local/bin
           echo "$HOME/.local/bin/zig-linux-x86_64-${{ env.zig }}" >> $GITHUB_PATH
           echo $PATH

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -199,8 +199,8 @@ jobs:
       - name: Install Zig
         run: |
           curl -L https://ziglang.org/download/${{ env.zig }}/zig-linux-x86_64-${{ env.zig }}.tar.xz -o zig.tar.xz
-          tar -xf zig.tar.xz -C /usr/local
-          echo "/usr/local/zig-linux-x86_64-${{ env.zig }}" >> $GITHUB_PATH
+          tar -xf zig.tar.xz -C $HOME/.local/bin
+          echo "$HOME/.local/bin/zig-linux-x86_64-${{ env.zig }}" >> $GITHUB_PATH
           echo $PATH
           zig version
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -199,8 +199,9 @@ jobs:
       - name: Install Zig
         run: |
           curl -L https://ziglang.org/download/${{ env.zig }}/zig-linux-x86_64-${{ env.zig }}.tar.xz -o zig.tar.xz
-          tar -xf zig.tar.xz -C /opt
-          echo "/opt/zig-linux-x86_64-${{ env.zig }}" >> $GITHUB_PATH
+          tar -xf zig.tar.xz -C /usr/local
+          echo "/usr/local/zig-linux-x86_64-${{ env.zig }}" >> $GITHUB_PATH
+          echo $PATH
           zig version
 
       - name: Install Go

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -177,6 +177,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       go: '1.22'
+      zig: 0.12.0
 
     steps:
       - # libfuse-dev is required to build our command-line program
@@ -192,8 +193,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      -
-        name: Install Go
+        
+      - name: Install Zig
+        run: |
+          curl -L https://ziglang.org/download/${{ env.zig }}/zig-linux-x86_64-${{ env.zig }}.tar.xz -o zig.tar.xz
+          tar -xf zig.tar.xz -C /opt
+          export PATH=/opt/zig-linux-x86_64-${{ env.zig }}:$PATH
+          zig version
+
+      - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.go }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -202,8 +202,6 @@ jobs:
           mkdir -p $HOME/.local/bin
           tar -xf zig.tar.xz -C $HOME/.local/bin
           echo "$HOME/.local/bin/zig-linux-x86_64-${{ env.zig }}" >> $GITHUB_PATH
-          echo $PATH
-          zig version
 
       - name: Install Go
         uses: actions/setup-go@v5

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,6 +1,8 @@
 name: Release binaries
 on:
   push:
+    branches:
+      - fix-rhel-builds
     tags:
       - 'v*'
 
@@ -242,6 +244,6 @@ jobs:
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
-          args: release --clean
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          args: release --snapshot
+        #env:
+        #  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -199,7 +199,7 @@ jobs:
       - name: Install Zig
         run: |
           curl -L https://ziglang.org/download/${{ env.zig }}/zig-linux-x86_64-${{ env.zig }}.tar.xz -o zig.tar.xz
-          mkdir -r $HOME/.local/bin
+          mkdir -p $HOME/.local/bin
           tar -xf zig.tar.xz -C $HOME/.local/bin
           echo "$HOME/.local/bin/zig-linux-x86_64-${{ env.zig }}" >> $GITHUB_PATH
           echo $PATH

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -200,7 +200,7 @@ jobs:
         run: |
           curl -L https://ziglang.org/download/${{ env.zig }}/zig-linux-x86_64-${{ env.zig }}.tar.xz -o zig.tar.xz
           tar -xf zig.tar.xz -C /opt
-          export PATH=/opt/zig-linux-x86_64-${{ env.zig }}:$PATH
+          echo "/opt/zig-linux-x86_64-${{ env.zig }}" >> $GITHUB_PATH
           zig version
 
       - name: Install Go

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -242,6 +242,6 @@ jobs:
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
-          args: release --snapshot
-        #env:
-        #  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,8 +1,6 @@
 name: Release binaries
 on:
   push:
-    branches:
-      - fix-rhel-builds
     tags:
       - 'v*'
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -62,6 +62,8 @@ builds:
       - amd64
     env:
       - CGO_ENABLED=1
+      - CC=zig cc -target x86_64-linux-gnu
+      - CXX=zig c++ -target x86_64-linux-gnu
     flags:
       - -trimpath
     mod_timestamp: '{{ .CommitTimestamp }}'
@@ -76,7 +78,7 @@ builds:
     goarch:
       - amd64
     env:
-      - CGO_ENABLED=1
+      - CGO_ENABLED=0
     flags:
       - -trimpath
     mod_timestamp: '{{ .CommitTimestamp }}'
@@ -90,8 +92,8 @@ builds:
       - arm64
     env:
       - CGO_ENABLED=1
-      - CC=aarch64-linux-gnu-gcc
-      - CXX=aarch64-linux-gnu-g++
+      - CC=zig cc -target aarch64-linux-gnu
+      - CXX=zig c++ -target aarch64-linux-gnu
     flags:
       - -trimpath
     mod_timestamp: '{{ .CommitTimestamp }}'
@@ -106,9 +108,7 @@ builds:
     goarch:
       - arm64
     env:
-      - CGO_ENABLED=1
-      - CC=aarch64-linux-gnu-gcc
-      - CXX=aarch64-linux-gnu-g++
+      - CGO_ENABLED=0
     flags:
       - -trimpath
     mod_timestamp: '{{ .CommitTimestamp }}'


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief

Changes our C compiler to use Zig https://ziglang.org/, which allows easier cross compilation support. This should allow us to deploy Cloudfuse to more Linux OS's without needing to change our deployment strategy or spin up VM's and docker images.

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #