### PR TITLE
Password is passphrase

### DIFF
--- a/cmd/config-gen.go
+++ b/cmd/config-gen.go
@@ -186,5 +186,5 @@ func init() {
 	generateConfig.Flags().StringVar(&opts.outputConfigPath, "output-file", "", "Output config file path.")
 	generateConfig.Flags().StringVar(&opts.tempDirPath, "temp-path", "", "Temporary file path.")
 	generateConfig.Flags().StringVar(&opts.passphrase, "passphrase", "",
-		"Key to be used for encryption / decryption. Key length shall be 16 (AES-128), 24 (AES-192), or 32 (AES-256) bytes in length.")
+		"Password to be used for encryption / decryption. Can also be specified by env-variable CLOUDFUSE_SECURE_CONFIG_PASSPHRASE.")
 }

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -682,7 +682,7 @@ func init() {
 		"Encrypt auto generated config file for each container")
 
 	mountCmd.PersistentFlags().StringVar(&options.PassPhrase, "passphrase", "",
-		"Base64 encoded key to decrypt config file. Can also be specified by env-variable CLOUDFUSE_SECURE_CONFIG_PASSPHRASE.\n Decoded key length shall be 16 (AES-128), 24 (AES-192), or 32 (AES-256) bytes in length.")
+		"Password to decrypt config file. Can also be specified by env-variable CLOUDFUSE_SECURE_CONFIG_PASSPHRASE.")
 
 	mountCmd.PersistentFlags().String("log-type", "syslog", "Type of logger to be used by the system. Set to syslog by default. Allowed values are silent|syslog|base.")
 	config.BindPFlag("logging.type", mountCmd.PersistentFlags().Lookup("log-type"))

--- a/cmd/secure.go
+++ b/cmd/secure.go
@@ -235,7 +235,7 @@ func init() {
 		"Configuration file to be encrypted / decrypted")
 
 	secureCmd.PersistentFlags().StringVar(&secOpts.PassPhrase, "passphrase", "",
-		"Base64 encoded key to decrypt config file. Can also be specified by env-variable CLOUDFUSE_SECURE_CONFIG_PASSPHRASE.\n Decoded key length shall be 16 (AES-128), 24 (AES-192), or 32 (AES-256) bytes in length.")
+		"Password to decrypt config file. Can also be specified by env-variable CLOUDFUSE_SECURE_CONFIG_PASSPHRASE.")
 
 	secureCmd.PersistentFlags().StringVar(&secOpts.OutputFile, "output-file", "",
 		"Path and name for the output file")

--- a/cmd/secure_test.go
+++ b/cmd/secure_test.go
@@ -209,7 +209,7 @@ func (suite *secureConfigTestSuite) TestSecureConfigEncryptInvalidKey() {
 	defer suite.cleanupTest()
 	confFile, _ := os.CreateTemp("", "conf*.yaml")
 	outFile, _ := os.CreateTemp("", "conf*.yaml")
-	passphrase := base64.StdEncoding.EncodeToString([]byte("123"))
+	passphrase := base64.StdEncoding.EncodeToString([]byte(""))
 
 	defer os.Remove(confFile.Name())
 	defer os.Remove(outFile.Name())

--- a/cmd/secure_test.go
+++ b/cmd/secure_test.go
@@ -27,7 +27,6 @@ package cmd
 
 import (
 	"bytes"
-	"encoding/base64"
 	"fmt"
 	"os"
 	"testing"
@@ -209,7 +208,7 @@ func (suite *secureConfigTestSuite) TestSecureConfigEncryptInvalidKey() {
 	defer suite.cleanupTest()
 	confFile, _ := os.CreateTemp("", "conf*.yaml")
 	outFile, _ := os.CreateTemp("", "conf*.yaml")
-	passphrase := base64.StdEncoding.EncodeToString([]byte(""))
+	passphrase := ""
 
 	defer os.Remove(confFile.Name())
 	defer os.Remove(outFile.Name())

--- a/common/encryption.go
+++ b/common/encryption.go
@@ -1,0 +1,39 @@
+/*
+   Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+
+   Copyright © 2023-2025 Seagate Technology LLC and/or its Affiliates
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE
+*/
+
+package common
+
+import "golang.org/x/crypto/argon2"
+
+const (
+	SaltLength    = 16
+	KeyLength     = 32
+	Argon2Time    = 1
+	Argon2Memory  = 64 * 1014
+	Argon2Threads = 4
+)
+
+func deriveKey(password []byte, salt []byte) []byte {
+	return argon2.IDKey(password, salt, Argon2Time, Argon2Memory, Argon2Threads, KeyLength)
+}

--- a/common/encryption.go
+++ b/common/encryption.go
@@ -27,7 +27,7 @@ package common
 import "golang.org/x/crypto/argon2"
 
 const (
-	SaltLength    = 16
+	SaltLength    = uint16(16)
 	KeyLength     = 32
 	Argon2Time    = 1
 	Argon2Memory  = 64 * 1014

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -78,23 +78,7 @@ func (suite *typesTestSuite) TestDirectoryDoesNotExist() {
 	suite.assert.False(exists)
 }
 
-func (suite *typesTestSuite) TestEncryptBadKeyTooSmall() {
-	// Generate a random key
-	key := make([]byte, 20)
-	encodedKey := make([]byte, 28)
-	rand.Read(key)
-	base64.StdEncoding.Encode(encodedKey, key)
-
-	encryptedPassphrase := memguard.NewEnclave(encodedKey)
-
-	data := make([]byte, 1024)
-	rand.Read(data)
-
-	_, err := EncryptData(data, encryptedPassphrase)
-	suite.assert.Error(err)
-}
-
-func (suite *typesTestSuite) TestDecryptBadKeyTooSmall() {
+func (suite *typesTestSuite) TestDecryptBadKey() {
 	// Generate a random key
 	key := make([]byte, 20)
 	encodedKey := make([]byte, 28)
@@ -110,39 +94,7 @@ func (suite *typesTestSuite) TestDecryptBadKeyTooSmall() {
 	suite.assert.Error(err)
 }
 
-func (suite *typesTestSuite) TestEncryptBadKeyTooLong() {
-	// Generate a random key
-	key := make([]byte, 36)
-	encodedKey := make([]byte, 48)
-	rand.Read(key)
-	base64.StdEncoding.Encode(encodedKey, key)
-
-	encryptedPassphrase := memguard.NewEnclave(encodedKey)
-
-	data := make([]byte, 1024)
-	rand.Read(data)
-
-	_, err := EncryptData(data, encryptedPassphrase)
-	suite.assert.Error(err)
-}
-
-func (suite *typesTestSuite) TestDecryptBadKeyTooLong() {
-	// Generate a random key
-	key := make([]byte, 36)
-	encodedKey := make([]byte, 48)
-	rand.Read(key)
-	base64.StdEncoding.Encode(encodedKey, key)
-
-	encryptedPassphrase := memguard.NewEnclave(encodedKey)
-
-	data := make([]byte, 1024)
-	rand.Read(data)
-
-	_, err := DecryptData(data, encryptedPassphrase)
-	suite.assert.Error(err)
-}
-
-func (suite *typesTestSuite) TestEncryptDecrypt16() {
+func (suite *typesTestSuite) TestEncryptDecrypt1() {
 	// Generate a random key
 	key := make([]byte, 16)
 	encodedKey := make([]byte, 24)
@@ -162,7 +114,7 @@ func (suite *typesTestSuite) TestEncryptDecrypt16() {
 	suite.assert.EqualValues(data, d)
 }
 
-func (suite *typesTestSuite) TestEncryptDecrypt24() {
+func (suite *typesTestSuite) TestEncryptDecrypt2() {
 	// Generate a random key
 	key := make([]byte, 24)
 	encodedKey := make([]byte, 32)
@@ -182,7 +134,7 @@ func (suite *typesTestSuite) TestEncryptDecrypt24() {
 	suite.assert.EqualValues(data, d)
 }
 
-func (suite *typesTestSuite) TestEncryptDecrypt32() {
+func (suite *typesTestSuite) TestEncryptDecrypt3() {
 	// Generate a random key
 	key := make([]byte, 32)
 	encodedKey := make([]byte, 44)
@@ -190,6 +142,42 @@ func (suite *typesTestSuite) TestEncryptDecrypt32() {
 	base64.StdEncoding.Encode(encodedKey, key)
 
 	encryptedPassphrase := memguard.NewEnclave(encodedKey)
+
+	data := make([]byte, 1024)
+	rand.Read(data)
+
+	cipher, err := EncryptData(data, encryptedPassphrase)
+	suite.assert.NoError(err)
+
+	d, err := DecryptData(cipher, encryptedPassphrase)
+	suite.assert.NoError(err)
+	suite.assert.EqualValues(data, d)
+}
+
+func (suite *typesTestSuite) TestEncryptDecrypt4() {
+	// Generate a random key
+	key := make([]byte, 32)
+	rand.Read(key)
+
+	encryptedPassphrase := memguard.NewEnclave(key)
+
+	data := make([]byte, 1024)
+	rand.Read(data)
+
+	cipher, err := EncryptData(data, encryptedPassphrase)
+	suite.assert.NoError(err)
+
+	d, err := DecryptData(cipher, encryptedPassphrase)
+	suite.assert.NoError(err)
+	suite.assert.EqualValues(data, d)
+}
+
+func (suite *typesTestSuite) TestEncryptDecrypt5() {
+	// Generate a random key
+	key := make([]byte, 64)
+	rand.Read(key)
+
+	encryptedPassphrase := memguard.NewEnclave(key)
 
 	data := make([]byte, 1024)
 	rand.Read(data)

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/vibhansa-msft/tlru v0.0.0-20240410102558-9e708419e21f
 	github.com/winfsp/cgofuse v1.6.0
 	go.uber.org/atomic v1.11.0
+	golang.org/x/crypto v0.36.0
 	golang.org/x/sys v0.31.0
 	gopkg.in/ini.v1 v1.67.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -76,7 +77,6 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/net v0.37.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief

This changes the passphrase field to be an actual password. It uses argon2id to convert that to a key which is then used for the aes encryption of the config file. This should make it easier to use since you can actually just provide a standard password, rather than a base64 encoded aes encryption key.

### Checklist

- [x] Tested locally
- [x] Added new dependencies
- [x] Updated documentation
- [x] Added tests

### Related Issues

- Related Issue #
- Closes #
