### PR TITLE
Change default cloudfuse size from 1 PB to 1 TB

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -58,7 +58,7 @@ const (
 
 	MbToBytes  = 1024 * 1024
 	GbToBytes  = 1024 * 1024 * 1024
-	PbToBytes  = 1024 * 1024 * 1024 * 1024 * 1024
+	TbToBytes  = 1024 * 1024 * 1024 * 1024
 	CfuseStats = "cloudfuse_stats"
 
 	FuseAllowedFlags = "invalid FUSE options. Allowed FUSE configurations are: `-o attr_timeout=TIMEOUT`, `-o negative_timeout=TIMEOUT`, `-o entry_timeout=TIMEOUT` `-o allow_other`, `-o allow_root`, `-o umask=PERMISSIONS -o default_permissions`, `-o ro`"

--- a/component/libfuse/libfuse2_handler.go
+++ b/component/libfuse/libfuse2_handler.go
@@ -312,7 +312,7 @@ func (cf *CgofuseFS) Statfs(path string, stat *fuse.Statfs_t) int {
 		stat.Namemax = attr.Namemax
 	} else {
 		var free, total, avail uint64
-		total = common.PbToBytes
+		total = common.TbToBytes
 		avail = total
 		free = total
 


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief

Change the default folder size from 1 PB to 1 TB. This should allow network optix to always allow this drive as a backup drive for storage purposes.

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #