### PR TITLE
Bugfix: upload fails after open file is renamed

### DIFF
--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -1592,6 +1592,7 @@ func (fc *FileCache) RenameFile(options internal.RenameFileOptions) error {
 	defer dflock.Unlock()
 
 	err := fc.NextComponent().RenameFile(options)
+	localOnly := os.IsNotExist(err)
 	err = fc.validateStorageError(options.Src, err, "RenameFile", true)
 	if err != nil {
 		log.Err("FileCache::RenameFile : %s failed to rename file [%s]", options.Src, err.Error())
@@ -1608,16 +1609,19 @@ func (fc *FileCache) RenameFile(options internal.RenameFileOptions) error {
 	localRenameErr := fc.renameCachedFile(localSrcPath, localDstPath, sflock, dflock)
 	if localRenameErr != nil {
 		// renameCachedFile only returns an error when we are at risk for data loss
-		// we must reverse the rename operation to prevent data loss
-		err := fc.NextComponent().RenameFile(internal.RenameFileOptions{
-			Src: options.Dst,
-			Dst: options.Src,
-		})
-		err = fc.validateStorageError(options.Src, err, "RenameFile", true)
-		if err != nil {
-			log.Err("FileCache::RenameFile : %s failed to reverse cloud rename to avoid data loss! [%v]", options.Src, err)
+		if !localOnly {
+			// we must reverse the rename operation to prevent data loss
+			err := fc.NextComponent().RenameFile(internal.RenameFileOptions{
+				Src: options.Dst,
+				Dst: options.Src,
+			})
+			err = fc.validateStorageError(options.Src, err, "RenameFile", false)
+			if err != nil {
+				log.Err("FileCache::RenameFile : %s failed to reverse cloud rename to avoid data loss! [%v]", options.Src, err)
+			}
+			localRenameErr = errors.Join(localRenameErr, err)
 		}
-		return errors.Join(localRenameErr, err)
+		return localRenameErr
 	}
 
 	// update any open handles to the file with its new name

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -1292,25 +1292,6 @@ func (suite *fileCacheTestSuite) TestRenameFileInCache() {
 	suite.assert.FileExists(filepath.Join(suite.fake_storage_path, dst))   // Dst does exist
 }
 
-func (suite *fileCacheTestSuite) TestRenameFileCase2() {
-	defer suite.cleanupTest()
-	// Default is to not create empty files on create file to support immutable storage.
-	src := "source3"
-	dst := "destination3"
-	suite.fileCache.CreateFile(internal.CreateFileOptions{Name: src, Mode: 0777})
-
-	err := suite.fileCache.RenameFile(internal.RenameFileOptions{Src: src, Dst: dst})
-	suite.assert.Error(err)
-	suite.assert.Equal(syscall.EIO, err)
-
-	// Src should be in local cache (since we failed the operation)
-	suite.assert.FileExists(filepath.Join(suite.cache_path, src))
-	// Src should not be in fake storage
-	suite.assert.NoFileExists(filepath.Join(suite.fake_storage_path, src))
-	// Dst should not be in fake storage
-	suite.assert.NoFileExists(filepath.Join(suite.fake_storage_path, dst))
-}
-
 func (suite *fileCacheTestSuite) TestRenameFileAndEvict() {
 	defer suite.cleanupTest()
 

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -34,6 +34,7 @@ import (
 	"math"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -1348,6 +1349,163 @@ func (suite *fileCacheTestSuite) TestRenameFileAndEvict() {
 		_, err = os.Stat(filepath.Join(suite.cache_path, dst))
 	}
 	suite.assert.NoFileExists(filepath.Join(suite.cache_path, dst)) // Dst shall not exists in cache
+}
+
+func (suite *fileCacheTestSuite) TestRenameOpenFileCase1() {
+	defer suite.cleanupTest()
+
+	src := "source5"
+	dst := "destination5"
+
+	// create file in cloud
+	handle, err := suite.loopback.CreateFile(internal.CreateFileOptions{Name: src, Mode: 0666})
+	suite.assert.NoError(err)
+	err = suite.loopback.CloseFile(internal.CloseFileOptions{Handle: handle})
+	suite.assert.NoError(err)
+
+	// open file for writing
+	handle, err = suite.fileCache.OpenFile(internal.OpenFileOptions{Name: src, Flags: os.O_RDWR, Mode: 0777})
+	suite.assert.NoError(err)
+	handlemap.Add(handle)
+	// Path should not be in the file cache (lazy open)
+	suite.assert.NoFileExists(suite.cache_path + "/" + src)
+
+	// rename open file
+	err = suite.fileCache.RenameFile(internal.RenameFileOptions{
+		Src: src,
+		Dst: dst,
+	})
+	suite.assert.NoError(err)
+	// rename succeeded in cloud
+	suite.assert.NoFileExists(filepath.Join(suite.fake_storage_path, src))
+	suite.assert.FileExists(filepath.Join(suite.fake_storage_path, dst))
+	// still in lazy open state
+	suite.assert.NoFileExists(filepath.Join(suite.cache_path, src))
+	suite.assert.NoFileExists(filepath.Join(suite.cache_path, dst))
+
+	// write to file handle
+	data := []byte("newdata")
+	n, err := suite.fileCache.WriteFile(internal.WriteFileOptions{
+		Handle: handle,
+		Data:   data,
+	})
+	suite.assert.NoError(err)
+	suite.assert.Equal(len(data), n)
+	// open is completed (file is downloaded), and writes go to the correct file
+	suite.assert.NoFileExists(filepath.Join(suite.cache_path, src))
+	suite.assert.FileExists(filepath.Join(suite.cache_path, dst))
+
+	// Close file handle
+	err = suite.fileCache.CloseFile(internal.CloseFileOptions{
+		Handle: handle,
+	})
+	suite.assert.NoError(err)
+
+	// Check cloud storage
+	suite.assert.NoFileExists(path.Join(suite.fake_storage_path, src)) // Src does not exist
+	suite.assert.FileExists(path.Join(suite.fake_storage_path, dst))   // Dst does exist
+	dstData, err := os.ReadFile(path.Join(suite.fake_storage_path, dst))
+	suite.assert.NoError(err)
+	suite.assert.Equal(data, dstData)
+}
+
+func (suite *fileCacheTestSuite) TestRenameOpenFileCase2() {
+	defer suite.cleanupTest()
+
+	src := "source6"
+	dst := "destination6"
+
+	// create source file
+	handle, err := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: src, Mode: 0666})
+	suite.assert.NoError(err)
+	handlemap.Add(handle)
+	// Path should be in the file cache
+	suite.assert.FileExists(suite.cache_path + "/" + src)
+
+	// rename open file
+	err = suite.fileCache.RenameFile(internal.RenameFileOptions{
+		Src: src,
+		Dst: dst,
+	})
+	suite.assert.NoError(err)
+
+	// write to file handle
+	data := []byte("newdata")
+	n, err := suite.fileCache.WriteFile(internal.WriteFileOptions{
+		Handle: handle,
+		Data:   data,
+	})
+	suite.assert.NoError(err)
+	suite.assert.Equal(len(data), n)
+
+	// Close file handle
+	err = suite.fileCache.CloseFile(internal.CloseFileOptions{
+		Handle: handle,
+	})
+	suite.assert.NoError(err)
+
+	// Check cloud storage
+	suite.assert.NoFileExists(path.Join(suite.fake_storage_path, src)) // Src does not exist
+	suite.assert.FileExists(path.Join(suite.fake_storage_path, dst))   // Dst does exist
+	dstData, err := os.ReadFile(path.Join(suite.fake_storage_path, dst))
+	suite.assert.NoError(err)
+	suite.assert.Equal(data, dstData)
+}
+
+func (suite *fileCacheTestSuite) TestRenameOpenFileCase3() {
+	defer suite.cleanupTest()
+
+	// Setup
+	src := "source7"
+	dst := "destination7"
+	// create source file
+	handle, err := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: src, Mode: 0666})
+	suite.assert.NoError(err)
+	handlemap.Add(handle)
+	// Path should be in the file cache
+	suite.assert.FileExists(suite.cache_path + "/" + src)
+	// write to file handle
+	initialData := []byte("initialData")
+	n, err := suite.fileCache.WriteFile(internal.WriteFileOptions{
+		Handle: handle,
+		Data:   initialData,
+	})
+	suite.assert.NoError(err)
+	suite.assert.Equal(len(initialData), n)
+	// flush to cloud
+	err = suite.fileCache.FlushFile(internal.FlushFileOptions{
+		Handle: handle,
+	})
+	suite.assert.NoError(err)
+	suite.assert.FileExists(filepath.Join(suite.fake_storage_path, src))
+
+	// rename open file
+	err = suite.fileCache.RenameFile(internal.RenameFileOptions{
+		Src: src,
+		Dst: dst,
+	})
+	suite.assert.NoError(err)
+	// write to file handle
+	newData := []byte("newData")
+	n, err = suite.fileCache.WriteFile(internal.WriteFileOptions{
+		Handle: handle,
+		Data:   newData,
+		Offset: int64(len(initialData)),
+	})
+	suite.assert.NoError(err)
+	suite.assert.Equal(len(newData), n)
+	// Close file handle
+	err = suite.fileCache.CloseFile(internal.CloseFileOptions{
+		Handle: handle,
+	})
+	suite.assert.NoError(err)
+
+	// Check that cloud storage got all data and file was renamed properly
+	suite.assert.NoFileExists(path.Join(suite.fake_storage_path, src)) // Src does not exist
+	suite.assert.FileExists(path.Join(suite.fake_storage_path, dst))   // Dst does exist
+	dstData, err := os.ReadFile(path.Join(suite.fake_storage_path, dst))
+	suite.assert.NoError(err)
+	suite.assert.Equal(append(initialData, newData...), dstData)
 }
 
 func (suite *fileCacheTestSuite) TestTruncateFileNotInCache() {


### PR DESCRIPTION
This PR fixes a bug that was causing upload failures:
When an open file is being written to, but is renamed before being closed, then closing the file fails.
This happens because the local file that CloseFile is trying to upload is the old filename, which does not exist.
The result is that the data still exists, with the right name, in local storage, **but it will not be uploaded** unless the file is opened and closed again using its new name.

In this change, RenameFile is changed to search the handlemap and update the Path field in any open handles to the file being renamed.

### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [x] Added tests

### Related Issues

- Related Issue #
- Closes #