### PR TITLE
Open Local File on OpenFile When No Object Exists

### DIFF
--- a/component/azstorage/block_blob.go
+++ b/component/azstorage/block_blob.go
@@ -569,7 +569,7 @@ func (bb *BlockBlob) List(prefix string, marker *string, count int32) ([]*intern
 	var dirList = make(map[string]bool)
 	for _, blobInfo := range listBlob.Segment.BlobItems {
 		blobInfo.Name = bb.getFileName(*blobInfo.Name)
-		attr := &internal.ObjAttr{}
+		var attr *internal.ObjAttr
 		if blobInfo.Properties.CustomerProvidedKeySHA256 != nil && *blobInfo.Properties.CustomerProvidedKeySHA256 != "" {
 			log.Trace("BlockBlob::List : blob is encrypted with customer provided key so fetching metadata explicitly using REST")
 			attr, err = bb.getAttrUsingRest(*blobInfo.Name)

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -795,7 +795,7 @@ func (fc *FileCache) DeleteFile(options internal.DeleteFileOptions) error {
 	return nil
 }
 
-func (fc *FileCache) downloadFile(handle *handlemap.Handle) error {
+func (fc *FileCache) openFileInternal(handle *handlemap.Handle) error {
 	log.Trace("FileCache::downloadFile : name=%s", handle.Path)
 
 	handle.Lock()
@@ -1130,7 +1130,7 @@ func (fc *FileCache) ReadInBuffer(options internal.ReadInBufferOptions) (int, er
 	// The file should already be in the cache since CreateFile/OpenFile was called before and a shared lock was acquired.
 	// log.Debug("FileCache::ReadInBuffer : Reading %v bytes from %s", len(options.Data), options.Handle.Path)
 
-	err := fc.downloadFile(options.Handle)
+	err := fc.openFileInternal(options.Handle)
 	if err != nil {
 		return 0, fmt.Errorf("error downloading file %s [%s]", options.Handle.Path, err)
 	}
@@ -1167,7 +1167,7 @@ func (fc *FileCache) WriteFile(options internal.WriteFileOptions) (int, error) {
 	// The file should already be in the cache since CreateFile/OpenFile was called before and a shared lock was acquired.
 	//log.Debug("FileCache::WriteFile : Writing %v bytes from %s", len(options.Data), options.Handle.Path)
 
-	err := fc.downloadFile(options.Handle)
+	err := fc.openFileInternal(options.Handle)
 	if err != nil {
 		return 0, fmt.Errorf("error downloading file for %s [%s]", options.Handle.Path, err)
 	}
@@ -1513,7 +1513,7 @@ func (fc *FileCache) TruncateFile(options internal.TruncateFileOptions) error {
 			log.Err("FileCache::TruncateFile : Error calling OpenFile with %s [%s]", options.Name, err.Error())
 		}
 
-		err = fc.downloadFile(h)
+		err = fc.openFileInternal(h)
 		if err != nil {
 			log.Err("FileCache::TruncateFile : Error calling downloadFile with %s [%s]", options.Name, err.Error())
 			return err

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -982,6 +982,9 @@ func (fc *FileCache) OpenFile(options internal.OpenFileOptions) (*handlemap.Hand
 		handle.Flags.Set(handlemap.HandleOpenedAppend)
 	}
 
+	// Increment the handle count in this lock item as there is one handle open for this now
+	flock.Inc()
+
 	// if there is no object in cloud storage, open the local file right away
 	// there is no performance penalty, and not doing this poses a consistency problem (open(O_CREATE), then stat)
 	if err != nil && os.IsNotExist(err) {

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -955,18 +955,6 @@ func (fc *FileCache) OpenFile(options internal.OpenFileOptions) (*handlemap.Hand
 		return nil, err
 	}
 
-	// if there is no object in cloud storage, we can just open the file locally
-	if err != nil && os.IsNotExist(err) {
-		handle, err := fc.OpenFileCase2(options)
-		if err == nil {
-			// Update the last download time of this file
-			flock.SetDownloadTime()
-			// Increment the handle count in this lock item as there is one handle open for this now
-			flock.Inc()
-		}
-		return handle, err
-	}
-
 	fileSize := int64(0)
 	if attr != nil {
 		fileSize = int64(attr.Size)
@@ -994,67 +982,12 @@ func (fc *FileCache) OpenFile(options internal.OpenFileOptions) (*handlemap.Hand
 		handle.Flags.Set(handlemap.HandleOpenedAppend)
 	}
 
-	return handle, nil
-}
-
-func (fc *FileCache) OpenFileCase2(options internal.OpenFileOptions) (*handlemap.Handle, error) {
-
-	localPath := filepath.Join(fc.tmpPath, options.Name)
-
-	// create the local file if it does not exist
-	_, statErr := os.Stat(localPath)
-	if statErr != nil && os.IsNotExist(statErr) {
-		// create directories
-		err := os.MkdirAll(filepath.Dir(localPath), fc.defaultPermission)
-		if err != nil {
-			log.Err("FileCache::OpenFile : error creating directory structure for file %s [%s]", options.Name, err.Error())
-			return nil, err
-		}
-		// Open the file in write mode.
-		f, err := os.OpenFile(localPath, os.O_CREATE|os.O_RDWR, options.Mode)
-		if err != nil {
-			log.Err("FileCache::OpenFile : error creating new file %s [%s]", options.Name, err.Error())
-			return nil, err
-		}
-		f.Close()
+	// if there is no object in cloud storage, open the local file right away
+	// there is no performance penalty, and not doing this poses a consistency problem (open(O_CREATE), then stat)
+	if err != nil && os.IsNotExist(err) {
+		err := fc.openFileInternal(handle, flock)
+		return handle, err
 	}
-
-	// If user has selected some non default mode in config then every local file shall be created with that mode only
-	err := os.Chmod(localPath, fc.defaultPermission)
-	if err != nil {
-		log.Err("FileCache::OpenFile : Failed to change mode of file %s [%s]", options.Name, err.Error())
-	}
-
-	// Open the file and grab a shared lock to prevent deletion by the cache policy.
-	f, err := os.OpenFile(localPath, options.Flags, options.Mode)
-	if err != nil {
-		log.Err("FileCache::OpenFile : error opening cached file %s [%s]", options.Name, err.Error())
-		return nil, err
-	}
-
-	// mark the file valid in cache
-	fc.policy.CacheValid(localPath)
-
-	// create handle
-	handle := handlemap.NewHandle(options.Name)
-
-	// populate handle
-	// size
-	inf, err := f.Stat()
-	if err == nil {
-		handle.Size = inf.Size()
-	}
-	// local handle number
-	handle.UnixFD = uint64(f.Fd())
-	// flags
-	if !fc.offloadIO {
-		handle.Flags.Set(handlemap.HandleFlagCached)
-	}
-	// local file object
-	handle.SetFileObject(f)
-
-	log.Info("FileCache::OpenFile : file=%s, fd=%d", options.Name, f.Fd())
-	fileCacheStatsCollector.UpdateStats(stats_manager.Increment, cacheServed, (int64)(1))
 
 	return handle, nil
 }

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -875,14 +875,11 @@ func (suite *fileCacheTestSuite) TestOpenFileNotInCache() {
 
 	handle, err = suite.fileCache.OpenFile(internal.OpenFileOptions{Name: path, Flags: os.O_RDWR, Mode: suite.fileCache.defaultPermission})
 	suite.assert.NoError(err)
-	// Download is required
-	err = suite.fileCache.openFileInternal(handle)
-	suite.assert.NoError(err)
 	suite.assert.EqualValues(path, handle.Path)
 	suite.assert.False(handle.Dirty())
 
-	// File should exist in cache
-	suite.assert.FileExists(filepath.Join(suite.cache_path, path))
+	// File should not exist in cache
+	suite.assert.NoFileExists(filepath.Join(suite.cache_path, path))
 }
 
 func (suite *fileCacheTestSuite) TestOpenFileInCache() {

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -901,6 +901,25 @@ func (suite *fileCacheTestSuite) TestOpenFileInCache() {
 	suite.assert.FileExists(filepath.Join(suite.cache_path, path))
 }
 
+func (suite *fileCacheTestSuite) TestOpenCreateGetAttr() {
+	defer suite.cleanupTest()
+	path := "file8a"
+
+	// we report file does not exist before it is created
+	attr, err := suite.fileCache.GetAttr(internal.GetAttrOptions{Name: path})
+	suite.assert.Nil(attr)
+	suite.assert.Error(err)
+	suite.assert.ErrorIs(err, os.ErrNotExist)
+	// since it does not exist, we allow the file to be created using OpenFile
+	handle, err := suite.fileCache.OpenFile(internal.OpenFileOptions{Name: path, Mode: 0777})
+	suite.assert.NoError(err)
+	suite.assert.EqualValues(path, handle.Path)
+	// we should report that the file exists now
+	attr, err = suite.fileCache.GetAttr(internal.GetAttrOptions{Name: path})
+	suite.assert.NoError(err)
+	suite.NotNil(attr)
+}
+
 // Tests for GetProperties in OpenFile should be done in E2E tests
 // - there is no good way to test it here with a loopback FS without a mock component.
 

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -908,10 +908,9 @@ func (suite *fileCacheTestSuite) TestOpenCreateGetAttr() {
 	// we report file does not exist before it is created
 	attr, err := suite.fileCache.GetAttr(internal.GetAttrOptions{Name: path})
 	suite.assert.Nil(attr)
-	suite.assert.Error(err)
 	suite.assert.ErrorIs(err, os.ErrNotExist)
 	// since it does not exist, we allow the file to be created using OpenFile
-	handle, err := suite.fileCache.OpenFile(internal.OpenFileOptions{Name: path, Mode: 0777})
+	handle, err := suite.fileCache.OpenFile(internal.OpenFileOptions{Name: path, Flags: os.O_CREATE, Mode: 0777})
 	suite.assert.NoError(err)
 	suite.assert.EqualValues(path, handle.Path)
 	// we should report that the file exists now

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -876,7 +876,7 @@ func (suite *fileCacheTestSuite) TestOpenFileNotInCache() {
 	handle, err = suite.fileCache.OpenFile(internal.OpenFileOptions{Name: path, Flags: os.O_RDWR, Mode: suite.fileCache.defaultPermission})
 	suite.assert.NoError(err)
 	// Download is required
-	err = suite.fileCache.downloadFile(handle)
+	err = suite.fileCache.openFileInternal(handle)
 	suite.assert.NoError(err)
 	suite.assert.EqualValues(path, handle.Path)
 	suite.assert.False(handle.Dirty())

--- a/component/loopback/loopback_fs.go
+++ b/component/loopback/loopback_fs.go
@@ -354,7 +354,7 @@ func (lfs *LoopbackFS) GetAttr(options internal.GetAttrOptions) (*internal.ObjAt
 	info, err := os.Lstat(path)
 	if err != nil {
 		log.Err("LoopbackFS::GetAttr : error [%s]", err)
-		return &internal.ObjAttr{}, err
+		return nil, err
 	}
 	attr := &internal.ObjAttr{
 		Path:  options.Name,


### PR DESCRIPTION
## ✅ What

- Actually open a local file in `OpenFile` if there is no object in cloud storage
- Rename `downloadFile` to `openFileInternal`
- Acquire lock _before_ calling `openFileInternal`, to allow `OpenFile` to call it as well
- Check that `openComplete` is false before acquiring a lock and calling `openFileInternal`, to prevent performance issues

## 🤔 Why

1. If there is no object to download, there is no performance penalty  for opening the file completely.
2. Without this change, if an application calls Open to create a new file, and then checks if that file exists, we would return ENOENT!