### PR TITLE
File cache test filenames don't need to be unique anymore!

### DIFF
--- a/component/file_cache/cache_policy_test.go
+++ b/component/file_cache/cache_policy_test.go
@@ -76,6 +76,7 @@ func (suite *cachePolicyTestSuite) TestGetUsageSizeOnDisk() {
 	f, _ := os.Create(cache_path + "/test")
 	data := make([]byte, 4097)
 	f.Write(data)
+	f.Close()
 	result, err := common.GetUsage(cache_path)
 	suite.assert.NoError(err)
 

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -1161,15 +1161,9 @@ func (fc *FileCache) closeFileInternal(options internal.CloseFileOptions, flock 
 
 	flock.Dec()
 
-	// unnecessary but tidy bookkeeping
-	if noCachedHandle {
-		//set boolean in isDownloadNeeded value to signal that the file has been downloaded
-		options.Handle.RemoveValue("openFileOptions")
-		// was this the only handle?
-		if flock.Count() == 0 {
-			// update file state
-			flock.LazyOpen = false
-		}
+	// if this is the last lazy handle, clear the lazy flag
+	if noCachedHandle && flock.Count() == 0 {
+		flock.LazyOpen = false
 	}
 
 	// If it is an fsync op then purge the file

--- a/component/file_cache/file_cache_linux_test.go
+++ b/component/file_cache/file_cache_linux_test.go
@@ -113,8 +113,7 @@ func (suite *fileCacheLinuxTestSuite) TestChmodNotInCache() {
 	defer suite.cleanupTest()
 	// Setup - create file directly in fake storage
 	path := "file33"
-	handle, _ := suite.loopback.CreateFile(internal.CreateFileOptions{Name: path, Mode: 0777})
-	suite.loopback.CloseFile(internal.CloseFileOptions{Handle: handle})
+	suite.loopback.CreateFile(internal.CreateFileOptions{Name: path, Mode: 0777})
 
 	// Path should be in fake storage
 	suite.assert.FileExists(suite.fake_storage_path + "/" + path)
@@ -199,8 +198,7 @@ func (suite *fileCacheLinuxTestSuite) TestChownNotInCache() {
 	defer suite.cleanupTest()
 	// Setup
 	path := "file36"
-	handle, _ := suite.loopback.CreateFile(internal.CreateFileOptions{Name: path, Mode: 0777})
-	suite.loopback.CloseFile(internal.CloseFileOptions{Handle: handle})
+	suite.loopback.CreateFile(internal.CreateFileOptions{Name: path, Mode: 0777})
 
 	// Path should be in fake storage
 	suite.assert.FileExists(suite.fake_storage_path + "/" + path)

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -231,7 +231,6 @@ func (suite *fileCacheTestSuite) TestDefaultCacheSize() {
 		var out bytes.Buffer
 		cmd.Stdout = &out
 		err := cmd.Run()
-		fmt.Println(err)
 		suite.assert.NoError(err)
 		freeDisk, err = strconv.Atoi(strings.TrimSpace(out.String()))
 		suite.assert.NoError(err)

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -140,13 +140,9 @@ func (suite *fileCacheTestSuite) cleanupTest() {
 
 	// Delete the temp directories created
 	err = os.RemoveAll(suite.cache_path)
-	if err != nil {
-		fmt.Printf("fileCacheTestSuite::cleanupTest : os.RemoveAll(%s) failed [%v]\n", suite.cache_path, err)
-	}
+	suite.assert.NoError(err)
 	err = os.RemoveAll(suite.fake_storage_path)
-	if err != nil {
-		fmt.Printf("fileCacheTestSuite::cleanupTest : os.RemoveAll(%s) failed [%v]\n", suite.fake_storage_path, err)
-	}
+	suite.assert.NoError(err)
 }
 
 // Tests the default configuration of file cache


### PR DESCRIPTION
## ✅ What

* A bit of code cleanup.
* Simplify code that clears the lazy flag when a file handle is closed.
* Only close test file handles when it's needed (for Windows). 
* With this change, test cleanup runs correctly, and so tests can reuse filenames without fear of collisions.
* Add assert to make unit tests fail when cleanup fails
 
## 🤔 Why
 
In one case handles need to be closed for tests to run correclty, but in most cases it's needed so test cleanup can delete the test files.
 
## 👩‍🔬 How to validate if applicable
 
Run file cache unit tests on Windows and Linux, and see no errors complaining about failure to cleanup the test.