### PR TITLE
Revert back to go 1.23.2 to avoid daemon issue

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -14,7 +14,7 @@ jobs:
   BuildAndTest-Coverage:
     strategy:
       matrix:
-        go: ['1.23']
+        go: ['1.23.2']
         job_name: ['linux']
 
         include:
@@ -521,7 +521,7 @@ jobs:
   BuildAndTest-Coverage-Windows:
     strategy:
       matrix:
-        go: ['1.23']
+        go: ['1.23.2']
         job_name: ['windows']
 
         include:
@@ -1005,7 +1005,7 @@ jobs:
     - BuildAndTest-Coverage-Windows
     strategy:
       matrix:
-        go: ['1.23']
+        go: ['1.23.2']
         job_name: ['linux']
 
         include:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -50,7 +50,7 @@ jobs:
       if: matrix.language == 'go'
       uses: actions/setup-go@v5
       with:
-        go-version: '1.23'
+        go-version: '1.23.2'
         check-latest: true
     
     - name: Go Version

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -67,7 +67,7 @@ jobs:
     needs: compile-gui
     runs-on: windows-latest
     env:
-      go: '1.23'
+      go: '1.23.2'
       cgo: '0'
       winfsp: winfsp-2.0.23075.msi
     steps:
@@ -209,7 +209,7 @@ jobs:
     needs: create-installer
     runs-on: ubuntu-latest
     env:
-      go: '1.23'
+      go: '1.23.2'
       zig: 0.13.0
 
     steps:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build and Test on Linux
     runs-on: ubuntu-latest
     env:
-      go: '1.23'
+      go: '1.23.2'
       cgo: ''
       containerName: 'test-cnt-ubn'
 
@@ -117,7 +117,7 @@ jobs:
     name: Build and Test on Windows
     runs-on: windows-latest
     env:
-      go: '1.23'
+      go: '1.23.2'
       cgo: '0'
       containerName: 'test-cnt-win'
 
@@ -149,7 +149,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     env:
-      go: '1.23'
+      go: '1.23.2'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Seagate/cloudfuse
 
-go 1.23.1
+go 1.23.2
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.15.0

--- a/go_installer.sh
+++ b/go_installer.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 work_dir=$(echo $1 | sed 's:/*$::')
-version="1.23.1"
+version="1.23.2"
 arch=`hostnamectl | grep "Arch" | rev | cut -d " " -f 1 | rev`
 
 if [ $arch != "arm64" ]


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief

Latest builds used go 1.23.3 to build cloudfuse, however, there is an issue with daemonizing our application with this version. It does not happen on 1.23.2. Cloudfuse still mounts, but there is an error given that it failed to create a daemon. I'm not sure exactly why, but this is a quick fix.

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #