### PR TITLE
Add windows startup to no_gui installer

### DIFF
--- a/build/windows_installer_build_no_gui.iss
+++ b/build/windows_installer_build_no_gui.iss
@@ -44,6 +44,7 @@ Name: "{userappdata}\{#MyAppName}"; Flags: uninsalwaysuninstall
 [Files]
 Source: "..\cloudfuse.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\cfusemon.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\windows-startup.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\NOTICE"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\LICENSE"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\README.md"; DestDir: "{app}"; Flags: ignoreversion


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief

Add windows_startup binary to the no_gui installer to allow the user to run cloudfuse service install and have mounts start on remount.

### Checklist

- [ ] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #
