### PR TITLE
Correct usage strings

### DIFF
--- a/cmd/generator.go
+++ b/cmd/generator.go
@@ -34,7 +34,7 @@ import (
 )
 
 var generateCmd = &cobra.Command{
-	Use:               "generate [component name]",
+	Use:               "generate <component name>",
 	Hidden:            true,
 	Short:             "Generate a new component for Cloudfuse",
 	Long:              "Generate a new component for Cloudfuse",

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -263,7 +263,7 @@ func parseConfig() error {
 // We use the cobra library to provide a CLI for Cloudfuse.
 // Look at https://cobra.dev/ for more information
 var mountCmd = &cobra.Command{
-	Use:               "mount [path]",
+	Use:               "mount <mount path>",
 	Short:             "Mounts the container as a filesystem",
 	Long:              "Mounts the container as a filesystem",
 	SuggestFor:        []string{"mnt", "mout"},

--- a/cmd/mount_all.go
+++ b/cmd/mount_all.go
@@ -56,7 +56,7 @@ type containerListingOptions struct {
 var mountAllOpts containerListingOptions
 
 var mountAllCmd = &cobra.Command{
-	Use:               "all [path] <flags>",
+	Use:               "all <mount path>",
 	Short:             "Mounts all containers for a given cloud account as a filesystem",
 	Long:              "Mounts all containers for a given cloud account as a filesystem",
 	SuggestFor:        []string{"mnta", "mout"},

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -36,7 +36,7 @@ import (
 var check bool
 
 var versionCmd = &cobra.Command{
-	Use:               "version [--check]",
+	Use:               "version",
 	Short:             "Command to print the current version along with optional check for latest version",
 	FlagErrorHandling: cobra.ExitOnError,
 	RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Make usage strings use square brackets for optional arguments and angle brackets for required arguments.
Since Cobra already adds "[flags]" to the usage string automatically when a command has flags, change our usage strings to just describe our required arguments and let Cobra do the rest.

### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief
Correct usage strings

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #