### PR TITLE
Use new SDDL option

### DIFF
--- a/cmd/health-monitor.go
+++ b/cmd/health-monitor.go
@@ -26,6 +26,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"path/filepath"
@@ -138,7 +139,7 @@ func validateHMonOptions() error {
 	}
 
 	if len(errMsg) != 0 {
-		return fmt.Errorf(errMsg)
+		return errors.New(errMsg)
 	}
 
 	return nil

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -727,5 +727,5 @@ func init() {
 
 func Destroy(message string) error {
 	_ = log.Destroy()
-	return fmt.Errorf(message)
+	return errors.New(message)
 }

--- a/component/azstorage/azauthmsi.go
+++ b/component/azstorage/azauthmsi.go
@@ -29,7 +29,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -90,7 +89,7 @@ func (azmsi *azAuthMSI) getTokenCredentialUsingCLI() (azcore.TokenCredential, er
 		if msg == "" {
 			msg = err.Error()
 		}
-		return nil, fmt.Errorf(msg)
+		return nil, errors.New(msg)
 	}
 
 	log.Info("azAuthMSI::getTokenCredentialUsingCLI : Successfully logged in using Azure CLI")

--- a/component/libfuse/libfuse2_handler.go
+++ b/component/libfuse/libfuse2_handler.go
@@ -341,7 +341,7 @@ func (cf *CgofuseFS) Statfs(path string, stat *fuse.Statfs_t) int {
 		stat.Namemax = attr.Namemax
 	} else {
 		var free, total, avail uint64
-		total = 400 * common.GbToBytes
+		total = common.TbToBytes
 		avail = total
 		free = total
 

--- a/component/libfuse/libfuse2_handler.go
+++ b/component/libfuse/libfuse2_handler.go
@@ -105,7 +105,6 @@ func (lf *Libfuse) initFuse() error {
 
 	// With WinFSP this will present all files as owned by the Authenticated Users group
 	if runtime.GOOS == "windows" {
-		// TODO: add SDDL file security option: https://github.com/rclone/rclone/issues/4717
 		// if uid & gid were not specified, pass -1 for both (which will cause WinFSP to look up the current user)
 		uid := int64(-1)
 		gid := int64(-1)
@@ -121,6 +120,10 @@ func (lf *Libfuse) initFuse() error {
 			lf.entryExpiration,
 			lf.attributeExpiration,
 			lf.negativeTimeout)
+
+		// Using SSDL file security option: https://github.com/rclone/rclone/issues/4717
+		// Enables everyone on system to have access to mount
+		options += ",FileSecurity=D:P(A;;FA;;;WD)"
 	}
 
 	// While reading a file let kernel do readahead for better perf
@@ -338,7 +341,7 @@ func (cf *CgofuseFS) Statfs(path string, stat *fuse.Statfs_t) int {
 		stat.Namemax = attr.Namemax
 	} else {
 		var free, total, avail uint64
-		total = common.TbToBytes
+		total = 400 * common.GbToBytes
 		avail = total
 		free = total
 


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief

All users on a Windows machine are now able to write to mounts by default on Windows. Previously, only the current user could write to the mount. 

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #