### PR TITLE
Fix network share on Windows to use hostname for server

### DIFF
--- a/component/libfuse/libfuse2_handler.go
+++ b/component/libfuse/libfuse2_handler.go
@@ -134,33 +134,29 @@ func (lf *Libfuse) initFuse() error {
 
 	// Runs as network file share on Windows only when mounting to drive letter.
 	if runtime.GOOS == "windows" && lf.networkShare && common.IsDriveLetter(lf.mountPath) {
-		// TODO: We can support any type of valid network share path so this path could
-		// be configurable for the config file. But this is a good default.
+		var nameStorage string
 
-		// by default nameStorage will be blank
-		nameStorage := "default"
-		kindStorage := "cloud"
+		serverName, err := os.Hostname()
+		if err != nil {
+			log.Err("Libfuse::initFuse : failed to mount fuse. unable to determine server host name.")
+			return errors.New("failed to mount fuse. unable to determine server host name")
+		}
 		// Borrow bucket-name string from attribute cache
 		if config.IsSet("s3storage.bucket-name") {
-
 			err := config.UnmarshalKey("s3storage.bucket-name", &nameStorage)
 			if err != nil {
-				nameStorage = "default"
+				nameStorage = "s3"
 				log.Err("initFuse : Failed to unmarshal s3storage.bucket-name")
-			} else {
-				kindStorage = "bucket"
 			}
 		} else if config.IsSet("azstorage.container") {
 			err := config.UnmarshalKey("azstorage.container", &nameStorage)
 			if err != nil {
-				nameStorage = "default"
+				nameStorage = "azure"
 				log.Err("initFuse : Failed to unmarshal s3storage.bucket-name")
-			} else {
-				kindStorage = "container"
 			}
 		}
 
-		volumePrefix := fmt.Sprintf("--VolumePrefix=\\%s\\%s", kindStorage, nameStorage)
+		volumePrefix := fmt.Sprintf("--VolumePrefix=\\%s\\%s", serverName, nameStorage)
 		opts = append(opts, volumePrefix)
 	}
 


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief

When using network share on Windows, we should use the hostname for the server name so that Windows can properly set permissions for the share.

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #
