### PR TITLE
Fix misused IsCached calls in fileCache tests

### DIFF
--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -336,7 +336,10 @@ func (suite *fileCacheTestSuite) TestDeleteDir() {
 	// Delete the directory
 	err = suite.fileCache.DeleteDir(internal.DeleteDirOptions{Name: dir})
 	suite.assert.NoError(err)
-	suite.assert.False(suite.fileCache.policy.IsCached(dir)) // Directory should not be cached
+	// wait for asynchronous deletion
+	time.Sleep(time.Second)
+	// Directory should not be cached
+	suite.assert.NoDirExists(filepath.Join(suite.cache_path, dir))
 }
 
 func (suite *fileCacheTestSuite) TestStreamDirError() {
@@ -494,8 +497,9 @@ func (suite *fileCacheTestSuite) TestStreamDirMixed() {
 
 func (suite *fileCacheTestSuite) TestFileUsed() {
 	defer suite.cleanupTest()
-	suite.fileCache.FileUsed("temp")
-	suite.fileCache.policy.IsCached("temp")
+	err := suite.fileCache.FileUsed("temp")
+	suite.assert.NoError(err)
+	suite.assert.True(suite.fileCache.policy.IsCached(filepath.Join(suite.cache_path, "temp")))
 }
 
 // File cache does not have CreateDir Method implemented hence results are undefined here
@@ -555,17 +559,13 @@ func (suite *fileCacheTestSuite) TestRenameDir() {
 	}
 	// The file (and directory) is in the cache and storage (see TestCreateFileInDirCreateEmptyFile)
 
-	// Delete the directory
+	// Rename the directory
 	err = suite.fileCache.RenameDir(internal.RenameDirOptions{Src: src, Dst: dst})
 	suite.assert.NoError(err)
-	suite.assert.False(suite.fileCache.policy.IsCached(src)) // Directory should not be cached
 	// wait for asynchronous deletion
-	time.Sleep(1 * time.Second)
+	time.Sleep(time.Second)
 	// src directory should not exist in local filesystem
-	fInfo, err := os.Stat(filepath.Join(suite.cache_path, src))
-	suite.assert.Nil(fInfo)
-	suite.assert.Error(err)
-	suite.assert.True(os.IsNotExist(err))
+	suite.assert.NoDirExists(filepath.Join(suite.cache_path, src))
 	// dst directory should exist and have contents from src
 	dstEntries, err := os.ReadDir(filepath.Join(suite.cache_path, dst))
 	suite.assert.NoError(err)
@@ -829,15 +829,10 @@ func (suite *fileCacheTestSuite) TestCloseFile() {
 		time.Sleep(time.Second)
 		_, err = os.Stat(filepath.Join(suite.cache_path, path))
 	}
-	suite.assert.True(os.IsNotExist(err))
-
-	suite.assert.False(suite.fileCache.policy.IsCached(path)) // File should be invalidated
 	// File should not be in cache
-	_, err = os.Stat(filepath.Join(suite.cache_path, path))
-	suite.assert.True(os.IsNotExist(err))
+	suite.assert.NoFileExists(filepath.Join(suite.cache_path, path))
 	// File should be in cloud storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(filepath.Join(suite.fake_storage_path, path))
 }
 
 func (suite *fileCacheTestSuite) TestCloseFileTimeout() {
@@ -856,14 +851,11 @@ func (suite *fileCacheTestSuite) TestCloseFileTimeout() {
 	// CloseFile
 	err := suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: handle})
 	suite.assert.NoError(err)
-	suite.assert.False(suite.fileCache.policy.IsCached(path)) // File should be invalidated
 
 	// File should be in cache
-	_, err = os.Stat(filepath.Join(suite.cache_path, path))
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(filepath.Join(suite.cache_path, path))
 	// File should be in cloud storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(filepath.Join(suite.fake_storage_path, path))
 
 	// loop until file does not exist - done due to async nature of eviction
 	_, err = os.Stat(filepath.Join(suite.cache_path, path))
@@ -873,9 +865,9 @@ func (suite *fileCacheTestSuite) TestCloseFileTimeout() {
 	}
 
 	// File should not be in cache
-	_, err = os.Stat(filepath.Join(suite.cache_path, path))
-	suite.assert.True(os.IsNotExist(err))
-
+	suite.assert.NoFileExists(filepath.Join(suite.cache_path, path))
+	// File should be invalidated
+	suite.assert.False(suite.fileCache.policy.IsCached(filepath.Join(suite.cache_path, path)))
 	// File should be in cloud storage
 	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
 	suite.assert.True(err == nil || os.IsExist(err))

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -564,6 +564,8 @@ func (suite *fileCacheTestSuite) TestRenameDir() {
 	suite.assert.NoError(err)
 	// wait for asynchronous deletion
 	time.Sleep(1 * time.Second)
+	// src directory should not be cached
+	suite.assert.False(suite.fileCache.policy.IsCached(filepath.Join(suite.cache_path, src)))
 	// src directory should not exist in local filesystem
 	fInfo, err := os.Stat(filepath.Join(suite.cache_path, src))
 	suite.assert.Nil(fInfo)

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -564,10 +564,6 @@ func (suite *fileCacheTestSuite) TestRenameDir() {
 	suite.assert.NoError(err)
 	// wait for asynchronous deletion
 	time.Sleep(1 * time.Second)
-	// files in src directory should not be cached
-	for i := 0; i < 5; i++ {
-		suite.assert.False(suite.fileCache.policy.IsCached(filepath.Join(suite.cache_path, path+strconv.Itoa(i))))
-	}
 	// src directory should not exist in local filesystem
 	fInfo, err := os.Stat(filepath.Join(suite.cache_path, src))
 	suite.assert.Nil(fInfo)

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -564,8 +564,10 @@ func (suite *fileCacheTestSuite) TestRenameDir() {
 	suite.assert.NoError(err)
 	// wait for asynchronous deletion
 	time.Sleep(1 * time.Second)
-	// src directory should not be cached
-	suite.assert.False(suite.fileCache.policy.IsCached(filepath.Join(suite.cache_path, src)))
+	// files in src directory should not be cached
+	for i := 0; i < 5; i++ {
+		suite.assert.False(suite.fileCache.policy.IsCached(filepath.Join(suite.cache_path, path+strconv.Itoa(i))))
+	}
 	// src directory should not exist in local filesystem
 	fInfo, err := os.Stat(filepath.Join(suite.cache_path, src))
 	suite.assert.Nil(fInfo)

--- a/component/file_cache/lru_policy.go
+++ b/component/file_cache/lru_policy.go
@@ -189,6 +189,8 @@ func (p *lruPolicy) CachePurge(name string) {
 	p.deleteEvent <- name
 }
 
+// Due to a race condition, this may return a false positive,
+// but it will not return a false negative.
 func (p *lruPolicy) IsCached(name string) bool {
 	log.Trace("lruPolicy::IsCached : %s", name)
 

--- a/component/file_cache/lru_policy.go
+++ b/component/file_cache/lru_policy.go
@@ -310,12 +310,10 @@ func (p *lruPolicy) removeNode(name string) {
 
 	var node *lruNode = nil
 
-	val, found := p.nodeMap.Load(name)
+	val, found := p.nodeMap.LoadAndDelete(name)
 	if !found || val == nil {
 		return
 	}
-
-	p.nodeMap.Delete(name)
 
 	p.Lock()
 	defer p.Unlock()


### PR DESCRIPTION
### Describe your changes in brief

* `policy.IsCached` needs to be called with a full local path, not an object name.
* `IsCached` was returning false incorrectly because it was being given the wrong path, so fixing that also involved fixing some tests to actually do what was intended.
* Directories do not have their own entries in the cache policy, so calling `IsCached` on a directory will return false even when the directory exists.
* There is a race condition in `TestCloseFile` and `TestRenameDir` that only comes up when a file is deleted right after being closed. The race condition makes `IsCached` return inconsistent results (sometimes it gives a false positive). The race condition is harmless because we only trust negative responses from IsCached. When it returns true, it's basically ignored. I just dropped the IsCached asserts in those cases.

### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Checklist

- [ ] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #