### PR TITLE
Always use timer for eviction

### DIFF
--- a/component/file_cache/cache_policy.go
+++ b/component/file_cache/cache_policy.go
@@ -56,9 +56,8 @@ type cachePolicy interface {
 
 	UpdateConfig(cachePolicyConfig) error
 
-	CacheValid(name string)      // Mark the file as hit
-	CacheInvalidate(name string) // Invalidate the file
-	CachePurge(name string)      // Schedule the file for deletion
+	CacheValid(name string) // Mark the file as hit
+	CachePurge(name string) // Schedule the file for deletion
 
 	IsCached(name string) bool // Whether or not the cache policy considers this file cached
 

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -652,12 +652,6 @@ func (fc *FileCache) RenameDir(options internal.RenameDirOptions) error {
 		fc.policy.CachePurge(directoriesToPurge[i])
 	}
 
-	if fc.cacheTimeout == 0 {
-		// delete destination path immediately
-		log.Info("FileCache::RenameDir : Timeout is zero, so removing local destination %s", options.Dst)
-		go fc.invalidateDirectory(options.Dst)
-	}
-
 	return nil
 }
 
@@ -1006,8 +1000,6 @@ func (fc *FileCache) closeFileInternal(options internal.CloseFileOptions, flock 
 	// if file has not been interactively read or written to by end user, then there is no cached file to close.
 	_, noCachedHandle := options.Handle.GetValue("openFileOptions")
 
-	localPath := filepath.Join(fc.tmpPath, options.Handle.Path)
-
 	err := fc.FlushFile(internal.FlushFileOptions{Handle: options.Handle, CloseInProgress: true}) //nolint
 	if err != nil {
 		log.Err("FileCache::closeFileInternal : failed to flush file %s", options.Handle.Path)
@@ -1044,7 +1036,6 @@ func (fc *FileCache) closeFileInternal(options internal.CloseFileOptions, flock 
 		return nil
 	}
 
-	fc.policy.CacheInvalidate(localPath) // Invalidate the file from the local cache if the timeout is zero.
 	return nil
 }
 
@@ -1395,11 +1386,6 @@ func (fc *FileCache) renameCachedFile(localSrcPath string, localDstPath string) 
 	// delete the source from our cache policy
 	// this will also delete the source file from local storage (if rename failed)
 	fc.policy.CachePurge(localSrcPath)
-
-	if fc.cacheTimeout == 0 {
-		// Destination file needs to be deleted immediately
-		go fc.policy.CachePurge(localDstPath)
-	}
 }
 
 // TruncateFile: Update the file with its new size.

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -1402,7 +1402,7 @@ func (suite *fileCacheTestSuite) TestRenameFileAndCacheCleanupWithNoTimeout() {
 	suite.assert.NoFileExists(suite.fake_storage_path + "/" + src) // Src does not exist
 	suite.assert.FileExists(suite.fake_storage_path + "/" + dst)   // Dst does exist
 
-	time.Sleep(100 * time.Millisecond) // Wait for the cache cleanup to occur
+	time.Sleep(200 * time.Millisecond) // Wait for the cache cleanup to occur
 	// cache should be completely clean
 	suite.assert.False(suite.fileCache.policy.IsCached(filepath.Join(suite.cache_path, src)))
 	suite.assert.False(suite.fileCache.policy.IsCached(filepath.Join(suite.cache_path, dst)))

--- a/component/file_cache/lru_policy_test.go
+++ b/component/file_cache/lru_policy_test.go
@@ -200,7 +200,6 @@ func (suite *lruPolicyTestSuite) TestCachePurge() {
 		highThreshold: defaultMaxThreshold,
 		lowThreshold:  defaultMinThreshold,
 		fileLocks:     &common.LockMap{},
-		policyTrace:   true,
 	}
 	suite.setupTestHelper(config)
 

--- a/component/file_cache/lru_policy_test.go
+++ b/component/file_cache/lru_policy_test.go
@@ -189,21 +189,8 @@ func (suite *lruPolicyTestSuite) TestCacheValid() {
 	suite.assert.EqualValues(1, node.usage)
 }
 
-func (suite *lruPolicyTestSuite) TestCacheInvalidate() {
+func (suite *lruPolicyTestSuite) TestCachePurge() {
 	defer suite.cleanupTest()
-	f, _ := os.Create(cache_path + "/temp")
-	f.Close()
-	suite.policy.CacheValid("temp")
-	suite.policy.CacheInvalidate("temp") // this is equivalent to purge since timeout=0
-
-	n, ok := suite.policy.nodeMap.Load("temp")
-	suite.assert.False(ok)
-	suite.assert.Nil(n)
-}
-
-func (suite *lruPolicyTestSuite) TestCacheInvalidateTimeout() {
-	defer suite.cleanupTest()
-	suite.cleanupTest()
 
 	config := cachePolicyConfig{
 		tmpPath:       cache_path,
@@ -213,23 +200,10 @@ func (suite *lruPolicyTestSuite) TestCacheInvalidateTimeout() {
 		highThreshold: defaultMaxThreshold,
 		lowThreshold:  defaultMinThreshold,
 		fileLocks:     &common.LockMap{},
+		policyTrace:   true,
 	}
-
 	suite.setupTestHelper(config)
 
-	suite.policy.CacheValid("temp")
-	suite.policy.CacheInvalidate("temp")
-
-	n, ok := suite.policy.nodeMap.Load("temp")
-	suite.assert.True(ok)
-	suite.assert.NotNil(n)
-	node := n.(*lruNode)
-	suite.assert.EqualValues("temp", node.name)
-	suite.assert.EqualValues(1, node.usage)
-}
-
-func (suite *lruPolicyTestSuite) TestCachePurge() {
-	defer suite.cleanupTest()
 	// test policy cache data
 	suite.policy.CacheValid("temp")
 	suite.policy.CachePurge("temp")


### PR DESCRIPTION
### Describe your changes in brief

This change improves the maintainability of the file cache, to make it easier to add features, and make further changes.

Only do eviction one way: using a timer.
If the timer is zero, use a fast timer (100ms), and evict everything.
Stop using CachePurge for manual evictions. Only use CachePurge when the object is being deleted.

### What type of Pull Request is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #