### PR TITLE
Fix widows service install command

### DIFF
--- a/cmd/service_windows.go
+++ b/cmd/service_windows.go
@@ -70,13 +70,9 @@ var installCmd = &cobra.Command{
 	Example:           "cloudfuse service install",
 	FlagErrorHandling: cobra.ExitOnError,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		dir, err := os.Getwd()
-		if err != nil {
-			return fmt.Errorf("unable to determine location of cloudfuse binary [%s]", err.Error())
-		}
-		programPath := filepath.Join(dir, "windows-startup.exe")
+		programPath := filepath.Join("C:", "Program Files", "Cloudfuse", "windows-startup.exe")
 		startupPath := filepath.Join(os.Getenv("APPDATA"), "Microsoft", "Windows", "Start Menu", "Programs", "Startup", StartupName)
-		err = makeLink(programPath, startupPath)
+		err := makeLink(programPath, startupPath)
 		if err != nil {
 			return fmt.Errorf("unable to create startup link [%s]", err.Error())
 		}


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief

Fixes the windows startup link when using the service install command.

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #
