### PR TITLE
Correct validateStorageError in file_cache

### DIFF
--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -860,7 +860,7 @@ func (fc *FileCache) CreateFile(options internal.CreateFileOptions) (*handlemap.
 func (fc *FileCache) validateStorageError(path string, err error, method string, recoverable bool) error {
 	// For methods that take in file name, the goal is to update the path in cloud storage and the local cache.
 	// See comments in GetAttr for the different situations we can run into. This specifically handles case 2.
-	if !fc.createEmptyFile && os.IsNotExist(err) {
+	if os.IsNotExist(err) {
 		log.Debug("FileCache::%s : %s does not exist in cloud storage", method, path)
 		// Check if the file exists in the local cache
 		localPath := filepath.Join(fc.tmpPath, path)
@@ -868,7 +868,7 @@ func (fc *FileCache) validateStorageError(path string, err error, method string,
 			log.Err("FileCache::%s : %s does not exist in local cache", method, path)
 			return syscall.ENOENT
 		} else {
-			if !recoverable {
+			if !recoverable || fc.createEmptyFile {
 				log.Err("FileCache::%s : %s has not been closed/flushed yet, unable to recover this operation on close", method, path)
 				return syscall.EIO
 			} else {

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -860,7 +860,7 @@ func (fc *FileCache) CreateFile(options internal.CreateFileOptions) (*handlemap.
 func (fc *FileCache) validateStorageError(path string, err error, method string, recoverable bool) error {
 	// For methods that take in file name, the goal is to update the path in cloud storage and the local cache.
 	// See comments in GetAttr for the different situations we can run into. This specifically handles case 2.
-	if !fc.createEmptyFile && err == syscall.ENOENT || os.IsNotExist(err) {
+	if !fc.createEmptyFile && os.IsNotExist(err) {
 		log.Debug("FileCache::%s : %s does not exist in cloud storage", method, path)
 		// Check if the file exists in the local cache
 		localPath := filepath.Join(fc.tmpPath, path)

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -1007,7 +1007,7 @@ func (suite *fileCacheTestSuite) TestDeleteFileCase2CreateEmptyFileTrue() {
 	// test
 	err := suite.fileCache.DeleteFile(internal.DeleteFileOptions{Name: path})
 	suite.assert.Error(err)
-	suite.assert.True(os.IsNotExist(err))
+	suite.assert.EqualValues(syscall.EIO, err)
 }
 
 func (suite *fileCacheTestSuite) TestDeleteFileError() {


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief
`validateStorageError()` is meant to identify whether an `ENOENT` error returned by a cloud call is due to the file being in cache but not in cloud (case 2), and to clear the error in that case.
`validateStorageError()` was incorrectly clearing cloud `ENOENT` errors whenever `createEmptyFile` was true (without checking whether the local file exists).
To correct this, we could either not check the `createEmptyFile` flag at all, or we should require it be false before clearing cloud `ENOENT` errors. I chose the second option.

I also set `recoverable` to true in a `RenameFile()` call to `validateStorageError()` where it was mistakenly left set to false (after changing `RenameFile()` to support renaming open files).

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #
