### PR TITLE
properly pass settings and default use in get configs when config fil…

### DIFF
--- a/gui/common_qt_functions.py
+++ b/gui/common_qt_functions.py
@@ -248,10 +248,10 @@ class customConfigFunctions():
                     configs = yaml.safe_load(file)
                     if configs is None:
                        # The configs file exists, but is empty, use default settings
-                       configs = self.getConfigs(True)
+                       configs = self.getConfigs(settings,True)
             except:
                 # Could not open or config file does not exist, use default settings
-                configs = self.getConfigs(True)
+                configs = self.getConfigs(settings,True)
         return configs
     
 


### PR DESCRIPTION
Fix missing config loop


### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief
When I changed how the getConfig function worked by passing in the settings as well as a default boolean, I forgot to update the path of missing a config file for passing in settings as well, so settings was set to True, and defaultConfig was always set to false
### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #