### PR TITLE
Allow GUI to only mount as a drive letter on Windows

### DIFF
--- a/gui/mountPrimaryWindow.py
+++ b/gui/mountPrimaryWindow.py
@@ -71,20 +71,15 @@ class FUSEWindow(settingsManager,configFuncs, QMainWindow, Ui_primaryFUSEwindow)
             #   https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#file-and-directory-names
             # Disallow the following [<,>,.,",|,?,*] - note, we still need directory characters to declare a path
             self.lineEdit_mountPoint.setValidator(QtGui.QRegularExpressionValidator(r'^[^<>."|?\0*]*$',self))
-            self.button_driveLetter = QtWidgets.QPushButton('Drive Letter')
-            self.button_driveLetter.setToolTip('Select an unused drive letter for mounting')
-
-            self.horizontalLayout_3.addWidget(self.button_driveLetter)
-            self.button_driveLetter.clicked.connect(self.chooseDriveLetter)
+            self.button_browse.setText('Drive Letter')
+            self.button_browse.setToolTip('Select an unused drive letter for mounting')
+            self.button_browse.clicked.connect(self.chooseDriveLetter)
         else:
             # Allow anything BUT Nul
             # Note: Different versions of Python don't like the embedded null character, send in the raw string instead
             self.lineEdit_mountPoint.setValidator(QtGui.QRegularExpressionValidator(r'^[^\0]*$',self))
-
-            self.button_browse = QtWidgets.QPushButton('Browse')
+            self.button_browse.setText('Browse')
             self.button_browse.setToolTip('Browse to a pre-existing directory to mount')
-
-            self.horizontalLayout_3.addWidget(self.button_browse)
             self.button_browse.clicked.connect(self.getFileDirInput)
 
         # Set up the signals for all the interactive entities

--- a/gui/mountPrimaryWindow.py
+++ b/gui/mountPrimaryWindow.py
@@ -80,9 +80,14 @@ class FUSEWindow(settingsManager,configFuncs, QMainWindow, Ui_primaryFUSEwindow)
             # Allow anything BUT Nul
             # Note: Different versions of Python don't like the embedded null character, send in the raw string instead
             self.lineEdit_mountPoint.setValidator(QtGui.QRegularExpressionValidator(r'^[^\0]*$',self))
+            
+            self.button_browse = QtWidgets.QPushButton("Browse")
+            self.button_browse.setToolTip("Browse to a pre-existing directory to mount")
+
+            self.horizontalLayout_3.addWidget(self.button_browse)
+            self.button_browse.clicked.connect(self.getFileDirInput)
 
         # Set up the signals for all the interactive entities
-        self.button_browse.clicked.connect(self.getFileDirInput)
         self.button_config.clicked.connect(self.showSettingsWidget)
         self.button_mount.clicked.connect(self.mountBucket)
         self.button_unmount.clicked.connect(self.unmountBucket)
@@ -91,11 +96,9 @@ class FUSEWindow(settingsManager,configFuncs, QMainWindow, Ui_primaryFUSEwindow)
         self.lineEdit_mountPoint.editingFinished.connect(self.updateMountPointInSettings)
         self.dropDown_bucketSelect.currentIndexChanged.connect(self.modifyPipeline)
         if platform == 'win32':
-            self.lineEdit_mountPoint.setToolTip('Designate a new location to mount the bucket, do not create the directory')
-            self.button_browse.setToolTip("Browse to a new location but don't create a new directory")
+            self.lineEdit_mountPoint.setToolTip('Designate a drive letter to mount to')
         else:
             self.lineEdit_mountPoint.setToolTip('Designate a location to mount the bucket - the directory must already exist')
-            self.button_browse.setToolTip('Browse to a pre-existing directory')
 
     def checkConfigDirectory(self):
         workingDir = self.getWorkingDir()

--- a/gui/mountPrimaryWindow.py
+++ b/gui/mountPrimaryWindow.py
@@ -71,8 +71,8 @@ class FUSEWindow(settingsManager,configFuncs, QMainWindow, Ui_primaryFUSEwindow)
             #   https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#file-and-directory-names
             # Disallow the following [<,>,.,",|,?,*] - note, we still need directory characters to declare a path
             self.lineEdit_mountPoint.setValidator(QtGui.QRegularExpressionValidator(r'^[^<>."|?\0*]*$',self))
-            self.button_driveLetter = QtWidgets.QPushButton("Drive Letter")
-            self.button_driveLetter.setToolTip("Select an unused drive letter for mounting")
+            self.button_driveLetter = QtWidgets.QPushButton('Drive Letter')
+            self.button_driveLetter.setToolTip('Select an unused drive letter for mounting')
 
             self.horizontalLayout_3.addWidget(self.button_driveLetter)
             self.button_driveLetter.clicked.connect(self.chooseDriveLetter)
@@ -80,9 +80,9 @@ class FUSEWindow(settingsManager,configFuncs, QMainWindow, Ui_primaryFUSEwindow)
             # Allow anything BUT Nul
             # Note: Different versions of Python don't like the embedded null character, send in the raw string instead
             self.lineEdit_mountPoint.setValidator(QtGui.QRegularExpressionValidator(r'^[^\0]*$',self))
-            
-            self.button_browse = QtWidgets.QPushButton("Browse")
-            self.button_browse.setToolTip("Browse to a pre-existing directory to mount")
+
+            self.button_browse = QtWidgets.QPushButton('Browse')
+            self.button_browse.setToolTip('Browse to a pre-existing directory to mount')
 
             self.horizontalLayout_3.addWidget(self.button_browse)
             self.button_browse.clicked.connect(self.getFileDirInput)
@@ -179,9 +179,9 @@ class FUSEWindow(settingsManager,configFuncs, QMainWindow, Ui_primaryFUSEwindow)
         if platform == 'win32':
             drive, tail = os.path.splitdrive(directory)
             # Only append the cloudfuse suffix if not mounting to a drive letter
-            if not(drive and (tail == "" or tail in ["\\", "/"])):
+            if not(drive and (tail == '' or tail in ['\\', '/'])):
                 directory = os.path.join(directory, mountDirSuffix)
-            
+
             if os.path.exists(directory):
                 self.addOutputText(f"Directory {directory} already exists! Aborting new mount.")
                 self.errorMessageBox(f"Error: Cloudfuse needs to create the directory {directory}, but it already exists!")
@@ -242,7 +242,7 @@ class FUSEWindow(settingsManager,configFuncs, QMainWindow, Ui_primaryFUSEwindow)
         # TODO: properly handle unmount. This is relying on the line_edit not being changed by the user.
         drive, tail = os.path.splitdrive(directory)
         # Only append the cloudfuse suffix if not mounting to a drive letter
-        if not(drive and (tail == "" or tail in ["\\", "/"])):
+        if not(drive and (tail == '' or tail in ['\\', '/'])):
             directory = os.path.join(directory, mountDirSuffix)
         commandParts = [cloudfuseCli, 'unmount', directory]
         if platform != 'win32':
@@ -284,7 +284,7 @@ class FUSEWindow(settingsManager,configFuncs, QMainWindow, Ui_primaryFUSEwindow)
         # run command
         try:
             process = subprocess.run(
-                commandParts, 
+                commandParts,
                 capture_output=True,
                 creationflags=subprocess.CREATE_NO_WINDOW if hasattr(subprocess, 'CREATE_NO_WINDOW') else 0)
             stdOut = process.stdout.decode().strip()
@@ -312,13 +312,13 @@ class FUSEWindow(settingsManager,configFuncs, QMainWindow, Ui_primaryFUSEwindow)
     def chooseDriveLetter(self):
         unused_letters = get_unused_driver_letters()
         if not unused_letters:
-            QtWidgets.QMessageBox.warning(self, "No Drive Letters", "No unused drive letters available.")
+            QtWidgets.QMessageBox.warning(self, 'No Drive Letters', 'No unused drive letters available.')
             return
 
         drive, ok = QtWidgets.QInputDialog.getItem(
             self,
-            "Select Drive Letter",
-            "Available drive letters:",
+            'Select Drive Letter',
+            'Available drive letters:',
             unused_letters,
             0,
             False
@@ -331,7 +331,7 @@ def get_unused_driver_letters():
     bitmask = ctypes.windll.kernel32.GetLogicalDrives()
     unused = []
     for letter in string.ascii_uppercase:
-        if not ((bitmask & 1) or (letter == "A" or letter == "B")):
-            unused.append(letter + ":")
+        if not ((bitmask & 1) or (letter == 'A' or letter == 'B')):
+            unused.append(letter + ':')
         bitmask >>=1
     return unused

--- a/gui/mountPrimaryWindow.ui
+++ b/gui/mountPrimaryWindow.ui
@@ -52,17 +52,7 @@
       <item>
        <widget class="QLineEdit" name="lineEdit_mountPoint">
         <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Designate a location to mount the bucket - the directory must exist on Linux, but not on Windows&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="button_browse">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Choose a location to mount the bucket - the directory must exist on Linux, but not on Windows&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string>Browse</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Designate a location to mount the bucket&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
        </widget>
       </item>

--- a/gui/mountPrimaryWindow.ui
+++ b/gui/mountPrimaryWindow.ui
@@ -56,6 +56,13 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QPushButton" name="button_browse">
+        <property name="text">
+         <string>Browse</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </item>
     <item row="1" column="0" colspan="2">


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief

This changes the GUI to only allow mounting as a drive letter on Windows, to reduce user confusion and simplify the Windows mounting process. It replaces the browse button with one for drive letters that display the available drive letters to mount on. The old code is still there, so you can manually type a path and still mount to it, but the browse button in gone.

Here is how the GUI looks now on Windows.

![image](https://github.com/user-attachments/assets/031493ab-8b7e-4fc3-a72b-ef27d341c493)

![image](https://github.com/user-attachments/assets/97de0e56-ecc8-442b-832e-31d1f9b29c4c)



### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #
