### PR TITLE
Fix open append

### DIFF
--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -843,7 +843,7 @@ func (fc *FileCache) downloadFile(handle *handlemap.Handle) error {
 		}
 
 		// Open the file in write mode.
-		f, err = common.OpenFile(localPath, flags, fMode)
+		f, err = common.OpenFile(localPath, os.O_CREATE|os.O_RDWR, fMode)
 		if err != nil {
 			log.Err("FileCache::downloadFile : error creating new file %s [%s]", handle.Path, err.Error())
 			return err
@@ -965,10 +965,12 @@ func (fc *FileCache) OpenFile(options internal.OpenFileOptions) (*handlemap.Hand
 	// create handle and record openFileOptions for later
 	handle := handlemap.NewHandle(options.Name)
 	handle.SetValue("openFileOptions", openFileOptions{flags: options.Flags, fMode: options.Mode})
-	// Increment the handle count in this lock item as there is one handle open for this now
+
 	if options.Flags&os.O_APPEND != 0 {
 		handle.Flags.Set(handlemap.HandleOpenedAppend)
 	}
+
+	// Increment the handle count in this lock item as there is one handle open for this now
 	flock.Inc()
 
 	return handle, nil

--- a/internal/handlemap/handle_map.go
+++ b/internal/handlemap/handle_map.go
@@ -43,10 +43,11 @@ const InvalidHandleID HandleID = 0
 
 // Flags represented in BitMap for various flags in the handle
 const (
-	HandleFlagUnknown uint16 = iota
-	HandleFlagDirty          // File has been modified with write operation or is a new file
-	HandleFlagFSynced        // User has called fsync on the file explicitly
-	HandleFlagCached         // File is cached in the local system by cloudfuse
+	HandleFlagUnknown  uint16 = iota
+	HandleFlagDirty           // File has been modified with write operation or is a new file
+	HandleFlagFSynced         // User has called fsync on the file explicitly
+	HandleFlagCached          // File is cached in the local system by cloudfuse
+	HandleOpenedAppend        // File is opened for Append
 )
 
 // Structure to hold in memory cache for streaming layer

--- a/test/e2e_tests/file_test.go
+++ b/test/e2e_tests/file_test.go
@@ -254,6 +254,34 @@ func (suite *fileTestSuite) TestFileCreateLabel() {
 	suite.fileTestCleanup([]string{fileName})
 }
 
+func (suite *fileTestSuite) TestFileAppend() {
+	fileName := filepath.Join(suite.testPath, "append_test.txt")
+	initialContent := []byte("Initial content\n")
+	appendContent := []byte("Appended content\n")
+
+	// Create and write initial content to the file
+	srcFile, err := os.OpenFile(fileName, os.O_CREATE|os.O_WRONLY, 0777)
+	suite.NoError(err)
+	_, err = srcFile.Write(initialContent)
+	suite.NoError(err)
+	srcFile.Close()
+
+	// Open the file with O_APPEND and append new content
+	appendFile, err := os.OpenFile(fileName, os.O_APPEND|os.O_WRONLY, 0777)
+	suite.NoError(err)
+	_, err = appendFile.Write(appendContent)
+	suite.NoError(err)
+	appendFile.Close()
+
+	// Read the file and verify the content
+	data, err := os.ReadFile(fileName)
+	suite.NoError(err)
+	expectedContent := append(initialContent, appendContent...)
+	suite.Equal(expectedContent, data)
+
+	suite.fileTestCleanup([]string{fileName})
+}
+
 // # Write a small file
 func (suite *fileTestSuite) TestFileWriteSmall() {
 	fileName := filepath.Join(suite.testPath, "small_write.txt")


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief

This fixes a bug where cloudfuse was unable to append to files opened with the O_APPEND flag.

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [x] Added tests

### Related Issues

- Closes #369