### PR TITLE
Use assert instead of stat in test file and directory existence

### DIFF
--- a/cmd/config-gen_test.go
+++ b/cmd/config-gen_test.go
@@ -96,7 +96,7 @@ foreground: false
 read-only: true
 allow-other: true
 
-logging:  
+logging:
   type: base
   level: log_debug
   file-path: /home/cloudfuse.log
@@ -113,7 +113,7 @@ components:
 libfuse:
   attribute-expiration-sec: 1
   entry-expiration-sec: 1
-  
+
 file_cache:
   path: { 0 }
   timeout-sec: 180
@@ -137,8 +137,7 @@ func (suite *genConfigTestSuite) TestGenConfig() {
 	suite.assert.NoError(err)
 
 	// Out file should exist
-	_, err = os.Stat(outFile)
-	suite.assert.NoError(err)
+	suite.assert.FileExists(outFile)
 }
 
 func (suite *genConfigTestSuite) TestGenConfigGet() {
@@ -158,8 +157,7 @@ func (suite *genConfigTestSuite) TestGenConfigGet() {
 	suite.assert.NoError(err)
 
 	// Out file should exist
-	_, err = os.Stat(outFile)
-	suite.assert.NoError(err)
+	suite.assert.FileExists(outFile)
 
 	// Gen-config should correctly set the temp path for the file_cache
 	path, err := executeCommandGen(rootCmd, "secure", "get", fmt.Sprintf("--config-file=%s", outFile), "--passphrase=12312312312312312312312312312312", "--key=file_cache.path")

--- a/cmd/secure_test.go
+++ b/cmd/secure_test.go
@@ -90,7 +90,7 @@ foreground: false
 read-only: true
 allow-other: true
 
-logging:  
+logging:
   type: base
   level: log_debug
   file-path: /home/cloudfuse.log
@@ -125,8 +125,7 @@ func (suite *secureConfigTestSuite) TestSecureConfigEncrypt() {
 	suite.assert.NoError(err)
 
 	// Config file should be deleted
-	_, err = os.Stat(confFile.Name())
-	suite.assert.Error(err)
+	suite.assert.NoFileExists(confFile.Name())
 }
 
 func (suite *secureConfigTestSuite) TestSecureConfigEncryptNoOutfile() {
@@ -146,12 +145,10 @@ func (suite *secureConfigTestSuite) TestSecureConfigEncryptNoOutfile() {
 	suite.assert.NoError(err)
 
 	// Config file should be deleted
-	_, err = os.Stat(confFile.Name())
-	suite.assert.Error(err)
+	suite.assert.NoFileExists(confFile.Name())
 
 	// Outfile should exist with proper extension
-	_, err = os.Stat(outFile)
-	suite.assert.NoError(err)
+	suite.assert.FileExists(outFile)
 }
 
 func (suite *secureConfigTestSuite) TestSecureConfigEncryptNotExistent() {
@@ -219,8 +216,7 @@ func (suite *secureConfigTestSuite) TestSecureConfigDecrypt() {
 	suite.assert.NoError(err)
 
 	// Config file should be deleted
-	_, err = os.Stat(confFile.Name())
-	suite.assert.Error(err)
+	suite.assert.NoFileExists(confFile.Name())
 
 	_, err = executeCommandSecure(rootCmd, "secure", "decrypt", fmt.Sprintf("--config-file=%s", outFile.Name()), "--passphrase=12312312312312312312312312312312", fmt.Sprintf("--output-file=./tmp.yaml"))
 	suite.assert.NoError(err)
@@ -250,23 +246,19 @@ func (suite *secureConfigTestSuite) TestSecureConfigDecryptNoOutputFile() {
 	suite.assert.NoError(err)
 
 	// Config file should be deleted
-	_, err = os.Stat(confFile.Name())
-	suite.assert.Error(err)
+	suite.assert.NoFileExists(confFile.Name())
 
 	// Encrypted file should exist
-	_, err = os.Stat(outFile)
-	suite.assert.NoError(err)
+	suite.assert.FileExists(outFile)
 
 	_, err = executeCommandSecure(rootCmd, "secure", "decrypt", fmt.Sprintf("--config-file=%s", outFile), "--passphrase=12312312312312312312312312312312")
 	suite.assert.NoError(err)
 
 	// Config file should exist
-	_, err = os.Stat(confFile.Name())
-	suite.assert.NoError(err)
+	suite.assert.FileExists(confFile.Name())
 
 	// Encrypted file should be deleted
-	_, err = os.Stat(outFile)
-	suite.assert.Error(err)
+	suite.assert.NoFileExists(outFile)
 
 	data, err := os.ReadFile(confFile.Name())
 	suite.assert.NoError(err)

--- a/component/file_cache/file_cache_linux_test.go
+++ b/component/file_cache/file_cache_linux_test.go
@@ -124,8 +124,7 @@ func (suite *fileCacheLinuxTestSuite) TestChmodNotInCache() {
 	suite.assert.True(os.IsNotExist(err))
 
 	// Path should be in fake storage
-	_, err = os.Stat(suite.fake_storage_path + "/" + path)
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(suite.fake_storage_path + "/" + path)
 
 	// Chmod
 	err = suite.fileCache.Chmod(internal.ChmodOptions{Name: path, Mode: os.FileMode(0666)})
@@ -218,8 +217,7 @@ func (suite *fileCacheLinuxTestSuite) TestChownNotInCache() {
 	suite.assert.True(os.IsNotExist(err))
 
 	// Path should be in fake storage
-	_, err = os.Stat(suite.fake_storage_path + "/" + path)
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(suite.fake_storage_path + "/" + path)
 
 	// Chown
 	owner := os.Getuid()
@@ -246,11 +244,9 @@ func (suite *fileCacheLinuxTestSuite) TestChownInCache() {
 	suite.assert.NoError(err)
 
 	// Path should be in the file cache
-	_, err = os.Stat(suite.cache_path + "/" + path)
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(suite.cache_path + "/" + path)
 	// Path should be in fake storage
-	_, err = os.Stat(suite.fake_storage_path + "/" + path)
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(suite.fake_storage_path + "/" + path)
 
 	// Chown
 	owner := os.Getuid()
@@ -296,8 +292,7 @@ func (suite *fileCacheLinuxTestSuite) TestChownCase2() {
 	suite.assert.EqualValues(oldOwner, stat.Uid)
 	suite.assert.EqualValues(oldGroup, stat.Gid)
 	// Path should not be in fake storage
-	_, err = os.Stat(suite.fake_storage_path + "/" + path)
-	suite.assert.True(os.IsNotExist(err))
+	suite.assert.NoFileExists(suite.fake_storage_path + "/" + path)
 }
 
 // In order for 'go test' to run this suite, we need to create

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -346,11 +346,9 @@ func (suite *fileCacheTestSuite) TestCreateDir() {
 	suite.assert.NoError(err)
 
 	// Path should not be added to the file cache
-	_, err = os.Stat(filepath.Join(suite.cache_path, path))
-	suite.assert.True(os.IsNotExist(err))
+	suite.assert.NoDirExists(filepath.Join(suite.cache_path, path))
 	// Path should be in fake storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.DirExists(filepath.Join(suite.fake_storage_path, path))
 }
 
 func (suite *fileCacheTestSuite) TestDeleteDir() {
@@ -607,10 +605,7 @@ func (suite *fileCacheTestSuite) TestRenameDir() {
 	// wait for asynchronous deletion
 	time.Sleep(1 * time.Second)
 	// src directory should not exist in local filesystem
-	fInfo, err := os.Stat(filepath.Join(suite.cache_path, src))
-	suite.assert.Nil(fInfo)
-	suite.assert.Error(err)
-	suite.assert.True(os.IsNotExist(err))
+	suite.assert.NoDirExists(filepath.Join(suite.cache_path, src))
 	// dst directory should exist and have contents from src
 	dstEntries, err := os.ReadDir(filepath.Join(suite.cache_path, dst))
 	suite.assert.NoError(err)
@@ -630,11 +625,9 @@ func (suite *fileCacheTestSuite) TestCreateFile() {
 	suite.assert.True(f.Dirty()) // Handle should be dirty since it was not created in cloud storage
 
 	// Path should be added to the file cache
-	_, err = os.Stat(filepath.Join(suite.cache_path, path))
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(filepath.Join(suite.cache_path, path))
 	// Path should not be in fake storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
-	suite.assert.True(os.IsNotExist(err))
+	suite.assert.NoFileExists(filepath.Join(suite.fake_storage_path, path))
 }
 
 func (suite *fileCacheTestSuite) TestCreateFileWithNoPerm() {
@@ -648,11 +641,9 @@ func (suite *fileCacheTestSuite) TestCreateFileWithNoPerm() {
 		suite.assert.True(f.Dirty()) // Handle should be dirty since it was not created in storage
 
 		// Path should be added to the file cache
-		_, err = os.Stat(suite.cache_path + "/" + path)
-		suite.assert.True(err == nil || os.IsExist(err))
+		suite.assert.FileExists(suite.cache_path + "/" + path)
 		// Path should not be in fake storage
-		_, err = os.Stat(suite.fake_storage_path + "/" + path)
-		suite.assert.True(os.IsNotExist(err))
+		suite.assert.NoFileExists(suite.fake_storage_path + "/" + path)
 		err = suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: f})
 		suite.assert.NoError(err)
 		info, _ := os.Stat(suite.cache_path + "/" + path)
@@ -667,11 +658,9 @@ func (suite *fileCacheTestSuite) TestCreateFileWithNoPerm() {
 		suite.assert.True(f.Dirty()) // Handle should be dirty since it was not created in storage
 
 		// Path should be added to the file cache
-		_, err = os.Stat(suite.cache_path + "/" + path)
-		suite.assert.True(err == nil || os.IsExist(err))
+		suite.assert.FileExists(suite.cache_path + "/" + path)
 		// Path should not be in fake storage
-		_, err = os.Stat(suite.fake_storage_path + "/" + path)
-		suite.assert.True(os.IsNotExist(err))
+		suite.assert.NoFileExists(suite.fake_storage_path + "/" + path)
 		err = suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: f})
 		suite.assert.NoError(err)
 		info, _ := os.Stat(suite.cache_path + "/" + path)
@@ -692,11 +681,9 @@ func (suite *fileCacheTestSuite) TestCreateFileWithWritePerm() {
 		os.Chmod(suite.cache_path+"/"+path, 0666)
 
 		// Path should be added to the file cache
-		_, err = os.Stat(suite.cache_path + "/" + path)
-		suite.assert.True(err == nil || os.IsExist(err))
+		suite.assert.FileExists(suite.cache_path + "/" + path)
 		// Path should not be in fake storage
-		_, err = os.Stat(suite.fake_storage_path + "/" + path)
-		suite.assert.True(os.IsNotExist(err))
+		suite.assert.NoFileExists(suite.fake_storage_path + "/" + path)
 		err = suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: f})
 		suite.assert.NoError(err)
 		info, _ := os.Stat(suite.cache_path + "/" + path)
@@ -713,11 +700,9 @@ func (suite *fileCacheTestSuite) TestCreateFileWithWritePerm() {
 		os.Chmod(suite.cache_path+"/"+path, 0331)
 
 		// Path should be added to the file cache
-		_, err = os.Stat(suite.cache_path + "/" + path)
-		suite.assert.True(err == nil || os.IsExist(err))
+		suite.assert.FileExists(suite.cache_path + "/" + path)
 		// Path should not be in fake storage
-		_, err = os.Stat(suite.fake_storage_path + "/" + path)
-		suite.assert.True(os.IsNotExist(err))
+		suite.assert.NoFileExists(suite.fake_storage_path + "/" + path)
 		err = suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: f})
 		suite.assert.NoError(err)
 		info, _ := os.Stat(suite.cache_path + "/" + path)
@@ -736,13 +721,10 @@ func (suite *fileCacheTestSuite) TestCreateFileInDir() {
 	suite.assert.True(f.Dirty()) // Handle should be dirty since it was not created in cloud storage
 
 	// Path should be added to the file cache, including directory
-	_, err = os.Stat(filepath.Join(suite.cache_path, dir))
-	suite.assert.True(err == nil || os.IsExist(err))
-	_, err = os.Stat(filepath.Join(suite.cache_path, path))
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.DirExists(filepath.Join(suite.cache_path, dir))
+	suite.assert.FileExists(filepath.Join(suite.cache_path, path))
 	// Path should not be in fake storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
-	suite.assert.True(os.IsNotExist(err))
+	suite.assert.NoFileExists(filepath.Join(suite.fake_storage_path, path))
 }
 
 func (suite *fileCacheTestSuite) TestCreateFileCreateEmptyFile() {
@@ -760,11 +742,9 @@ func (suite *fileCacheTestSuite) TestCreateFileCreateEmptyFile() {
 	suite.assert.False(f.Dirty()) // Handle should not be dirty since it was written to storage
 
 	// Path should be added to the file cache
-	_, err = os.Stat(filepath.Join(suite.cache_path, path))
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(filepath.Join(suite.cache_path, path))
 	// Path should be in fake storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(filepath.Join(suite.fake_storage_path, path))
 }
 
 func (suite *fileCacheTestSuite) TestCreateFileInDirCreateEmptyFile() {
@@ -783,15 +763,11 @@ func (suite *fileCacheTestSuite) TestCreateFileInDirCreateEmptyFile() {
 	suite.assert.False(f.Dirty()) // Handle should be dirty since it was not created in cloud storage
 
 	// Path should be added to the file cache, including directory
-	_, err = os.Stat(filepath.Join(suite.cache_path, dir))
-	suite.assert.True(err == nil || os.IsExist(err))
-	_, err = os.Stat(filepath.Join(suite.cache_path, path))
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.DirExists(filepath.Join(suite.cache_path, dir))
+	suite.assert.FileExists(filepath.Join(suite.cache_path, path))
 	// Path should be in fake storage, including directory
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, dir))
-	suite.assert.True(err == nil || os.IsExist(err))
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.DirExists(filepath.Join(suite.fake_storage_path, dir))
+	suite.assert.FileExists(filepath.Join(suite.fake_storage_path, path))
 }
 
 func (suite *fileCacheTestSuite) TestSyncFile() {
@@ -819,8 +795,7 @@ func (suite *fileCacheTestSuite) TestSyncFile() {
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: handle})
 
 	// Path should not be in file cache
-	_, err = os.Stat(filepath.Join(suite.cache_path, path))
-	suite.assert.True(os.IsNotExist(err))
+	suite.assert.NoFileExists(filepath.Join(suite.cache_path, path))
 
 	path = "file.fsync"
 	suite.fileCache.syncToFlush = true
@@ -832,8 +807,7 @@ func (suite *fileCacheTestSuite) TestSyncFile() {
 	err = suite.fileCache.SyncFile(internal.SyncFileOptions{Handle: handle})
 	suite.assert.NoError(err)
 	suite.assert.False(handle.Dirty())
-	_, err = os.Stat(suite.fake_storage_path + "/" + path)
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(suite.fake_storage_path + "/" + path)
 
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: handle})
 }
@@ -851,11 +825,9 @@ func (suite *fileCacheTestSuite) TestDeleteFile() {
 	suite.assert.NoError(err)
 
 	// Path should not be in file cache
-	_, err = os.Stat(filepath.Join(suite.cache_path, path))
-	suite.assert.True(os.IsNotExist(err))
+	suite.assert.NoFileExists(filepath.Join(suite.cache_path, path))
 	// Path should not be in fake storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
-	suite.assert.True(os.IsNotExist(err))
+	suite.assert.NoFileExists(filepath.Join(suite.fake_storage_path, path))
 }
 
 // Case 2 Test cover when the file does not exist in cloud storage but it exists in the local cache.
@@ -871,11 +843,9 @@ func (suite *fileCacheTestSuite) TestDeleteFileCase2() {
 	suite.assert.Equal(syscall.EIO, err)
 
 	// Path should not be in local cache (since we failed the operation)
-	_, err = os.Stat(filepath.Join(suite.cache_path, path))
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(filepath.Join(suite.cache_path, path))
 	// Path should not be in fake storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
-	suite.assert.True(os.IsNotExist(err))
+	suite.assert.NoFileExists(filepath.Join(suite.fake_storage_path, path))
 }
 
 func (suite *fileCacheTestSuite) TestDeleteFileError() {
@@ -917,8 +887,7 @@ func (suite *fileCacheTestSuite) TestOpenFileNotInCache() {
 	suite.assert.False(handle.Dirty())
 
 	// File should exist in cache
-	_, err = os.Stat(filepath.Join(suite.cache_path, path))
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(filepath.Join(suite.cache_path, path))
 }
 
 func (suite *fileCacheTestSuite) TestOpenFileInCache() {
@@ -937,8 +906,7 @@ func (suite *fileCacheTestSuite) TestOpenFileInCache() {
 	suite.assert.False(handle.Dirty())
 
 	// File should exist in cache
-	_, err = os.Stat(filepath.Join(suite.cache_path, path))
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(filepath.Join(suite.cache_path, path))
 }
 
 // Tests for GetProperties in OpenFile should be done in E2E tests
@@ -965,11 +933,9 @@ func (suite *fileCacheTestSuite) TestCloseFile() {
 	suite.assert.True(os.IsNotExist(err))
 
 	// File should not be in cache
-	_, err = os.Stat(filepath.Join(suite.cache_path, path))
-	suite.assert.True(os.IsNotExist(err))
+	suite.assert.NoFileExists(filepath.Join(suite.cache_path, path))
 	// File should be in cloud storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(filepath.Join(suite.fake_storage_path, path))
 }
 
 func (suite *fileCacheTestSuite) TestCloseFileTimeout() {
@@ -990,11 +956,9 @@ func (suite *fileCacheTestSuite) TestCloseFileTimeout() {
 	suite.assert.NoError(err)
 
 	// File should be in cache
-	_, err = os.Stat(filepath.Join(suite.cache_path, path))
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(filepath.Join(suite.cache_path, path))
 	// File should be in cloud storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(filepath.Join(suite.fake_storage_path, path))
 
 	// loop until file does not exist - done due to async nature of eviction
 	_, err = os.Stat(filepath.Join(suite.cache_path, path))
@@ -1004,13 +968,11 @@ func (suite *fileCacheTestSuite) TestCloseFileTimeout() {
 	}
 
 	// File should not be in cache
-	_, err = os.Stat(filepath.Join(suite.cache_path, path))
-	suite.assert.True(os.IsNotExist(err))
+	suite.assert.NoFileExists(filepath.Join(suite.cache_path, path))
 	// File should be invalidated
 	suite.assert.False(suite.fileCache.policy.IsCached(filepath.Join(suite.cache_path, path)))
 	// File should be in cloud storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(filepath.Join(suite.fake_storage_path, path))
 }
 
 func (suite *fileCacheTestSuite) TestOpenCloseHandleCount() {
@@ -1165,17 +1127,15 @@ func (suite *fileCacheTestSuite) TestFlushFileEmpty() {
 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
 
 	// Path should not be in fake storage
-	_, err := os.Stat(filepath.Join(suite.fake_storage_path, file))
-	suite.assert.True(os.IsNotExist(err))
+	suite.assert.NoFileExists(filepath.Join(suite.fake_storage_path, file))
 
 	// Flush the Empty File
-	err = suite.fileCache.FlushFile(internal.FlushFileOptions{Handle: handle})
+	err := suite.fileCache.FlushFile(internal.FlushFileOptions{Handle: handle})
 	suite.assert.NoError(err)
 	suite.assert.False(handle.Dirty())
 
 	// Path should be in fake storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, file))
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(filepath.Join(suite.fake_storage_path, file))
 }
 
 func (suite *fileCacheTestSuite) TestFlushFile() {
@@ -1188,17 +1148,15 @@ func (suite *fileCacheTestSuite) TestFlushFile() {
 	suite.fileCache.WriteFile(internal.WriteFileOptions{Handle: handle, Offset: 0, Data: data})
 
 	// Path should not be in fake storage
-	_, err := os.Stat(filepath.Join(suite.fake_storage_path, file))
-	suite.assert.True(os.IsNotExist(err))
+	suite.assert.NoFileExists(filepath.Join(suite.fake_storage_path, file))
 
 	// Flush the Empty File
-	err = suite.fileCache.FlushFile(internal.FlushFileOptions{Handle: handle})
+	err := suite.fileCache.FlushFile(internal.FlushFileOptions{Handle: handle})
 	suite.assert.NoError(err)
 	suite.assert.False(handle.Dirty())
 
 	// Path should be in fake storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, file))
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(filepath.Join(suite.fake_storage_path, file))
 	// Check that fake_storage updated with data
 	d, _ := os.ReadFile(filepath.Join(suite.fake_storage_path, file))
 	suite.assert.EqualValues(data, d)
@@ -1337,18 +1295,15 @@ func (suite *fileCacheTestSuite) TestRenameFileNotInCache() {
 	suite.assert.True(os.IsNotExist(err))
 
 	// Path should be in fake storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, src))
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(filepath.Join(suite.fake_storage_path, src))
 
 	// RenameFile
 	err = suite.fileCache.RenameFile(internal.RenameFileOptions{Src: src, Dst: dst})
 	suite.assert.NoError(err)
 
 	// Path in fake storage should be updated
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, src)) // Src does not exist
-	suite.assert.True(os.IsNotExist(err))
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, dst)) // Dst does exist
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.NoFileExists(filepath.Join(suite.fake_storage_path, src)) // Src does not exist
+	suite.assert.FileExists(filepath.Join(suite.fake_storage_path, dst))   // Dst does exist
 }
 
 func (suite *fileCacheTestSuite) TestRenameFileInCache() {
@@ -1364,24 +1319,18 @@ func (suite *fileCacheTestSuite) TestRenameFileInCache() {
 	suite.assert.NoError(err)
 
 	// Path should be in the file cache
-	_, err = os.Stat(filepath.Join(suite.cache_path, src))
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(filepath.Join(suite.cache_path, src))
 	// Path should be in fake storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, src))
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(filepath.Join(suite.fake_storage_path, src))
 
 	// RenameFile
 	err = suite.fileCache.RenameFile(internal.RenameFileOptions{Src: src, Dst: dst})
 	suite.assert.NoError(err)
 	// Path in fake storage and file cache should be updated
-	_, err = os.Stat(filepath.Join(suite.cache_path, src)) // Src does not exist
-	suite.assert.True(os.IsNotExist(err))
-	_, err = os.Stat(filepath.Join(suite.cache_path, dst)) // Dst shall exists in cache
-	suite.assert.True(err == nil || os.IsExist(err))
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, src)) // Src does not exist
-	suite.assert.True(os.IsNotExist(err))
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, dst)) // Dst does exist
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.NoFileExists(filepath.Join(suite.cache_path, src))        // Src does not exist
+	suite.assert.FileExists(filepath.Join(suite.cache_path, dst))          // Dst shall exists in cache
+	suite.assert.NoFileExists(filepath.Join(suite.fake_storage_path, src)) // Src does not exist
+	suite.assert.FileExists(filepath.Join(suite.fake_storage_path, dst))   // Dst does exist
 
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: openHandle})
 }
@@ -1398,14 +1347,11 @@ func (suite *fileCacheTestSuite) TestRenameFileCase2() {
 	suite.assert.Equal(syscall.EIO, err)
 
 	// Src should be in local cache (since we failed the operation)
-	_, err = os.Stat(filepath.Join(suite.cache_path, src))
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(filepath.Join(suite.cache_path, src))
 	// Src should not be in fake storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, src))
-	suite.assert.True(os.IsNotExist(err))
+	suite.assert.NoFileExists(filepath.Join(suite.fake_storage_path, src))
 	// Dst should not be in fake storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, dst))
-	suite.assert.True(os.IsNotExist(err))
+	suite.assert.NoFileExists(filepath.Join(suite.fake_storage_path, dst))
 }
 
 func (suite *fileCacheTestSuite) TestRenameFileAndCacheCleanup() {
@@ -1423,34 +1369,26 @@ func (suite *fileCacheTestSuite) TestRenameFileAndCacheCleanup() {
 	openHandle, _ := suite.fileCache.OpenFile(internal.OpenFileOptions{Name: src, Mode: 0666})
 
 	// Path should be in the file cache
-	_, err := os.Stat(suite.cache_path + "/" + src)
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(suite.cache_path + "/" + src)
 	// Path should be in fake storage
-	_, err = os.Stat(suite.fake_storage_path + "/" + src)
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(suite.fake_storage_path + "/" + src)
 
 	// RenameFile
-	err = suite.fileCache.RenameFile(internal.RenameFileOptions{Src: src, Dst: dst})
+	err := suite.fileCache.RenameFile(internal.RenameFileOptions{Src: src, Dst: dst})
 	suite.assert.NoError(err)
 	// Path in fake storage and file cache should be updated
-	_, err = os.Stat(suite.cache_path + "/" + src) // Src does not exist
-	suite.assert.True(os.IsNotExist(err))
-	_, err = os.Stat(suite.cache_path + "/" + dst) // Dst shall exists in cache
-	suite.assert.True(err == nil || os.IsExist(err))
-	_, err = os.Stat(suite.fake_storage_path + "/" + src) // Src does not exist
-	suite.assert.True(os.IsNotExist(err))
-	_, err = os.Stat(suite.fake_storage_path + "/" + dst) // Dst does exist
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.NoFileExists(suite.cache_path + "/" + src)        // Src does not exist
+	suite.assert.FileExists(suite.cache_path + "/" + dst)          // Dst shall exists in cache
+	suite.assert.NoFileExists(suite.fake_storage_path + "/" + src) // Src does not exist
+	suite.assert.FileExists(suite.fake_storage_path + "/" + dst)   // Dst does exist
 
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: openHandle})
 
-	time.Sleep(5 * time.Second)                    // Check once before the cache cleanup that file exists
-	_, err = os.Stat(suite.cache_path + "/" + dst) // Dst shall exists in cache
-	suite.assert.True(err == nil || os.IsExist(err))
+	time.Sleep(5 * time.Second)                           // Check once before the cache cleanup that file exists
+	suite.assert.FileExists(suite.cache_path + "/" + dst) // Dst shall exists in cache
 
-	time.Sleep(8 * time.Second)                    // Wait for the cache cleanup to occur
-	_, err = os.Stat(suite.cache_path + "/" + dst) // Dst shall not exists in cache
-	suite.assert.True(err == nil || os.IsNotExist(err))
+	time.Sleep(8 * time.Second)                           // Wait for the cache cleanup to occur
+	suite.assert.FileExists(suite.cache_path + "/" + dst) // Dst shall not exists in cache
 }
 
 func (suite *fileCacheTestSuite) TestRenameFileAndCacheCleanupWithNoTimeout() {
@@ -1468,30 +1406,23 @@ func (suite *fileCacheTestSuite) TestRenameFileAndCacheCleanupWithNoTimeout() {
 	openHandle, _ := suite.fileCache.OpenFile(internal.OpenFileOptions{Name: src, Mode: 0666})
 
 	// Path should be in the file cache
-	_, err := os.Stat(suite.cache_path + "/" + src)
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(suite.cache_path + "/" + src)
 	// Path should be in fake storage
-	_, err = os.Stat(suite.fake_storage_path + "/" + src)
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(suite.fake_storage_path + "/" + src)
 
 	// RenameFile
-	err = suite.fileCache.RenameFile(internal.RenameFileOptions{Src: src, Dst: dst})
+	err := suite.fileCache.RenameFile(internal.RenameFileOptions{Src: src, Dst: dst})
 	suite.assert.NoError(err)
 	// Path in fake storage and file cache should be updated
-	_, err = os.Stat(suite.cache_path + "/" + src) // Src does not exist
-	suite.assert.True(os.IsNotExist(err))
-	_, err = os.Stat(suite.cache_path + "/" + dst) // Dst shall exists in cache
-	suite.assert.True(err == nil || os.IsExist(err))
-	_, err = os.Stat(suite.fake_storage_path + "/" + src) // Src does not exist
-	suite.assert.True(os.IsNotExist(err))
-	_, err = os.Stat(suite.fake_storage_path + "/" + dst) // Dst does exist
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.NoFileExists(suite.cache_path + "/" + src)        // Src does not exist
+	suite.assert.FileExists(suite.cache_path + "/" + dst)          // Dst shall exists in cache
+	suite.assert.NoFileExists(suite.fake_storage_path + "/" + src) // Src does not exist
+	suite.assert.FileExists(suite.fake_storage_path + "/" + dst)   // Dst does exist
 
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: openHandle})
 
-	time.Sleep(1 * time.Second)                    // Wait for the cache cleanup to occur
-	_, err = os.Stat(suite.cache_path + "/" + dst) // Dst shall not exists in cache
-	suite.assert.True(err == nil || os.IsNotExist(err))
+	time.Sleep(1 * time.Second)                             // Wait for the cache cleanup to occur
+	suite.assert.NoFileExists(suite.cache_path + "/" + dst) // Dst shall not exists in cache
 }
 
 func (suite *fileCacheTestSuite) TestTruncateFileNotInCache() {
@@ -1509,8 +1440,7 @@ func (suite *fileCacheTestSuite) TestTruncateFileNotInCache() {
 	suite.assert.True(os.IsNotExist(err))
 
 	// Path should be in fake storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(filepath.Join(suite.fake_storage_path, path))
 
 	// Chmod
 	size := 1024
@@ -1531,15 +1461,13 @@ func (suite *fileCacheTestSuite) TestTruncateFileInCache() {
 	openHandle, _ := suite.fileCache.OpenFile(internal.OpenFileOptions{Name: path, Mode: 0666})
 
 	// Path should be in the file cache
-	_, err := os.Stat(filepath.Join(suite.cache_path, path))
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(filepath.Join(suite.cache_path, path))
 	// Path should be in fake storage
-	_, err = os.Stat(filepath.Join(suite.fake_storage_path, path))
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(filepath.Join(suite.fake_storage_path, path))
 
 	// Chmod
 	size := 1024
-	err = suite.fileCache.TruncateFile(internal.TruncateFileOptions{Name: path, Size: int64(size)})
+	err := suite.fileCache.TruncateFile(internal.TruncateFileOptions{Name: path, Size: int64(size)})
 	suite.assert.NoError(err)
 	// Path in fake storage and file cache should be updated
 	info, _ := os.Stat(filepath.Join(suite.cache_path, path))
@@ -1567,8 +1495,7 @@ func (suite *fileCacheTestSuite) TestTruncateFileCase2() {
 
 	// Path should not be in fake storage
 	// With new changes we always download and then truncate so file will exists in local path
-	// _, err = os.Stat(suite.fake_storage_path + "/" + path)
-	// suite.assert.True(os.IsNotExist(err))
+	// suite.assert.NoFileExists(suite.fake_storage_path + "/" + path)
 }
 
 func (suite *fileCacheTestSuite) TestZZMountPathConflict() {

--- a/component/file_cache/file_cache_windows_test.go
+++ b/component/file_cache/file_cache_windows_test.go
@@ -125,8 +125,7 @@ func (suite *fileCacheWindowsTestSuite) TestChownNotInCache() {
 	// suite.assert.True(os.IsNotExist(err))
 
 	// Path should be in fake storage
-	_, err = os.Stat(suite.fake_storage_path + "/" + path)
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(suite.fake_storage_path + "/" + path)
 
 	// Checking that nothing changed with existing files
 	owner := os.Getuid()
@@ -135,8 +134,7 @@ func (suite *fileCacheWindowsTestSuite) TestChownNotInCache() {
 	suite.assert.Nil(err)
 
 	// Path in fake storage should be updated
-	_, err = os.Stat(suite.fake_storage_path + "/" + path)
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(suite.fake_storage_path + "/" + path)
 }
 
 func (suite *fileCacheWindowsTestSuite) TestChownInCache() {
@@ -150,11 +148,9 @@ func (suite *fileCacheWindowsTestSuite) TestChownInCache() {
 	suite.assert.NoError(err)
 
 	// Path should be in the file cache
-	_, err = os.Stat(suite.cache_path + "/" + path)
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(suite.cache_path + "/" + path)
 	// Path should be in fake storage
-	_, err = os.Stat(suite.fake_storage_path + "/" + path)
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(suite.fake_storage_path + "/" + path)
 
 	// Chown is not supportred on Windows, but checking that calling it does not cause an error
 	owner := os.Getuid()
@@ -163,11 +159,9 @@ func (suite *fileCacheWindowsTestSuite) TestChownInCache() {
 	suite.assert.NoError(err)
 
 	// Checking that nothing changed with existing files
-	_, err = os.Stat(suite.cache_path + "/" + path)
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(suite.cache_path + "/" + path)
 
-	_, err = os.Stat(suite.fake_storage_path + "/" + path)
-	suite.assert.True(err == nil || os.IsExist(err))
+	suite.assert.FileExists(suite.fake_storage_path + "/" + path)
 
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: openHandle})
 }

--- a/component/file_cache/lru_policy_test.go
+++ b/component/file_cache/lru_policy_test.go
@@ -250,9 +250,8 @@ func (suite *lruPolicyTestSuite) TestCachePurge() {
 	time.Sleep(1 * time.Second)
 	// validate all aPaths were deleted
 	for _, path := range aPaths {
-		_, err := os.Stat(path)
-		suite.assert.Error(err)
-		suite.assert.True(os.IsNotExist(err))
+		suite.assert.NoFileExists(path)
+		suite.assert.NoDirExists(path)
 	}
 	// validate other paths were not touched
 	var otherPaths []string

--- a/component/loopback/loopback_fs_test.go
+++ b/component/loopback/loopback_fs_test.go
@@ -107,9 +107,7 @@ func (suite *LoopbackFSTestSuite) TestCreateDir() {
 
 	err := suite.lfs.CreateDir(internal.CreateDirOptions{Name: dirTwo, Mode: os.FileMode(0777)})
 	assert.NoError(err, "CreateDir: Failed")
-	info, err := os.Stat(filepath.Join(testPath, dirTwo))
-	assert.NoError(err, "CreateDir: Could not stat created dir")
-	assert.True(info.IsDir(), "CreateDir: not a dir")
+	suite.DirExists(filepath.Join(testPath, dirTwo))
 }
 
 func (suite *LoopbackFSTestSuite) TestDeleteDir() {
@@ -118,8 +116,7 @@ func (suite *LoopbackFSTestSuite) TestDeleteDir() {
 
 	err := suite.lfs.DeleteDir(internal.DeleteDirOptions{Name: dirEmpty})
 	assert.NoError(err, "DeleteDir: Failed")
-	_, err = os.Stat(filepath.Join(testPath, dirEmpty))
-	assert.Error(err, "DeleteDir: Failed to delete")
+	suite.NoDirExists(filepath.Join(testPath, dirEmpty), "DeleteDir: Failed to delete")
 }
 
 func (suite *LoopbackFSTestSuite) TestStreamDir() {
@@ -145,10 +142,7 @@ func (suite *LoopbackFSTestSuite) TestRenameDir() {
 	err := suite.lfs.RenameDir(internal.RenameDirOptions{Src: dirEmpty, Dst: "newempty"})
 	assert.NoError(err, "RenameDir: Failed")
 
-	info, err := os.Stat(filepath.Join(testPath, "newempty"))
-	assert.NoError(err, "RenameDir: Unable to stat renamed dir")
-
-	assert.Equal("newempty", info.Name(), "RenameDir: name does not match")
+	suite.DirExists(filepath.Join(testPath, "newempty"))
 }
 
 func (suite *LoopbackFSTestSuite) TestCreateFile() {
@@ -159,9 +153,7 @@ func (suite *LoopbackFSTestSuite) TestCreateFile() {
 	assert.NoError(err, "CreateFile: Failed")
 	assert.NotNil(handle)
 
-	info, err := os.Stat(filepath.Join(testPath, fileEmpty))
-	assert.NoError(err, "CreateFile: unable to stat created file")
-	assert.Equal(fileEmpty, info.Name())
+	assert.FileExists(filepath.Join(testPath, fileEmpty))
 
 	err = suite.lfs.CloseFile(internal.CloseFileOptions{Handle: handle})
 	assert.NoError(err, "CreateFile: Failed to close file")
@@ -173,8 +165,7 @@ func (suite *LoopbackFSTestSuite) TestDeleteFile() {
 
 	err := suite.lfs.DeleteFile(internal.DeleteFileOptions{Name: fileHello})
 	assert.NoError(err, "DeleteFile: Failed")
-	_, err = os.Stat(filepath.Join(testPath, fileHello))
-	assert.Error(err, "DeleteFile: file was not deleted")
+	assert.NoFileExists(filepath.Join(testPath, fileHello), "DeleteFile: file was not deleted")
 }
 
 func (suite *LoopbackFSTestSuite) TestReadInBuffer() {

--- a/test/e2e_tests/dir_test.go
+++ b/test/e2e_tests/dir_test.go
@@ -163,8 +163,7 @@ func (suite *dirTestSuite) TestDirRename() {
 	err = os.Rename(dirName, newName)
 	suite.NoError(err)
 
-	_, err = os.Stat(dirName)
-	suite.True(os.IsNotExist(err))
+	suite.NoDirExists(dirName)
 
 	// cleanup
 	suite.dirTestCleanup([]string{newName})
@@ -404,11 +403,9 @@ func (suite *dirTestSuite) TestDirRenameFull() {
 	suite.NoError(err)
 
 	//  Deleted directory shall not be present in the container now
-	_, err = os.Stat(dirName)
-	suite.True(os.IsNotExist(err))
+	suite.NoDirExists(dirName)
 
-	_, err = os.Stat(newName)
-	suite.False(os.IsNotExist(err))
+	suite.DirExists(newName)
 
 	// this should fail as the new dir should be filled
 	err = os.Remove(newName)
@@ -432,8 +429,7 @@ func (suite *dirTestSuite) TestGitStash() {
 		_, err := cmd.Output()
 		suite.NoError(err)
 
-		_, err = os.Stat(dirName)
-		suite.NoError(err)
+		suite.DirExists(dirName)
 
 		err = os.Chdir(dirName)
 		suite.NoError(err)

--- a/test/e2e_tests/file_test.go
+++ b/test/e2e_tests/file_test.go
@@ -135,8 +135,7 @@ func (suite *fileTestSuite) TestFileCreatSpclChar() {
 	srcFile.Close()
 	time.Sleep(time.Second * 2)
 
-	_, err = os.Stat(fileName)
-	suite.NoError(err)
+	suite.FileExists(fileName)
 
 	files, err := os.ReadDir(suite.testPath)
 	suite.NoError(err)
@@ -163,8 +162,7 @@ func (suite *fileTestSuite) TestFileCreateEncodeChar() {
 	srcFile.Close()
 	time.Sleep(time.Second * 2)
 
-	_, err = os.Stat(fileName)
-	suite.NoError(err)
+	suite.FileExists(fileName)
 
 	files, err := os.ReadDir(suite.testPath)
 	suite.NoError(err)
@@ -204,8 +202,7 @@ func (suite *fileTestSuite) TestFileCreateMultiSpclCharWithinSpclDir() {
 	srcFile.Close()
 	time.Sleep(time.Second * 2)
 
-	_, err = os.Stat(fileName)
-	suite.NoError(err)
+	suite.FileExists(fileName)
 
 	files, err := os.ReadDir(speclDirName)
 	suite.NoError(err)


### PR DESCRIPTION
### Describe your changes in brief

Assert has built-in functions to check if a file or directory exists. Use those instead of stat.
This improves assert debugging by providing the reason why the assert failed, as well as being shorter and more readable.

### What type of Pull Request is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Checklist

- [ ] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #