### PR TITLE
Add support for custom SDDL strings for permissions on Windows

### DIFF
--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -43,8 +43,9 @@ generate SDDL strings to change permissions.
 
    If you used the standard cloudfuse installer on Windows, then WinFsp is already installed on your system.
 
-2. Find Your Account's SID and UID Use the fsptool utility to discover your account's SID and UID. Open a command prompt
-and run:
+2. Find Your Account's SID and UID:
+
+   Use the fsptool utility to discover your account's SID and UID. Open a command prompt and run:
 
         'C:\Program Files (x86)\WinFsp\bin\fsptool-x64.exe' id
 

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -12,8 +12,8 @@ To run in foreground mode, you must pass the option `--foreground=true` when usi
 
 ## Running in background mode (recommended)
 
-Cloudfuse runs in the background by default. It uses the WinFSP launcher to run the mount in the background.
-Cloudfuse will also automatically restart existing mounts on user login.
+Cloudfuse runs in the background by default. It uses the WinFSP launcher to run the mount in the background. Cloudfuse
+will also automatically restart existing mounts on user login.
 
         cloudfuse.exe mount <mount path> --config-file=<config file>
 
@@ -23,13 +23,51 @@ To unmount a specific instance, use the unmount command. This will also prevent 
 
 Cloudfuse supports mounting any number of buckets.
 
-If the container is not automatically mounted on user login after a reboot, you may need to (re)install the Cloudfuse startup program:
+If the container is not automatically mounted on user login after a reboot, you may need to (re)install the Cloudfuse
+startup program:
 
         cloudfuse.exe service install
 
 To uninstall the Cloudfuse startup program use the uninstall command.
 
         cloudfuse.exe service uninstall
+
+## Windows Security and User Permissions
+
+By default, cloudfuse allows all users to read/write to the mounted directory. If you need specific permissions for your
+share you must provide them in your config file when you mount using cloudfuse. This requires you to generate and use
+Security Descriptor Definition Language (SDDL) strings to manage permissions. We provide a brief example for how to
+generate SDDL strings to change permissions.
+
+1. Ensure that you have WinFsp installed on your system:
+
+   If you used the standard cloudfuse installer on Windows, then WinFsp is already installed on your system.
+
+2. Find Your Account's SID and UID Use the fsptool utility to discover your account's SID and UID. Open a command prompt
+and run:
+
+        'C:\Program Files (x86)\WinFsp\bin\fsptool-x64.exe' id
+
+   This will output something like:
+
+        User=S-1-5-21-773277305-2169295204-1991566178-478888(user) (uid=21479625)
+        Owner=S-1-5-21-773277305-2169295204-1991566178-478888(user) (uid=21479625)
+        Group=S-1-5-21-773277305-2169295204-1991566178-478888(user) (gid=21479625)
+
+3. Generate SDDL for Specific Permissions: Use the fsptool to generate the SDDL string for your account's UID with
+specific permissions. For example, to generate an SDDL for rwx------ permissions:
+
+        'C:\Program Files (x86)\WinFsp\bin\fsptool-x64.exe' perm 21479625:0:700
+
+   This will output something like:
+
+        O:S-1-0-65534G:S-1-5-0D:P(A;;0x1f01bf;;;S-1-0-65534)(A;;0x120088;;;S-1-5-0)(A;;0x120088;;;WD) (perm=65534:0:0700)
+
+4. Edit your config file: Edit the libfuse section of the config.yaml file to include the windows-sddl entry. Add the
+SDDL string you generated in the previous step. For example:
+
+        libfuse:
+          windows-sddl: O:S-1-0-65534G:S-1-5-0D:P(A;;0x1f01bf;;;S-1-0-65534)(A;;0x120088;;;S-1-5-0)(A;;0x120088;;;WD)
 
 ## Filename Limitations
 

--- a/component/libfuse/libfuse.go
+++ b/component/libfuse/libfuse.go
@@ -73,6 +73,7 @@ type Libfuse struct {
 	directIO              bool
 	umask                 uint32
 	displayCapacityMb     uint64
+	windowsSDDL           string
 }
 
 // To support pagination in readdir calls this structure holds a block of items for a given directory
@@ -107,6 +108,7 @@ type LibfuseOptions struct {
 	DirectIO                bool   `config:"direct-io" yaml:"direct-io,omitempty"`
 	Umask                   uint32 `config:"umask" yaml:"umask,omitempty"`
 	DisplayCapacityMb       uint64 `config:"display-capacity-mb" yaml:"display-capacity-mb,omitempty"`
+	WindowsSSDL             string `config:"windows-sddl" yaml:"windows-sddl,omitempty"`
 }
 
 const compName = "libfuse"
@@ -202,6 +204,7 @@ func (lf *Libfuse) Validate(opt *LibfuseOptions) error {
 	lf.ownerGID = opt.Gid
 	lf.ownerUID = opt.Uid
 	lf.umask = opt.Umask
+	lf.windowsSDDL = opt.WindowsSSDL
 
 	if opt.allowOther {
 		lf.dirPermission = uint(common.DefaultAllowOtherPermissionBits)

--- a/component/libfuse/libfuse2_handler.go
+++ b/component/libfuse/libfuse2_handler.go
@@ -68,6 +68,8 @@ type CgofuseFS struct {
 	gid uint32
 }
 
+const windowsDefaultSDDL = "D:P(A;;FA;;;WD)" // Enables everyone on system to have access to mount
+
 // Note: libfuse prepends "/" to the path.
 // TODO: Not sure if this is needed for cgofuse, will need to check
 // trimFusePath trims the first character from the path provided by libfuse
@@ -122,8 +124,11 @@ func (lf *Libfuse) initFuse() error {
 			lf.negativeTimeout)
 
 		// Using SSDL file security option: https://github.com/rclone/rclone/issues/4717
-		// Enables everyone on system to have access to mount
-		options += ",FileSecurity=D:P(A;;FA;;;WD)"
+		windowsSDDL := windowsDefaultSDDL
+		if lf.windowsSDDL != "" {
+			windowsSDDL = lf.windowsSDDL
+		}
+		options += ",FileSecurity=" + windowsSDDL
 	}
 
 	fuse_options := createFuseOptions(lf.host, lf.allowOther, lf.allowRoot, lf.readOnly, lf.nonEmptyMount, lf.maxFuseThreads, lf.umask)

--- a/setup/advancedConfig.yaml
+++ b/setup/advancedConfig.yaml
@@ -27,7 +27,6 @@
 #  10. 'sdk-trace' has been removed and setting log level to log_debug will auto enable these logs.
 # -----------------------------------------------------------------------------------------------------------------------
 
-
 # Daemon configuration
 foreground: true|false <run blobfuse2 in foreground or background>
 
@@ -73,6 +72,7 @@ libfuse:
   max-fuse-threads: <number of threads allowed at libfuse layer for highly parallel operations, Default is 128>
   direct-io: true|false <enable to bypass the kernel cache>
   network-share: true|false <runs as a network share. may improve performance when latency to cloud is high. only supported on Windows. Known issue - only one Cloudfuse network share can be mounted at a time>
+  windows-sddl: <windows file security and permissions setting in SDDL syntax. Default - D:P(A;;FA;;;WD) corresponding to every user having read/write access>
 
 # Streaming configuration – remove and redirect to block-cache
 stream:
@@ -128,7 +128,7 @@ loopbackfs:
 
 # Azure storage configuration
 azstorage:
-# Required
+  # Required
   type: block|adls <type of storage account to be connected. Default - block>
   account-name: <name of the storage account>
   container: <name of the storage container to be mounted>
@@ -167,11 +167,11 @@ azstorage:
   virtual-directory: true|false <support virtual directories without existence of a special marker blob. Default - true>
   disable-compression: true|false <disable transport layer content encoding like gzip, set this flag to true if blobs have content-encoding set in container>
   max-results-for-list: <maximum number of results returned in a single list API call while getting file attributes. Default - 2>
-  telemetry : <additional information that customer want to push in user-agent>
+  telemetry: <additional information that customer want to push in user-agent>
   honour-acl: true|false <honour ACLs on files and directories when mounted using MSI Auth and object-ID is provided in config>
   cpk-enabled: true|false <enable client provided key encryption>
   cpk-encryption-key: <customer provided base64-encoded AES-256 encryption key value>
-  cpk-encryption-key-sha256:  <customer provided base64-encoded sha256 of the encryption key>
+  cpk-encryption-key-sha256: <customer provided base64-encoded sha256 of the encryption key>
 
 # S3 storage configuration
 s3storage:

--- a/setup/baseConfig.yaml
+++ b/setup/baseConfig.yaml
@@ -27,7 +27,6 @@
 #  10. 'sdk-trace' has been removed and setting log level to log_debug will auto enable these logs.
 # -----------------------------------------------------------------------------------------------------------------------
 
-
 # Daemon configuration
 foreground: true|false <run cloudfuse in foreground or background>
 
@@ -71,6 +70,7 @@ libfuse:
   direct-io: true|false <enable to bypass the kernel cache>
   network-share: true|false <runs as a network share. may improve performance when latency to cloud is high. only supported on Windows. Known issue - only one Cloudfuse network share can be mounted at a time>
   display-capacity-mb: <number of MB to display as the mounted storage capacity. Default - 1TB (1048576 MB)>
+  windows-sddl: <windows file security and permissions setting in SDDL syntax. Default - D:P(A;;FA;;;WD) corresponding to every user having read/write access>
 
   # Streaming configuration
 stream:
@@ -126,7 +126,7 @@ loopbackfs:
 
 # Azure storage configuration
 azstorage:
-# Required
+  # Required
   type: block|adls <type of storage account to be connected. Default - block>
   account-name: <name of the storage account>
   container: <name of the storage container to be mounted>
@@ -165,11 +165,11 @@ azstorage:
   virtual-directory: true|false <support virtual directories without existence of a special marker blob. Default - true>
   disable-compression: true|false <disable transport layer content encoding like gzip, set this flag to true if blobs have content-encoding set in container>
   max-results-for-list: <maximum number of results returned in a single list API call while getting file attributes. Default - 2>
-  telemetry : <additional information that customer want to push in user-agent>
+  telemetry: <additional information that customer want to push in user-agent>
   honour-acl: true|false <honour ACLs on files and directories when mounted using MSI Auth and object-ID is provided in config>
   cpk-enabled: true|false <enable client provided key encryption>
   cpk-encryption-key: <customer provided base64-encoded AES-256 encryption key value>
-  cpk-encryption-key-sha256:  <customer provided base64-encoded sha256 of the encryption key>
+  cpk-encryption-key-sha256: <customer provided base64-encoded sha256 of the encryption key>
 
 # S3 storage configuration
 s3storage:


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief

This adds the ability for the user to change the default user / file permissions in windows by passing a SDDL string in the config file. Additionally, adds some instructions and guidance on how to do this.

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [x] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #
