### PR TITLE
Add update command for cloudfuse on Linux

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -27,6 +27,7 @@ package cmd
 
 import (
 	"bytes"
+	"crypto/rand"
 	"fmt"
 	"strings"
 	"testing"
@@ -58,6 +59,12 @@ func resetCLIFlags(cmd cobra.Command) {
 		f.Value.Set(f.DefValue)
 	})
 	viper.Reset()
+}
+
+func randomString(length int) string {
+	b := make([]byte, length)
+	rand.Read(b)
+	return fmt.Sprintf("%x", b)[:length]
 }
 
 // Taken from cobra library's testing https://github.com/spf13/cobra/blob/master/command_test.go#L34

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -27,7 +27,6 @@ package cmd
 
 import (
 	"bytes"
-	"crypto/rand"
 	"fmt"
 	"strings"
 	"testing"
@@ -59,12 +58,6 @@ func resetCLIFlags(cmd cobra.Command) {
 		f.Value.Set(f.DefValue)
 	})
 	viper.Reset()
-}
-
-func randomString(length int) string {
-	b := make([]byte, length)
-	rand.Read(b)
-	return fmt.Sprintf("%x", b)[:length]
 }
 
 // Taken from cobra library's testing https://github.com/spf13/cobra/blob/master/command_test.go#L34

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -76,7 +76,7 @@ var updateCmd = &cobra.Command{
 	Long:  "Update the cloudfuse binary.",
 	RunE: func(command *cobra.Command, args []string) error {
 		if runtime.GOOS == "windows" {
-			return errors.New("Update is not supported on Windows")
+			return errors.New("Update is not supported on Windows. Download the latest release manually here https://github.com/Seagate/cloudfuse/releases/latest.")
 		}
 		if opt.Package == "" {
 			packageFormat, err := determinePackageFormat()

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,0 +1,311 @@
+/*
+   Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+
+   Copyright © 2023-2025 Seagate Technology LLC and/or its Affiliates
+   Copyright © 2020-2024 Microsoft Corporation. All rights reserved.
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE
+*/
+
+package cmd
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	_ "embed"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	"github.com/Seagate/cloudfuse/common"
+	"github.com/spf13/cobra"
+)
+
+// Options for the CLI update command
+type Options struct {
+	Output  string // output path
+	Version string
+	Package string // package format: tar, deb, rpm
+}
+
+var Opt = Options{}
+
+type asset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+type release struct {
+	TagName string  `json:"tag_name"`
+	Assets  []asset `json:"assets"`
+}
+
+type releaseInfo struct {
+	Version   string
+	AssetURL  string
+	AssetName string
+	HashURL   string
+}
+
+func randomString(length int) string {
+	b := make([]byte, length)
+	rand.Read(b)
+	return fmt.Sprintf("%x", b)[:length]
+}
+
+var updateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update the cloudfuse binary.",
+	Long:  "Update the cloudfuse binary.",
+	RunE: func(command *cobra.Command, args []string) error {
+		if runtime.GOOS == "windows" {
+			return errors.New("Update is not supported on Windows")
+		}
+		if Opt.Package == "" {
+			Opt.Package = "tar"
+		}
+		if Opt.Output == "" && Opt.Package == "tar" {
+			return errors.New("Need to pass --package with deb or rpm or specify an --output location for Linux")
+		}
+		if Opt.Package != "tar" && Opt.Package != "deb" && Opt.Package != "rpm" {
+			return errors.New("--package should be one of tar|deb|rpm")
+		}
+		if runtime.GOOS != "linux" && (Opt.Package == "deb" || Opt.Package == "rpm") {
+			return errors.New(".deb and .rpm packages are supported only on Linux")
+		}
+		if os.Geteuid() != 0 && Opt.Output == "" && (Opt.Package == "deb" || Opt.Package == "rpm") {
+			return errors.New(".deb and .rpm requires elevated privileges")
+		}
+		if err := installUpdate(context.Background(), &Opt); err != nil {
+			return fmt.Errorf("Error: %v", err)
+		}
+		return nil
+	},
+}
+
+// installUpdate performs the self-update
+func installUpdate(ctx context.Context, opt *Options) error {
+	relInfo, err := getRelease(ctx, opt.Version)
+	if err != nil {
+		return fmt.Errorf("unable to detect new version: %w", err)
+	}
+
+	if relInfo.Version == common.CloudfuseVersion {
+		fmt.Println("cloudfuse is up to date")
+		return nil
+	}
+
+	fileName, err := downloadUpdate(ctx, relInfo, opt.Output)
+	if err != nil {
+		return fmt.Errorf("unable to download release: %w", err)
+	}
+
+	if err := verifyHash(fileName, relInfo.AssetName, relInfo.HashURL); err != nil {
+		return fmt.Errorf("unable to verify checksum: %w", err)
+	}
+
+	if opt.Output != "" {
+		return nil
+	}
+
+	return installPackage(fileName)
+}
+
+// installPackage installs the deb or rpm package
+func installPackage(fileName string) error {
+	var packageCommand string
+	if strings.HasSuffix(fileName, "deb") {
+		packageCommand = "dpkg"
+	} else if strings.HasSuffix(fileName, "rpm") {
+		packageCommand = "rpm"
+	} else {
+		return errors.New("unsupported package format")
+	}
+
+	cmd := exec.Command(packageCommand, "-i", fileName)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to run %s: %v", packageCommand, err)
+	}
+	return nil
+}
+
+// downloadUpdate downloads the update file
+func downloadUpdate(ctx context.Context, relInfo *releaseInfo, output string) (string, error) {
+	resp, err := http.Get(relInfo.AssetURL)
+	if err != nil {
+		return "", fmt.Errorf("unable to get URL %s: %w", relInfo.AssetURL, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to get release info: %s", resp.Status)
+	}
+
+	var installFile *os.File
+	if output != "" {
+		installFile, err = os.Create(output)
+	} else {
+		installFile, err = os.CreateTemp("", "cloudfuse-update-*"+relInfo.AssetName)
+	}
+	if err != nil {
+		return "", fmt.Errorf("unable to create file: %w", err)
+	}
+	defer installFile.Close()
+
+	if _, err = io.Copy(installFile, resp.Body); err != nil {
+		return "", fmt.Errorf("unable to copy file: %w", err)
+	}
+
+	return installFile.Name(), nil
+}
+
+func getRelease(ctx context.Context, version string) (*releaseInfo, error) {
+	url := "https://api.github.com/repos/Seagate/cloudfuse/releases/latest"
+	if version != "" {
+		url = fmt.Sprintf("https://api.github.com/repos/Seagate/cloudfuse/releases/tags/v%s", version)
+	}
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get release info: %s", resp.Status)
+	}
+
+	var rel release
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return nil, err
+	}
+
+	asset, err := selectPackageAsset(rel.Assets)
+	if err != nil {
+		return nil, err
+	}
+
+	hashAsset, err := downloadHashAsset(rel.Assets)
+	if err != nil {
+		return nil, err
+	}
+
+	return &releaseInfo{
+		Version:   strings.TrimPrefix(rel.TagName, "v"),
+		AssetURL:  asset.BrowserDownloadURL,
+		AssetName: asset.Name,
+		HashURL:   hashAsset.BrowserDownloadURL,
+	}, nil
+}
+
+func selectPackageAsset(assets []asset) (*asset, error) {
+	osName := runtime.GOOS
+	arch := runtime.GOARCH
+	ext := Opt.Package
+
+	if ext == "tar" {
+		ext = "tar.gz"
+	}
+
+	for _, asset := range assets {
+		if strings.HasPrefix(asset.Name, "cloudfuse_no_gui_") &&
+			strings.Contains(asset.Name, osName) &&
+			strings.Contains(asset.Name, arch) &&
+			strings.HasSuffix(asset.Name, ext) {
+			return &asset, nil
+		}
+	}
+
+	return nil, errors.New("no suitable version of cloudfuse found for the current platform")
+}
+
+func downloadHashAsset(assets []asset) (*asset, error) {
+	for _, asset := range assets {
+		if strings.Contains(asset.Name, "checksums_sha256") {
+			return &asset, nil
+		}
+	}
+
+	return nil, errors.New("no checksums found")
+}
+
+func findChecksum(packageName string, checksumTable string) (string, error) {
+	lines := strings.Split(checksumTable, "\n")
+	for _, line := range lines {
+		parts := strings.Fields(line)
+		if len(parts) == 2 && parts[1] == packageName {
+			return parts[0], nil
+		}
+	}
+	return "", errors.New("checksum not found for the given file name")
+}
+
+func verifyHash(fileName, packageName, hashURL string) error {
+	resp, err := http.Get(hashURL)
+	if err != nil {
+		return fmt.Errorf("unable to download checksum file: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to get checksum file: %s", resp.Status)
+	}
+
+	hashes := new(strings.Builder)
+	if _, err = io.Copy(hashes, resp.Body); err != nil {
+		return fmt.Errorf("failed to get checksum file: %s", resp.Status)
+	}
+
+	expectedHash, err := findChecksum(packageName, hashes.String())
+	if err != nil {
+		return fmt.Errorf("failed to get checksum file: %s", resp.Status)
+	}
+
+	file, err := os.Open(fileName)
+	if err != nil {
+		return fmt.Errorf("unable to open file: %w", err)
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return fmt.Errorf("unable to compute hash: %w", err)
+	}
+
+	computedHash := hex.EncodeToString(hash.Sum(nil))
+	if computedHash != expectedHash {
+		return errors.New("checksum mismatch")
+	}
+
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(updateCmd)
+	updateCmd.PersistentFlags().StringVar(&Opt.Output, "output", "", "Save the downloaded binary at a given path (default: replace running binary)")
+	updateCmd.PersistentFlags().StringVar(&Opt.Version, "version", "", "Install the given cloudfuse version (default: latest)")
+	updateCmd.PersistentFlags().StringVar(&Opt.Package, "package", "", "Package format: tar|deb|rpm (default: tar)")
+}

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -77,6 +77,17 @@ func (suite *updateTestSuite) TestGetRelease() {
 	suite.assert.Error(err)
 }
 
+func (suite *updateTestSuite) TestUpdateAdminRightsPromptLinuxDefault() {
+	if runtime.GOOS != "linux" {
+		return
+	}
+	defer suite.cleanupTest()
+
+	_, err := executeCommandC(rootCmd, "update")
+	suite.assert.Error(err)
+	suite.assert.Equal(err.Error(), ".deb and .rpm requires elevated privileges")
+}
+
 func (suite *updateTestSuite) TestUpdateAdminRightsPromptLinux() {
 	if runtime.GOOS != "linux" {
 		return

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -1,0 +1,138 @@
+/*
+   Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+
+   Copyright © 2023-2025 Seagate Technology LLC and/or its Affiliates
+   Copyright © 2020-2024 Microsoft Corporation. All rights reserved.
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE
+*/
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/Seagate/cloudfuse/common"
+	"github.com/Seagate/cloudfuse/common/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type updateTestSuite struct {
+	suite.Suite
+	assert *assert.Assertions
+}
+
+func (suite *updateTestSuite) SetupTest() {
+	suite.assert = assert.New(suite.T())
+
+	options = mountOptions{}
+	err := log.SetDefaultLogger("silent", common.LogConfig{Level: common.ELogLevel.LOG_DEBUG()})
+	if err != nil {
+		panic(fmt.Sprintf("Unable to set silent logger as default: %v", err))
+	}
+
+}
+
+func (suite *updateTestSuite) cleanupTest() {
+	resetCLIFlags(*updateCmd)
+	resetCLIFlags(*rootCmd)
+}
+
+func (suite *updateTestSuite) TestGetRelease() {
+	defer suite.cleanupTest()
+	ctx := context.Background()
+
+	validVersion := "1.8.0"
+	resultVer, err := getRelease(ctx, validVersion)
+	suite.assert.NoError(err)
+	suite.assert.Equal(validVersion, resultVer.Version)
+
+	// When no version is passed, should get the latest version
+	resultVer, err = getRelease(ctx, "")
+	suite.assert.NoError(err)
+
+	invalidVersion := "1.1.10"
+	resultVer, err = getRelease(ctx, invalidVersion)
+	suite.assert.Error(err)
+}
+
+func (suite *updateTestSuite) TestUpdateAdminRightsPromptLinux() {
+	if runtime.GOOS != "linux" {
+		return
+	}
+	defer suite.cleanupTest()
+
+	_, err := executeCommandC(rootCmd, "update", "--package=deb")
+	suite.assert.Error(err)
+	suite.assert.Equal(err.Error(), ".deb and .rpm requires elevated privileges")
+}
+
+func (suite *updateTestSuite) TestUpdateWithOutputDebLinux() {
+	if runtime.GOOS != "linux" {
+		return
+	}
+	defer suite.cleanupTest()
+
+	outputFile, err := os.CreateTemp("", "update-file*")
+	suite.assert.NoError(err)
+
+	_, err = executeCommandC(rootCmd, "update", "--package=deb", fmt.Sprintf("--output=%s", outputFile.Name()))
+	suite.assert.NoError(err)
+
+	os.Remove(outputFile.Name())
+}
+
+func (suite *updateTestSuite) TestUpdateWithOutputRpmLinux() {
+	if runtime.GOOS != "linux" {
+		return
+	}
+	defer suite.cleanupTest()
+
+	outputFile, err := os.CreateTemp("", "update-file*")
+	suite.assert.NoError(err)
+
+	_, err = executeCommandC(rootCmd, "update", "--package=rpm", fmt.Sprintf("--output=%s", outputFile.Name()))
+	suite.assert.NoError(err)
+
+	os.Remove(outputFile.Name())
+}
+
+func (suite *updateTestSuite) TestUpdateWithOutputTarLinux() {
+	if runtime.GOOS != "linux" {
+		return
+	}
+	defer suite.cleanupTest()
+
+	outputFile, err := os.CreateTemp("", "update-file*")
+	suite.assert.NoError(err)
+
+	_, err = executeCommandC(rootCmd, "update", "--package=tar", fmt.Sprintf("--output=%s", outputFile.Name()))
+	suite.assert.NoError(err)
+
+	os.Remove(outputFile.Name())
+}
+
+func TestUpdateCommand(t *testing.T) {
+	suite.Run(t, new(updateTestSuite))
+}


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief

This adds a new update command for Cloudfuse. It enables downloading updates from our GitHub releases. It also verifies that the checksum of the download matches the checksum in our release. It currently only supports Linux. Users on Linux should specify either the package type they want to download (deb, rpm) or an output location where the file will be downloaded for the user to install.

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #
