### PR TITLE
Fix Open File RenameDir Bug

### DIFF
--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -629,7 +629,7 @@ func (fc *FileCache) RenameDir(options internal.RenameDirOptions) error {
 				sflock := fc.fileLocks.Get(srcName)
 				dflock := fc.fileLocks.Get(dstName)
 				// complete local rename
-				err := fc.renameCachedFile(srcName, dstName, sflock, dflock)
+				err := fc.renameCachedFile(path, newPath, sflock, dflock)
 				if err != nil {
 					// there's really not much we can do to handle the error, so just log it
 					log.Err("FileCache::RenameDir : %s file rename failed. Directory state is inconsistent!", path)

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -633,9 +633,9 @@ func (fc *FileCache) RenameDir(options internal.RenameDirOptions) error {
 				if err != nil {
 					// there's really not much we can do to handle the error, so just log it
 					log.Err("FileCache::RenameDir : %s file rename failed. Directory state is inconsistent!", path)
-				} else {
-					fc.renameOpenHandles(srcName, dstName, sflock, dflock)
 				}
+				// handle should be updated regardless, for consistency on upload
+				fc.renameOpenHandles(srcName, dstName, sflock, dflock)
 			} else {
 				log.Debug("FileCache::RenameDir : Creating local destination directory %s", newPath)
 				// create the new directory

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -1543,7 +1543,6 @@ func (fc *FileCache) RenameFile(options internal.RenameFileOptions) error {
 		return err
 	}
 
-	// get local path
 	localSrcPath := filepath.Join(fc.tmpPath, options.Src)
 	localDstPath := filepath.Join(fc.tmpPath, options.Dst)
 
@@ -1576,7 +1575,6 @@ func (fc *FileCache) RenameFile(options internal.RenameFileOptions) error {
 }
 
 func (fc *FileCache) renameCachedFile(localSrcPath, localDstPath string, sflock, dflock *common.LockMapItem) error {
-	// rename local file
 	err := os.Rename(localSrcPath, localDstPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -1595,7 +1593,6 @@ func (fc *FileCache) renameCachedFile(localSrcPath, localDstPath string, sflock,
 		log.Debug("FileCache::renameCachedFile : %s -> %s Successfully renamed local file", localSrcPath, localDstPath)
 		fc.policy.CacheValid(localDstPath)
 	}
-
 	// delete the source from our cache policy
 	// this will also delete the source file from local storage (if rename failed)
 	fc.policy.CachePurge(localSrcPath, sflock)


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief
Similar to #404, this fixes a bug where renaming the parent directory of an open file clobbers the open file handle.

### Checklist

- [ ] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [x] Added tests

### Related Issues

- Related Issue #
- Closes #
