### PR TITLE
Minor improvements in file cache

### DIFF
--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -1369,6 +1369,7 @@ func (suite *fileCacheTestSuite) TestRenameFileAndCacheCleanup() {
 	err := suite.fileCache.RenameFile(internal.RenameFileOptions{Src: src, Dst: dst})
 	suite.assert.NoError(err)
 	// Path in fake storage and file cache should be updated
+	suite.assert.False(suite.fileCache.policy.IsCached(filepath.Join(suite.cache_path, src)))
 	suite.assert.NoFileExists(suite.cache_path + "/" + src)        // Src does not exist
 	suite.assert.FileExists(suite.cache_path + "/" + dst)          // Dst shall exists in cache
 	suite.assert.NoFileExists(suite.fake_storage_path + "/" + src) // Src does not exist
@@ -1399,6 +1400,7 @@ func (suite *fileCacheTestSuite) TestRenameFileAndCacheCleanupWithNoTimeout() {
 	err := suite.fileCache.RenameFile(internal.RenameFileOptions{Src: src, Dst: dst})
 	suite.assert.NoError(err)
 	// Path in fake storage and file cache should be updated
+	suite.assert.False(suite.fileCache.policy.IsCached(filepath.Join(suite.cache_path, src)))
 	suite.assert.NoFileExists(suite.cache_path + "/" + src)        // Src does not exist
 	suite.assert.FileExists(suite.cache_path + "/" + dst)          // Dst shall exists in cache
 	suite.assert.NoFileExists(suite.fake_storage_path + "/" + src) // Src does not exist
@@ -1406,7 +1408,8 @@ func (suite *fileCacheTestSuite) TestRenameFileAndCacheCleanupWithNoTimeout() {
 
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: openHandle})
 
-	time.Sleep(100 * time.Millisecond)                      // Wait for the cache cleanup to occur
+	time.Sleep(100 * time.Millisecond) // Wait for the cache cleanup to occur
+	suite.assert.False(suite.fileCache.policy.IsCached(filepath.Join(suite.cache_path, dst)))
 	suite.assert.NoFileExists(suite.cache_path + "/" + dst) // Dst shall not exists in cache
 }
 

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -1437,7 +1437,7 @@ func (suite *fileCacheTestSuite) TestTruncateFileNotInCache() {
 	suite.assert.EqualValues(info.Size(), size)
 }
 
-func (suite *fileCacheTestSuite) TestTruncateFileInCache() {
+func (suite *fileCacheTestSuite) TestTruncateFileCase3() {
 	defer suite.cleanupTest()
 	// Setup
 	path := "file31"

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -1399,14 +1399,14 @@ func (suite *fileCacheTestSuite) TestRenameFileAndCacheCleanupWithNoTimeout() {
 	// RenameFile
 	err := suite.fileCache.RenameFile(internal.RenameFileOptions{Src: src, Dst: dst})
 	suite.assert.NoError(err)
+
+	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: openHandle})
 	// Path in fake storage and file cache should be updated
 	suite.assert.False(suite.fileCache.policy.IsCached(filepath.Join(suite.cache_path, src)))
 	suite.assert.NoFileExists(suite.cache_path + "/" + src)        // Src does not exist
 	suite.assert.FileExists(suite.cache_path + "/" + dst)          // Dst shall exists in cache
 	suite.assert.NoFileExists(suite.fake_storage_path + "/" + src) // Src does not exist
 	suite.assert.FileExists(suite.fake_storage_path + "/" + dst)   // Dst does exist
-
-	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: openHandle})
 
 	time.Sleep(100 * time.Millisecond) // Wait for the cache cleanup to occur
 	suite.assert.False(suite.fileCache.policy.IsCached(filepath.Join(suite.cache_path, dst)))

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -1247,9 +1247,7 @@ func (suite *fileCacheTestSuite) TestGetAttrCase4() {
 		time.Sleep(10 * time.Millisecond)
 		_, err = os.Stat(filepath.Join(suite.cache_path, file))
 	}
-	// TODO: why is check test flaky (on both platforms)?
-	fmt.Println("Skipping TestGetAttrCase4 eviction check (flaky).")
-	// suite.assert.True(os.IsNotExist(err))
+	suite.assert.True(os.IsNotExist(err))
 
 	// open the file in parallel and try getting the size of file while open is on going
 	go suite.fileCache.OpenFile(internal.OpenFileOptions{Name: file, Mode: 0666})

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -936,7 +936,7 @@ func (suite *fileCacheTestSuite) TestCloseFile() {
 func (suite *fileCacheTestSuite) TestCloseFileTimeout() {
 	defer suite.cleanupTest()
 	suite.cleanupTest() // teardown the default file cache generated
-	cacheTimeout := 5
+	cacheTimeout := 1
 	config := fmt.Sprintf("file_cache:\n  path: %s\n  offload-io: true\n  timeout-sec: %d\n\nloopbackfs:\n  path: %s",
 		suite.cache_path, cacheTimeout, suite.fake_storage_path)
 	suite.setupTestHelper(config) // setup a new file cache with a custom config (teardown will occur after the test as usual)
@@ -1353,7 +1353,7 @@ func (suite *fileCacheTestSuite) TestRenameFileAndCacheCleanup() {
 	defer suite.cleanupTest()
 	suite.cleanupTest()
 
-	config := fmt.Sprintf("file_cache:\n  path: %s\n  offload-io: true\n  timeout-sec: 2\n\nloopbackfs:\n  path: %s",
+	config := fmt.Sprintf("file_cache:\n  path: %s\n  offload-io: true\n  timeout-sec: 1\n\nloopbackfs:\n  path: %s",
 		suite.cache_path, suite.fake_storage_path)
 	suite.setupTestHelper(config) // setup a new file cache with a custom config (teardown will occur after the test as usual)
 
@@ -1376,10 +1376,10 @@ func (suite *fileCacheTestSuite) TestRenameFileAndCacheCleanup() {
 	suite.assert.NoFileExists(suite.fake_storage_path + "/" + src) // Src does not exist
 	suite.assert.FileExists(suite.fake_storage_path + "/" + dst)   // Dst does exist
 
-	time.Sleep(1 * time.Second)                           // Check once before the cache cleanup that file exists
+	time.Sleep(500 * time.Millisecond)                    // Check once before the cache cleanup that file exists
 	suite.assert.FileExists(suite.cache_path + "/" + dst) // Dst shall exists in cache
 
-	time.Sleep(2 * time.Second)                           // Wait for the cache cleanup to occur
+	time.Sleep(1 * time.Second)                           // Wait for the cache cleanup to occur
 	suite.assert.FileExists(suite.cache_path + "/" + dst) // Dst shall not exists in cache
 }
 

--- a/component/file_cache/file_cache_windows_test.go
+++ b/component/file_cache/file_cache_windows_test.go
@@ -120,9 +120,7 @@ func (suite *fileCacheWindowsTestSuite) TestChownNotInCache() {
 		time.Sleep(10 * time.Millisecond)
 		_, err = os.Stat(suite.cache_path + "/" + path)
 	}
-	// this check is flaky in our CI pipeline on Windows, so skip it
-	fmt.Println("Skipping TestChownNotInCache IsNotExist check on Windows because it's flaky.")
-	// suite.assert.True(os.IsNotExist(err))
+	suite.assert.True(os.IsNotExist(err))
 
 	// Path should be in fake storage
 	suite.assert.FileExists(suite.fake_storage_path + "/" + path)

--- a/component/file_cache/lru_policy.go
+++ b/component/file_cache/lru_policy.go
@@ -183,8 +183,6 @@ func (p *lruPolicy) CachePurge(name string) {
 	p.deleteEvent <- name
 }
 
-// Due to a race condition, this may return a false positive,
-// but it will not return a false negative.
 func (p *lruPolicy) IsCached(name string) bool {
 	log.Trace("lruPolicy::IsCached : %s", name)
 

--- a/component/file_cache/lru_policy.go
+++ b/component/file_cache/lru_policy.go
@@ -74,9 +74,6 @@ type lruPolicy struct {
 }
 
 const (
-	// Check for file expiry in below number of seconds
-	CacheTimeoutCheckInterval = 5
-
 	// Check for disk usage in below number of minutes
 	DiskUsageCheckInterval = 1
 )
@@ -126,13 +123,10 @@ func (p *lruPolicy) StartPolicy() error {
 		p.diskUsageMonitor = time.Tick(time.Duration(DiskUsageCheckInterval * time.Minute))
 	}
 
-	// Only start the timeoutMonitor if evictTime is non-zero.
-	// If evictTime=0, we delete on invalidate so there is no need for a timeout monitor signal to be sent.
 	log.Info("lruPolicy::StartPolicy : Policy set with %v timeout", p.cacheTimeout)
 
-	if p.cacheTimeout != 0 {
-		p.cacheTimeoutMonitor = time.Tick(time.Duration(time.Duration(p.cacheTimeout) * time.Second))
-	}
+	// if timeout is zero time.Tick will return nil
+	p.cacheTimeoutMonitor = time.Tick(time.Duration(time.Duration(p.cacheTimeout) * time.Second))
 
 	go p.clearCache()
 	go p.asyncCacheValid()
@@ -352,18 +346,19 @@ func (p *lruPolicy) updateMarker() {
 
 	p.Lock()
 	node := p.lastMarker
+	// remove lastMarker from linked list
 	if node.next != nil {
 		node.next.prev = node.prev
 	}
-
 	if node.prev != nil {
 		node.prev.next = node.next
 	}
+	// and insert it at the head
 	node.prev = nil
 	node.next = p.head
 	p.head.prev = node
 	p.head = node
-
+	// swap lastMarker with currMarker
 	p.lastMarker = p.currMarker
 	p.currMarker = node
 


### PR DESCRIPTION
### Describe your changes in brief

In file cache test suite:

* Re-enable tests that were flaky due to race conditions that are fixed now
* Shorten a couple test sleep times
* Remove unnecessary OpenFile when timeout is non-zero
* Remove redundant call to setupTestHelper with config identical to test default config

In lru_policy:

* Remove unused const
* Simplify cacheTimeoutMonitor code
  * (calling time.Tick with a zero interval already returns nil, so no need to check if the interval is zero)
* Add comments to updateMarker to explain linked list code

### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Checklist

- [ ] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #