### PR TITLE
Use base64 encoded string for encrypting config file

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -381,11 +381,11 @@ jobs:
     
     - name: 'CLI : Mount all with secure config'
       timeout-minutes: 2
-      run: "./cloudfuse.test unmount all\ncp ${{ env.cloudfuse_CFG }} /tmp/configMountall.yaml\necho \"mountall:\" >> /tmp/configMountall.yaml\necho \"  container-allowlist:\" >> /tmp/configMountall.yaml\necho \"    - abcd\" >> /tmp/configMountall.yaml\ncat /tmp/configMountall.yaml\n\n./cloudfuse.test -test.v -test.coverprofile=${{ env.WORK_DIR }}/secure_encrypt_all.cov secure encrypt --config-file=/tmp/configMountall.yaml --output-file=${{ runner.workspace }}/cloudfuse.azsec --passphrase=123123123123123123123123 \nif [ $? -ne 0 ]; then\n  exit 1\nfi\n\n./cloudfuse.test -test.v -test.coverprofile=${{ env.WORK_DIR }}/mount_all_cmd_secure.cov mount all ${{ env.MOUNT_DIR }} --config-file=${{ runner.workspace }}/cloudfuse.azsec --passphrase=123123123123123123123123 --log-level=log_debug --foreground=true &\nif [ $? -ne 0 ]; then\n  exit 1\nfi\n\nsleep 5\n./cloudfuse.test unmount all"
+      run: "./cloudfuse.test unmount all\ncp ${{ env.cloudfuse_CFG }} /tmp/configMountall.yaml\necho \"mountall:\" >> /tmp/configMountall.yaml\necho \"  container-allowlist:\" >> /tmp/configMountall.yaml\necho \"    - abcd\" >> /tmp/configMountall.yaml\ncat /tmp/configMountall.yaml\n\n./cloudfuse.test -test.v -test.coverprofile=${{ env.WORK_DIR }}/secure_encrypt_all.cov secure encrypt --config-file=/tmp/configMountall.yaml --output-file=${{ runner.workspace }}/cloudfuse.azsec --passphrase=12312312312312312312312312312312 \nif [ $? -ne 0 ]; then\n  exit 1\nfi\n\n./cloudfuse.test -test.v -test.coverprofile=${{ env.WORK_DIR }}/mount_all_cmd_secure.cov mount all ${{ env.MOUNT_DIR }} --config-file=${{ runner.workspace }}/cloudfuse.azsec --passphrase=12312312312312312312312312312312 --log-level=log_debug --foreground=true &\nif [ $? -ne 0 ]; then\n  exit 1\nfi\n\nsleep 5\n./cloudfuse.test unmount all"
     
     - name: 'CLI : Mount all with secure config 2'
       timeout-minutes: 2
-      run: "./cloudfuse.test unmount all\ncp ${{ env.cloudfuse_CFG }} /tmp/configMountall.yaml\necho \"mountall:\" >> /tmp/configMountall.yaml\necho \"  container-denylist:\" >> /tmp/configMountall.yaml\necho \"    - abcd\" >> /tmp/configMountall.yaml\ncat /tmp/configMountall.yaml\n\n./cloudfuse.test -test.v -test.coverprofile=${{ env.WORK_DIR }}/secure_encrypt_all2.cov secure encrypt --config-file=/tmp/configMountall.yaml --output-file=${{ runner.workspace }}/cloudfuse.azsec --passphrase=123123123123123123123123 \nif [ $? -ne 0 ]; then\n  exit 1\nfi\n\n./cloudfuse.test -test.v -test.coverprofile=${{ env.WORK_DIR }}/mount_all_cmd_secure2.cov mount all ${{ env.MOUNT_DIR }} --config-file=${{ runner.workspace }}/cloudfuse.azsec --passphrase=123123123123123123123123 --log-level=log_debug --foreground=true &\nif [ $? -ne 0 ]; then\n  exit 1\nfi\n\nsleep 5\n./cloudfuse.test unmount all"
+      run: "./cloudfuse.test unmount all\ncp ${{ env.cloudfuse_CFG }} /tmp/configMountall.yaml\necho \"mountall:\" >> /tmp/configMountall.yaml\necho \"  container-denylist:\" >> /tmp/configMountall.yaml\necho \"    - abcd\" >> /tmp/configMountall.yaml\ncat /tmp/configMountall.yaml\n\n./cloudfuse.test -test.v -test.coverprofile=${{ env.WORK_DIR }}/secure_encrypt_all2.cov secure encrypt --config-file=/tmp/configMountall.yaml --output-file=${{ runner.workspace }}/cloudfuse.azsec --passphrase=12312312312312312312312312312312 \nif [ $? -ne 0 ]; then\n  exit 1\nfi\n\n./cloudfuse.test -test.v -test.coverprofile=${{ env.WORK_DIR }}/mount_all_cmd_secure2.cov mount all ${{ env.MOUNT_DIR }} --config-file=${{ runner.workspace }}/cloudfuse.azsec --passphrase=12312312312312312312312312312312 --log-level=log_debug --foreground=true &\nif [ $? -ne 0 ]; then\n  exit 1\nfi\n\nsleep 5\n./cloudfuse.test unmount all"
     
     - name: 'CLI : Remount test'
       timeout-minutes: 2
@@ -451,7 +451,7 @@ jobs:
         ACCOUNT_ENDPOINT: https://${{ secrets.NIGHTLY_STO_BLOB_ACC_NAME }}.blob.core.windows.net
         VERBOSE_LOG: false
         USE_HTTP: false
-      run: "set +x\nrm -rf ${{ env.MOUNT_DIR }}/*\nrm -rf ${{ env.TEMP_DIR }}/*\n./cloudfuse.test unmount all\n./cloudfuse.test gen-test-config --config-file=azure_key.yaml --container-name=${{ matrix.containerName }} --temp-path=${{ env.TEMP_DIR }} --output-file=${{ env.cloudfuse_CFG }}\n\n./cloudfuse.test -test.v -test.coverprofile=${{ env.WORK_DIR }}/secure_encrypt.cov secure encrypt --config-file=${{ env.cloudfuse_CFG }} --output-file=${{ runner.workspace }}/cloudfuse.azsec --passphrase=123123123123123123123123 \nif [ $? -ne 0 ]; then\n  exit 1\nfi\n./cloudfuse.test -test.v -test.coverprofile=${{ env.WORK_DIR }}/mount_secure.cov mount ${{ env.MOUNT_DIR }} --config-file=${{ runner.workspace }}/cloudfuse.azsec --passphrase=123123123123123123123123 &\nsleep 10\nps -aux | grep cloudfuse\nrm -rf ${{ env.MOUNT_DIR }}/*\ncd test/e2e_tests\ngo test -v -timeout=7200s ./... -args -mnt-path=${{ env.MOUNT_DIR }} -adls=false -tmp-path=${{ env.TEMP_DIR }}\ncd -\n\n./cloudfuse.test -test.v -test.coverprofile=${{ env.WORK_DIR }}/secure_set.cov secure set --config-file=${{ runner.workspace }}/cloudfuse.azsec --passphrase=123123123123123123123123 --key=logging.level --value=log_debug\n./cloudfuse.test unmount all\nsleep 5"
+      run: "set +x\nrm -rf ${{ env.MOUNT_DIR }}/*\nrm -rf ${{ env.TEMP_DIR }}/*\n./cloudfuse.test unmount all\n./cloudfuse.test gen-test-config --config-file=azure_key.yaml --container-name=${{ matrix.containerName }} --temp-path=${{ env.TEMP_DIR }} --output-file=${{ env.cloudfuse_CFG }}\n\n./cloudfuse.test -test.v -test.coverprofile=${{ env.WORK_DIR }}/secure_encrypt.cov secure encrypt --config-file=${{ env.cloudfuse_CFG }} --output-file=${{ runner.workspace }}/cloudfuse.azsec --passphrase=12312312312312312312312312312312 \nif [ $? -ne 0 ]; then\n  exit 1\nfi\n./cloudfuse.test -test.v -test.coverprofile=${{ env.WORK_DIR }}/mount_secure.cov mount ${{ env.MOUNT_DIR }} --config-file=${{ runner.workspace }}/cloudfuse.azsec --passphrase=12312312312312312312312312312312 &\nsleep 10\nps -aux | grep cloudfuse\nrm -rf ${{ env.MOUNT_DIR }}/*\ncd test/e2e_tests\ngo test -v -timeout=7200s ./... -args -mnt-path=${{ env.MOUNT_DIR }} -adls=false -tmp-path=${{ env.TEMP_DIR }}\ncd -\n\n./cloudfuse.test -test.v -test.coverprofile=${{ env.WORK_DIR }}/secure_set.cov secure set --config-file=${{ runner.workspace }}/cloudfuse.azsec --passphrase=12312312312312312312312312312312 --key=logging.level --value=log_debug\n./cloudfuse.test unmount all\nsleep 5"
     
     - name: 'CLI : Health monitor stop pid'
       shell: bash {0}
@@ -1023,18 +1023,18 @@ jobs:
         rm -rf ${{ env.TEMP_DIR }}/*
         ./cloudfuse.test unmount all
         ./cloudfuse.test gen-test-config --config-file=azure_key.yaml --container-name=${{ matrix.containerName }} --temp-path=${{ env.TEMP_DIR }} --output-file=${{ env.cloudfuse_CFG }}
-        ./cloudfuse.test -test.v -test.coverprofile=${{ env.WORK_DIR }}/secure_encrypt.cov secure encrypt --config-file=${{ env.cloudfuse_CFG }} --output-file=${{ env.WORK_DIR }}/cloudfuse.azsec --passphrase=123123123123123123123123 
+        ./cloudfuse.test -test.v -test.coverprofile=${{ env.WORK_DIR }}/secure_encrypt.cov secure encrypt --config-file=${{ env.cloudfuse_CFG }} --output-file=${{ env.WORK_DIR }}/cloudfuse.azsec --passphrase=12312312312312312312312312312312 
         if [ $? -ne 0 ]; then
           exit 1
         fi
-      # ./cloudfuse.test -test.v -test.coverprofile=${{ env.WORK_DIR }}/mount_secure.cov mount ${{ env.MOUNT_DIR }} --config-file=${{ env.WORK_DIR }}/cloudfuse.azsec --passphrase=123123123123123123123123 --foreground=true &
+      # ./cloudfuse.test -test.v -test.coverprofile=${{ env.WORK_DIR }}/mount_secure.cov mount ${{ env.MOUNT_DIR }} --config-file=${{ env.WORK_DIR }}/cloudfuse.azsec --passphrase=12312312312312312312312312312312 --foreground=true &
       # sleep 10
       # pid=`ps -a | grep cloudfuse | tr -s ' ' | cut -d ' ' -f2`
       # rm -rf ${{ env.MOUNT_DIR }}/*
       # cd test/e2e_tests
       # go test -v -timeout=7200s ./... -args -mnt-path=${{ env.MOUNT_DIR }} -adls=false -tmp-path=${{ env.TEMP_DIR }}
       # cd -
-      # ./cloudfuse.test -test.v -test.coverprofile=${{ env.WORK_DIR }}/secure_set.cov secure set --config-file=${{ env.WORK_DIR }}/cloudfuse.azsec --passphrase=123123123123123123123123 --key=logging.level --value=log_debug
+      # ./cloudfuse.test -test.v -test.coverprofile=${{ env.WORK_DIR }}/secure_set.cov secure set --config-file=${{ env.WORK_DIR }}/cloudfuse.azsec --passphrase=12312312312312312312312312312312 --key=logging.level --value=log_debug
       # kill $pid
       # sleep 5
     

--- a/cmd/config-gen.go
+++ b/cmd/config-gen.go
@@ -142,7 +142,7 @@ var generateConfig = &cobra.Command{
 			}
 		}
 
-		cipherText, err := common.EncryptData([]byte(newConfig), []byte(opts.passphrase))
+		cipherText, err := common.EncryptData([]byte(newConfig), opts.passphrase)
 		if err != nil {
 			return err
 		}

--- a/cmd/config-gen_test.go
+++ b/cmd/config-gen_test.go
@@ -133,7 +133,7 @@ func (suite *genConfigTestSuite) TestGenConfig() {
 
 	confFile.Close()
 
-	_, err = executeCommandGen(rootCmd, "gen-config", fmt.Sprintf("--config-file=%s", confFile.Name()), "--passphrase=123123123123123123123123", fmt.Sprintf("--output-file=%s", outFile), "--temp-path=/tmp")
+	_, err = executeCommandGen(rootCmd, "gen-config", fmt.Sprintf("--config-file=%s", confFile.Name()), "--passphrase=12312312312312312312312312312312", fmt.Sprintf("--output-file=%s", outFile), "--temp-path=/tmp")
 	suite.assert.NoError(err)
 
 	// Out file should exist
@@ -154,7 +154,7 @@ func (suite *genConfigTestSuite) TestGenConfigGet() {
 
 	confFile.Close()
 
-	_, err = executeCommandGen(rootCmd, "gen-config", fmt.Sprintf("--config-file=%s", confFile.Name()), "--passphrase=123123123123123123123123", fmt.Sprintf("--output-file=%s", outFile), "--temp-path=/tmp")
+	_, err = executeCommandGen(rootCmd, "gen-config", fmt.Sprintf("--config-file=%s", confFile.Name()), "--passphrase=12312312312312312312312312312312", fmt.Sprintf("--output-file=%s", outFile), "--temp-path=/tmp")
 	suite.assert.NoError(err)
 
 	// Out file should exist
@@ -162,7 +162,7 @@ func (suite *genConfigTestSuite) TestGenConfigGet() {
 	suite.assert.NoError(err)
 
 	// Gen-config should correctly set the temp path for the file_cache
-	path, err := executeCommandGen(rootCmd, "secure", "get", fmt.Sprintf("--config-file=%s", outFile), "--passphrase=123123123123123123123123", "--key=file_cache.path")
+	path, err := executeCommandGen(rootCmd, "secure", "get", fmt.Sprintf("--config-file=%s", outFile), "--passphrase=12312312312312312312312312312312", "--key=file_cache.path")
 	suite.assert.NoError(err)
 	suite.assert.Equal("Fetching scalar configuration\nfile_cache.path = /tmp\n", path)
 }

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -212,7 +212,7 @@ func parseConfig() error {
 			return fmt.Errorf("failed to read encrypted config file %s [%s]", options.ConfigFile, err.Error())
 		}
 
-		plainText, err := common.DecryptData(cipherText, []byte(options.PassPhrase))
+		plainText, err := common.DecryptData(cipherText, options.PassPhrase)
 		if err != nil {
 			return fmt.Errorf("failed to decrypt config file %s [%s]", options.ConfigFile, err.Error())
 		}
@@ -648,7 +648,7 @@ func init() {
 		"Encrypt auto generated config file for each container")
 
 	mountCmd.PersistentFlags().StringVar(&options.PassPhrase, "passphrase", "",
-		"Key to decrypt config file. Can also be specified by env-variable CLOUDFUSE_SECURE_CONFIG_PASSPHRASE.\nKey length shall be 16 (AES-128), 24 (AES-192), or 32 (AES-256) bytes in length.")
+		"Base64 encoded key to decrypt config file. Can also be specified by env-variable CLOUDFUSE_SECURE_CONFIG_PASSPHRASE.\n Decoded key length shall be 16 (AES-128), 24 (AES-192), or 32 (AES-256) bytes in length.")
 
 	mountCmd.PersistentFlags().String("log-type", "syslog", "Type of logger to be used by the system. Set to syslog by default. Allowed values are silent|syslog|base.")
 	config.BindPFlag("logging.type", mountCmd.PersistentFlags().Lookup("log-type"))

--- a/cmd/mount_all.go
+++ b/cmd/mount_all.go
@@ -395,7 +395,7 @@ func writeConfigFile(contConfigFile string) error {
 			return fmt.Errorf("failed to marshall yaml content")
 		}
 
-		cipherText, err := common.EncryptData(confStream, []byte(options.PassPhrase))
+		cipherText, err := common.EncryptData(confStream, opts.passphrase)
 		if err != nil {
 			return fmt.Errorf("failed to encrypt yaml content [%s]", err.Error())
 		}

--- a/cmd/secure_set.go
+++ b/cmd/secure_set.go
@@ -84,7 +84,7 @@ var setKeyCmd = &cobra.Command{
 			return fmt.Errorf("failed to marshal config [%s]", err.Error())
 		}
 
-		cipherText, err := common.EncryptData(confStream, []byte(secOpts.PassPhrase))
+		cipherText, err := common.EncryptData(confStream, secOpts.PassPhrase)
 		if err != nil {
 			return fmt.Errorf("failed to encrypt config [%s]", err.Error())
 		}

--- a/cmd/secure_test.go
+++ b/cmd/secure_test.go
@@ -121,7 +121,7 @@ func (suite *secureConfigTestSuite) TestSecureConfigEncrypt() {
 
 	confFile.Close()
 
-	_, err = executeCommandSecure(rootCmd, "secure", "encrypt", fmt.Sprintf("--config-file=%s", confFile.Name()), "--passphrase=123123123123123123123123", fmt.Sprintf("--output-file=%s", outFile.Name()))
+	_, err = executeCommandSecure(rootCmd, "secure", "encrypt", fmt.Sprintf("--config-file=%s", confFile.Name()), "--passphrase=12312312312312312312312312312312", fmt.Sprintf("--output-file=%s", outFile.Name()))
 	suite.assert.NoError(err)
 
 	// Config file should be deleted
@@ -142,7 +142,7 @@ func (suite *secureConfigTestSuite) TestSecureConfigEncryptNoOutfile() {
 
 	confFile.Close()
 
-	_, err = executeCommandSecure(rootCmd, "secure", "encrypt", fmt.Sprintf("--config-file=%s", confFile.Name()), "--passphrase=123123123123123123123123")
+	_, err = executeCommandSecure(rootCmd, "secure", "encrypt", fmt.Sprintf("--config-file=%s", confFile.Name()), "--passphrase=12312312312312312312312312312312")
 	suite.assert.NoError(err)
 
 	// Config file should be deleted
@@ -157,7 +157,7 @@ func (suite *secureConfigTestSuite) TestSecureConfigEncryptNoOutfile() {
 func (suite *secureConfigTestSuite) TestSecureConfigEncryptNotExistent() {
 	defer suite.cleanupTest()
 	confFile := "abcd.yaml"
-	_, err := executeCommandSecure(rootCmd, "secure", "encrypt", fmt.Sprintf("--config-file=%s", confFile), "--passphrase=123123123123123123123123")
+	_, err := executeCommandSecure(rootCmd, "secure", "encrypt", fmt.Sprintf("--config-file=%s", confFile), "--passphrase=12312312312312312312312312312312")
 	suite.assert.Error(err)
 }
 
@@ -215,14 +215,14 @@ func (suite *secureConfigTestSuite) TestSecureConfigDecrypt() {
 	confFile.Close()
 	outFile.Close()
 
-	_, err = executeCommandSecure(rootCmd, "secure", "encrypt", fmt.Sprintf("--config-file=%s", confFile.Name()), "--passphrase=123123123123123123123123", fmt.Sprintf("--output-file=%s", outFile.Name()))
+	_, err = executeCommandSecure(rootCmd, "secure", "encrypt", fmt.Sprintf("--config-file=%s", confFile.Name()), "--passphrase=12312312312312312312312312312312", fmt.Sprintf("--output-file=%s", outFile.Name()))
 	suite.assert.NoError(err)
 
 	// Config file should be deleted
 	_, err = os.Stat(confFile.Name())
 	suite.assert.Error(err)
 
-	_, err = executeCommandSecure(rootCmd, "secure", "decrypt", fmt.Sprintf("--config-file=%s", outFile.Name()), "--passphrase=123123123123123123123123", fmt.Sprintf("--output-file=./tmp.yaml"))
+	_, err = executeCommandSecure(rootCmd, "secure", "decrypt", fmt.Sprintf("--config-file=%s", outFile.Name()), "--passphrase=12312312312312312312312312312312", fmt.Sprintf("--output-file=./tmp.yaml"))
 	suite.assert.NoError(err)
 
 	data, err := os.ReadFile("./tmp.yaml")
@@ -246,7 +246,7 @@ func (suite *secureConfigTestSuite) TestSecureConfigDecryptNoOutputFile() {
 
 	confFile.Close()
 
-	_, err = executeCommandSecure(rootCmd, "secure", "encrypt", fmt.Sprintf("--config-file=%s", confFile.Name()), "--passphrase=123123123123123123123123")
+	_, err = executeCommandSecure(rootCmd, "secure", "encrypt", fmt.Sprintf("--config-file=%s", confFile.Name()), "--passphrase=12312312312312312312312312312312")
 	suite.assert.NoError(err)
 
 	// Config file should be deleted
@@ -257,7 +257,7 @@ func (suite *secureConfigTestSuite) TestSecureConfigDecryptNoOutputFile() {
 	_, err = os.Stat(outFile)
 	suite.assert.NoError(err)
 
-	_, err = executeCommandSecure(rootCmd, "secure", "decrypt", fmt.Sprintf("--config-file=%s", outFile), "--passphrase=123123123123123123123123")
+	_, err = executeCommandSecure(rootCmd, "secure", "decrypt", fmt.Sprintf("--config-file=%s", outFile), "--passphrase=12312312312312312312312312312312")
 	suite.assert.NoError(err)
 
 	// Config file should exist
@@ -308,10 +308,10 @@ func (suite *secureConfigTestSuite) TestSecureConfigGet() {
 	confFile.Close()
 	outFile.Close()
 
-	_, err = executeCommandSecure(rootCmd, "secure", "encrypt", fmt.Sprintf("--config-file=%s", confFile.Name()), "--passphrase=123123123123123123123123", fmt.Sprintf("--output-file=%s", outFile.Name()))
+	_, err = executeCommandSecure(rootCmd, "secure", "encrypt", fmt.Sprintf("--config-file=%s", confFile.Name()), "--passphrase=12312312312312312312312312312312", fmt.Sprintf("--output-file=%s", outFile.Name()))
 	suite.assert.NoError(err)
 
-	_, err = executeCommandSecure(rootCmd, "secure", "get", fmt.Sprintf("--config-file=%s", outFile.Name()), "--passphrase=123123123123123123123123", "--key=logging.level")
+	_, err = executeCommandSecure(rootCmd, "secure", "get", fmt.Sprintf("--config-file=%s", outFile.Name()), "--passphrase=12312312312312312312312312312312", "--key=logging.level")
 	suite.assert.NoError(err)
 }
 
@@ -329,10 +329,10 @@ func (suite *secureConfigTestSuite) TestSecureConfigGetInvalidKey() {
 	confFile.Close()
 	outFile.Close()
 
-	_, err = executeCommandSecure(rootCmd, "secure", "encrypt", fmt.Sprintf("--config-file=%s", confFile.Name()), "--passphrase=123123123123123123123123", fmt.Sprintf("--output-file=%s", outFile.Name()))
+	_, err = executeCommandSecure(rootCmd, "secure", "encrypt", fmt.Sprintf("--config-file=%s", confFile.Name()), "--passphrase=12312312312312312312312312312312", fmt.Sprintf("--output-file=%s", outFile.Name()))
 	suite.assert.NoError(err)
 
-	_, err = executeCommandSecure(rootCmd, "secure", "get", fmt.Sprintf("--config-file=%s", outFile.Name()), "--passphrase=123123123123123123123123", "--key=abcd.efg")
+	_, err = executeCommandSecure(rootCmd, "secure", "get", fmt.Sprintf("--config-file=%s", outFile.Name()), "--passphrase=12312312312312312312312312312312", "--key=abcd.efg")
 	suite.assert.Error(err)
 }
 
@@ -350,15 +350,15 @@ func (suite *secureConfigTestSuite) TestSecureConfigSet() {
 	confFile.Close()
 	outFile.Close()
 
-	_, err = executeCommandSecure(rootCmd, "secure", "encrypt", fmt.Sprintf("--config-file=%s", confFile.Name()), "--passphrase=123123123123123123123123", fmt.Sprintf("--output-file=%s", outFile.Name()))
+	_, err = executeCommandSecure(rootCmd, "secure", "encrypt", fmt.Sprintf("--config-file=%s", confFile.Name()), "--passphrase=12312312312312312312312312312312", fmt.Sprintf("--output-file=%s", outFile.Name()))
 	suite.assert.NoError(err)
 
-	_, err = executeCommandSecure(rootCmd, "secure", "get", fmt.Sprintf("--config-file=%s", outFile.Name()), "--passphrase=123123123123123123123123", "--key=logging.level")
+	_, err = executeCommandSecure(rootCmd, "secure", "get", fmt.Sprintf("--config-file=%s", outFile.Name()), "--passphrase=12312312312312312312312312312312", "--key=logging.level")
 	suite.assert.NoError(err)
 
-	_, err = executeCommandSecure(rootCmd, "secure", "set", fmt.Sprintf("--config-file=%s", outFile.Name()), "--passphrase=123123123123123123123123", "--key=logging.level", "--value=log_err")
+	_, err = executeCommandSecure(rootCmd, "secure", "set", fmt.Sprintf("--config-file=%s", outFile.Name()), "--passphrase=12312312312312312312312312312312", "--key=logging.level", "--value=log_err")
 	suite.assert.NoError(err)
 
-	_, err = executeCommandSecure(rootCmd, "secure", "get", fmt.Sprintf("--config-file=%s", outFile.Name()), "--passphrase=123123123123123123123123", "--key=logging.level")
+	_, err = executeCommandSecure(rootCmd, "secure", "get", fmt.Sprintf("--config-file=%s", outFile.Name()), "--passphrase=12312312312312312312312312312312", "--key=logging.level")
 	suite.assert.NoError(err)
 }

--- a/common/config/config_parser.go
+++ b/common/config/config_parser.go
@@ -133,7 +133,7 @@ func DecryptConfigFile(fileName string, passphrase string) error {
 		return fmt.Errorf("Encrypted config file is empty")
 	}
 
-	plainText, err := common.DecryptData(cipherText, []byte(passphrase))
+	plainText, err := common.DecryptData(cipherText, passphrase)
 	if err != nil {
 		return fmt.Errorf("Failed to decrypt config file [%s]", err.Error())
 	}

--- a/common/config/config_test.go
+++ b/common/config/config_test.go
@@ -464,12 +464,12 @@ func (suite *ConfigTestSuite) TestConfigFileDescryption() {
 	assert.NoError(err)
 	assert.NotNil(plaintext)
 
-	cipherText, err := common.EncryptData(plaintext, []byte("123123123123123123123123"))
+	cipherText, err := common.EncryptData(plaintext, "12312312312312312312312312312312")
 	assert.NoError(err)
 	err = os.WriteFile("test_enc.yaml", cipherText, 0644)
 	assert.NoError(err)
 
-	err = DecryptConfigFile("test_enc.yaml", "123123123123123123123123")
+	err = DecryptConfigFile("test_enc.yaml", "12312312312312312312312312312312")
 	assert.NoError(err)
 
 	_ = os.Remove("test.yaml")

--- a/common/util.go
+++ b/common/util.go
@@ -29,6 +29,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"os"
@@ -172,8 +173,13 @@ func NormalizeObjectName(name string) string {
 }
 
 // Encrypt given data using the key provided
-func EncryptData(plainData []byte, key []byte) ([]byte, error) {
-	block, err := aes.NewCipher(key)
+func EncryptData(plainData []byte, key string) ([]byte, error) {
+	binaryKey, err := base64.StdEncoding.DecodeString(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to base64 decode passphrase [%s]", err.Error())
+	}
+
+	block, err := aes.NewCipher(binaryKey)
 	if err != nil {
 		return nil, err
 	}
@@ -193,8 +199,13 @@ func EncryptData(plainData []byte, key []byte) ([]byte, error) {
 }
 
 // Decrypt given data using the key provided
-func DecryptData(cipherData []byte, key []byte) ([]byte, error) {
-	block, err := aes.NewCipher(key)
+func DecryptData(cipherData []byte, key string) ([]byte, error) {
+	binaryKey, err := base64.StdEncoding.DecodeString(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to base64 decode passphrase [%s]", err.Error())
+	}
+
+	block, err := aes.NewCipher(binaryKey)
 	if err != nil {
 		return nil, err
 	}

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -27,6 +27,7 @@ package common
 
 import (
 	"crypto/rand"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -84,7 +85,7 @@ func (suite *typesTestSuite) TestEncryptBadKey() {
 	data := make([]byte, 1024)
 	rand.Read(data)
 
-	_, err := EncryptData(data, key)
+	_, err := EncryptData(data, string(key))
 	suite.assert.Error(err)
 }
 
@@ -96,14 +97,49 @@ func (suite *typesTestSuite) TestDecryptBadKey() {
 	data := make([]byte, 1024)
 	rand.Read(data)
 
-	_, err := DecryptData(data, key)
+	_, err := DecryptData(data, string(key))
 	suite.assert.Error(err)
 }
 
-func (suite *typesTestSuite) TestEncryptDecrypt() {
+func (suite *typesTestSuite) TestEncryptDecrypt16() {
 	// Generate a random key
-	key := make([]byte, 16)
-	rand.Read(key)
+	binaryKey := make([]byte, 16)
+	rand.Read(binaryKey)
+	key := base64.StdEncoding.EncodeToString(binaryKey)
+
+	data := make([]byte, 1024)
+	rand.Read(data)
+
+	cipher, err := EncryptData(data, key)
+	suite.assert.NoError(err)
+
+	d, err := DecryptData(cipher, key)
+	suite.assert.NoError(err)
+	suite.assert.EqualValues(data, d)
+}
+
+func (suite *typesTestSuite) TestEncryptDecrypt24() {
+	// Generate a random key
+	binaryKey := make([]byte, 24)
+	rand.Read(binaryKey)
+	key := base64.StdEncoding.EncodeToString(binaryKey)
+
+	data := make([]byte, 1024)
+	rand.Read(data)
+
+	cipher, err := EncryptData(data, key)
+	suite.assert.NoError(err)
+
+	d, err := DecryptData(cipher, key)
+	suite.assert.NoError(err)
+	suite.assert.EqualValues(data, d)
+}
+
+func (suite *typesTestSuite) TestEncryptDecrypt32() {
+	// Generate a random key
+	binaryKey := make([]byte, 32)
+	rand.Read(binaryKey)
+	key := base64.StdEncoding.EncodeToString(binaryKey)
 
 	data := make([]byte, 1024)
 	rand.Read(data)


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief

The passphrase used for securing our config file should be base64 encoded since the cipher key can represent binary data. Before it was assumed the passphrase was the binary data, but this causes issues with non printable characters. Now the passphrase can represent all possible generated cipher keys.

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [x] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #