### PR TITLE
Fix issue with secure config failed due to incorrectly decoding the b…

### DIFF
--- a/cmd/secure_test.go
+++ b/cmd/secure_test.go
@@ -130,6 +130,27 @@ func (suite *secureConfigTestSuite) TestSecureConfigEncrypt() {
 	suite.assert.NoFileExists(confFile.Name())
 }
 
+func (suite *secureConfigTestSuite) TestSecureConfigEncrypt2() {
+	defer suite.cleanupTest()
+	confFile, _ := os.CreateTemp("", "conf*.yaml")
+	outFile, _ := os.CreateTemp("", "conf*.yaml")
+	passphrase := "hvHlJUKlmZql3gLAcP6Ho41Js5rm8zUAKnwGb1lIffg="
+
+	defer os.Remove(confFile.Name())
+	defer os.Remove(outFile.Name())
+
+	_, err := confFile.WriteString(testPlainTextConfig)
+	suite.assert.NoError(err)
+
+	confFile.Close()
+
+	_, err = executeCommandSecure(rootCmd, "secure", "encrypt", fmt.Sprintf("--config-file=%s", confFile.Name()), fmt.Sprintf("--passphrase=%s", passphrase), fmt.Sprintf("--output-file=%s", outFile.Name()))
+	suite.assert.NoError(err)
+
+	// Config file should be deleted
+	suite.assert.NoFileExists(confFile.Name())
+}
+
 func (suite *secureConfigTestSuite) TestSecureConfigEncryptNoOutfile() {
 	defer suite.cleanupTest()
 	confFile, _ := os.CreateTemp("", "conf*.yaml")
@@ -208,6 +229,40 @@ func (suite *secureConfigTestSuite) TestSecureConfigDecrypt() {
 	confFile, _ := os.CreateTemp("", "conf*.yaml")
 	outFile, _ := os.CreateTemp("", "conf*.yaml")
 	passphrase := "12312312312312312312312312312312"
+	fmt.Println(passphrase)
+
+	defer os.Remove(confFile.Name())
+	defer os.Remove(outFile.Name())
+
+	_, err := confFile.WriteString(testPlainTextConfig)
+	suite.assert.NoError(err)
+
+	confFile.Close()
+	outFile.Close()
+
+	_, err = executeCommandSecure(rootCmd, "secure", "encrypt", fmt.Sprintf("--config-file=%s", confFile.Name()), fmt.Sprintf("--passphrase=%s", passphrase), fmt.Sprintf("--output-file=%s", outFile.Name()))
+	suite.assert.NoError(err)
+
+	// Config file should be deleted
+	suite.assert.NoFileExists(confFile.Name())
+
+	_, err = executeCommandSecure(rootCmd, "secure", "decrypt", fmt.Sprintf("--config-file=%s", outFile.Name()), fmt.Sprintf("--passphrase=%s", passphrase), fmt.Sprintf("--output-file=./tmp.yaml"))
+	suite.assert.NoError(err)
+
+	data, err := os.ReadFile("./tmp.yaml")
+	suite.assert.NoError(err)
+
+	suite.assert.Equal(testPlainTextConfig, string(data))
+
+	os.Remove("./tmp.yaml")
+	os.Remove(confFile.Name() + "." + SecureConfigExtension)
+}
+
+func (suite *secureConfigTestSuite) TestSecureConfigDecrypt2() {
+	defer suite.cleanupTest()
+	confFile, _ := os.CreateTemp("", "conf*.yaml")
+	outFile, _ := os.CreateTemp("", "conf*.yaml")
+	passphrase := "hvHlJUKlmZql3gLAcP6Ho41Js5rm8zUAKnwGb1lIffg="
 	fmt.Println(passphrase)
 
 	defer os.Remove(confFile.Name())

--- a/common/util.go
+++ b/common/util.go
@@ -246,12 +246,17 @@ func EncryptData(plainData []byte, key *memguard.Enclave) ([]byte, error) {
 	}
 	defer secretKey.Destroy()
 
-	binaryKey, err := base64.StdEncoding.DecodeString(secretKey.String())
-
-	block, err := aes.NewCipher(binaryKey)
+	decodedKey := make([]byte, 32)
+	_, err = base64.StdEncoding.Decode(decodedKey, secretKey.Bytes())
 	if err != nil {
 		return nil, err
 	}
+
+	block, err := aes.NewCipher(decodedKey)
+	if err != nil {
+		return nil, err
+	}
+	clear(decodedKey)
 
 	gcm, err := cipher.NewGCM(block)
 	if err != nil {
@@ -279,12 +284,17 @@ func DecryptData(cipherData []byte, key *memguard.Enclave) ([]byte, error) {
 	}
 	defer secretKey.Destroy()
 
-	binaryKey, err := base64.StdEncoding.DecodeString(secretKey.String())
-
-	block, err := aes.NewCipher(binaryKey)
+	decodedKey := make([]byte, 32)
+	_, err = base64.StdEncoding.Decode(decodedKey, secretKey.Bytes())
 	if err != nil {
 		return nil, err
 	}
+
+	block, err := aes.NewCipher(decodedKey)
+	if err != nil {
+		return nil, err
+	}
+	clear(decodedKey)
 
 	gcm, err := cipher.NewGCM(block)
 	if err != nil {

--- a/common/util.go
+++ b/common/util.go
@@ -246,11 +246,18 @@ func EncryptData(plainData []byte, key *memguard.Enclave) ([]byte, error) {
 	}
 	defer secretKey.Destroy()
 
-	decodedKey := make([]byte, 32)
+	// A base64 encode of a key of length 32 will be at maximum a length of 44 bytes
+	if len(secretKey.Bytes()) > 44 {
+		return nil, errors.New("Provided decoded base64 key is longer than 32 bytes. Decoded key " +
+			"length shall be 16 (AES-128), 24 (AES-192), or 32 (AES-256) bytes in length.")
+	}
+
+	decodedKey := make([]byte, 32) // Valid key can't be longer than 32 bytes
 	_, err = base64.StdEncoding.Decode(decodedKey, secretKey.Bytes())
 	if err != nil {
 		return nil, err
 	}
+	decodedKey = bytes.Trim(decodedKey, "\x00") // trim any null bytes if key is 16, or 24 bytes
 
 	block, err := aes.NewCipher(decodedKey)
 	if err != nil {
@@ -284,11 +291,18 @@ func DecryptData(cipherData []byte, key *memguard.Enclave) ([]byte, error) {
 	}
 	defer secretKey.Destroy()
 
-	decodedKey := make([]byte, 32)
+	// A base64 encode of a key of length 32 will be at maximum a length of 44 bytes
+	if len(secretKey.Bytes()) > 44 {
+		return nil, errors.New("Provided decoded base64 key is longer than 32 bytes. Decoded key " +
+			"length shall be 16 (AES-128), 24 (AES-192), or 32 (AES-256) bytes in length.")
+	}
+
+	decodedKey := make([]byte, 32) // Valid key can't be longer than 32 bytes
 	_, err = base64.StdEncoding.Decode(decodedKey, secretKey.Bytes())
 	if err != nil {
 		return nil, err
 	}
+	decodedKey = bytes.Trim(decodedKey, "\x00") // trim any null bytes if key is 16, or 24 bytes
 
 	block, err := aes.NewCipher(decodedKey)
 	if err != nil {

--- a/common/util.go
+++ b/common/util.go
@@ -30,6 +30,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -245,7 +246,9 @@ func EncryptData(plainData []byte, key *memguard.Enclave) ([]byte, error) {
 	}
 	defer secretKey.Destroy()
 
-	block, err := aes.NewCipher(secretKey.Data())
+	binaryKey, err := base64.StdEncoding.DecodeString(secretKey.String())
+
+	block, err := aes.NewCipher(binaryKey)
 	if err != nil {
 		return nil, err
 	}
@@ -276,7 +279,9 @@ func DecryptData(cipherData []byte, key *memguard.Enclave) ([]byte, error) {
 	}
 	defer secretKey.Destroy()
 
-	block, err := aes.NewCipher(secretKey.Data())
+	binaryKey, err := base64.StdEncoding.DecodeString(secretKey.String())
+
+	block, err := aes.NewCipher(binaryKey)
 	if err != nil {
 		return nil, err
 	}

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -78,7 +78,7 @@ func (suite *typesTestSuite) TestDirectoryDoesNotExist() {
 	suite.assert.False(exists)
 }
 
-func (suite *typesTestSuite) TestEncryptBadKey() {
+func (suite *typesTestSuite) TestEncryptBadKeyTooSmall() {
 	// Generate a random key
 	key := make([]byte, 20)
 	encodedKey := make([]byte, 28)
@@ -94,10 +94,42 @@ func (suite *typesTestSuite) TestEncryptBadKey() {
 	suite.assert.Error(err)
 }
 
-func (suite *typesTestSuite) TestDecryptBadKey() {
+func (suite *typesTestSuite) TestDecryptBadKeyTooSmall() {
 	// Generate a random key
 	key := make([]byte, 20)
 	encodedKey := make([]byte, 28)
+	rand.Read(key)
+	base64.StdEncoding.Encode(encodedKey, key)
+
+	encryptedPassphrase := memguard.NewEnclave(encodedKey)
+
+	data := make([]byte, 1024)
+	rand.Read(data)
+
+	_, err := DecryptData(data, encryptedPassphrase)
+	suite.assert.Error(err)
+}
+
+func (suite *typesTestSuite) TestEncryptBadKeyTooLong() {
+	// Generate a random key
+	key := make([]byte, 36)
+	encodedKey := make([]byte, 48)
+	rand.Read(key)
+	base64.StdEncoding.Encode(encodedKey, key)
+
+	encryptedPassphrase := memguard.NewEnclave(encodedKey)
+
+	data := make([]byte, 1024)
+	rand.Read(data)
+
+	_, err := EncryptData(data, encryptedPassphrase)
+	suite.assert.Error(err)
+}
+
+func (suite *typesTestSuite) TestDecryptBadKeyTooLong() {
+	// Generate a random key
+	key := make([]byte, 36)
+	encodedKey := make([]byte, 48)
 	rand.Read(key)
 	base64.StdEncoding.Encode(encodedKey, key)
 

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -27,6 +27,7 @@ package common
 
 import (
 	"crypto/rand"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -80,9 +81,11 @@ func (suite *typesTestSuite) TestDirectoryDoesNotExist() {
 func (suite *typesTestSuite) TestEncryptBadKey() {
 	// Generate a random key
 	key := make([]byte, 20)
+	encodedKey := make([]byte, 28)
 	rand.Read(key)
+	base64.StdEncoding.Encode(encodedKey, key)
 
-	encryptedPassphrase := memguard.NewEnclave(key)
+	encryptedPassphrase := memguard.NewEnclave(encodedKey)
 
 	data := make([]byte, 1024)
 	rand.Read(data)
@@ -94,9 +97,11 @@ func (suite *typesTestSuite) TestEncryptBadKey() {
 func (suite *typesTestSuite) TestDecryptBadKey() {
 	// Generate a random key
 	key := make([]byte, 20)
+	encodedKey := make([]byte, 28)
 	rand.Read(key)
+	base64.StdEncoding.Encode(encodedKey, key)
 
-	encryptedPassphrase := memguard.NewEnclave(key)
+	encryptedPassphrase := memguard.NewEnclave(encodedKey)
 
 	data := make([]byte, 1024)
 	rand.Read(data)
@@ -108,9 +113,11 @@ func (suite *typesTestSuite) TestDecryptBadKey() {
 func (suite *typesTestSuite) TestEncryptDecrypt16() {
 	// Generate a random key
 	key := make([]byte, 16)
+	encodedKey := make([]byte, 24)
 	rand.Read(key)
+	base64.StdEncoding.Encode(encodedKey, key)
 
-	encryptedPassphrase := memguard.NewEnclave(key)
+	encryptedPassphrase := memguard.NewEnclave(encodedKey)
 
 	data := make([]byte, 1024)
 	rand.Read(data)
@@ -126,9 +133,11 @@ func (suite *typesTestSuite) TestEncryptDecrypt16() {
 func (suite *typesTestSuite) TestEncryptDecrypt24() {
 	// Generate a random key
 	key := make([]byte, 24)
+	encodedKey := make([]byte, 32)
 	rand.Read(key)
+	base64.StdEncoding.Encode(encodedKey, key)
 
-	encryptedPassphrase := memguard.NewEnclave(key)
+	encryptedPassphrase := memguard.NewEnclave(encodedKey)
 
 	data := make([]byte, 1024)
 	rand.Read(data)
@@ -144,9 +153,11 @@ func (suite *typesTestSuite) TestEncryptDecrypt24() {
 func (suite *typesTestSuite) TestEncryptDecrypt32() {
 	// Generate a random key
 	key := make([]byte, 32)
+	encodedKey := make([]byte, 44)
 	rand.Read(key)
+	base64.StdEncoding.Encode(encodedKey, key)
 
-	encryptedPassphrase := memguard.NewEnclave(key)
+	encryptedPassphrase := memguard.NewEnclave(encodedKey)
 
 	data := make([]byte, 1024)
 	rand.Read(data)


### PR DESCRIPTION
…ase64 string, and allow for env variable when passing passphrase when generating config


### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief

This fixes several issues with encrypted config files. First it fixes a bug from switching to memguard where we did not decode the passphrase string from base64 which could cause error with some encryption keys. Additionally, we allow using gen-config command with the passphrase environment variable.

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #
