### PR TITLE
Default to first *authorized* bucket

### DIFF
--- a/cmd/mount_all.go
+++ b/cmd/mount_all.go
@@ -263,7 +263,7 @@ func getBucketListS3() ([]string, error) {
 	}
 
 	// Get the list of containers from the component
-	containerList, err = s3Component.ListBuckets()
+	containerList, err = s3Component.ListAuthorizedBuckets()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get bucket list from storage [%s]", err.Error())
 	}

--- a/component/s3storage/client.go
+++ b/component/s3storage/client.go
@@ -238,19 +238,20 @@ func (cl *Client) Configure(cfg Config) error {
 			log.Err("Client::Configure : Error no authorized bucket exists in account: %v", err)
 			return errNoBucketInAccount
 		case 1:
+			cl.Config.authConfig.BucketName = bucketList[0]
 			log.Warn(
 				"Client::Configure : Bucket defaulted to the only authorized one: %s",
-				bucketList[0],
+				cl.Config.authConfig.BucketName,
 			)
 		default:
 			// multiple accessible buckets were found, choose the first one, alphabetically
 			slices.Sort(bucketList)
+			cl.Config.authConfig.BucketName = bucketList[0]
 			log.Warn(
 				"Client::Configure : Bucket defaulted to the first authorized one, alphabetically: %s",
-				bucketList[0],
+				cl.Config.authConfig.BucketName,
 			)
 		}
-		cl.Config.authConfig.BucketName = bucketList[0]
 		return nil
 	}
 

--- a/component/s3storage/client_test.go
+++ b/component/s3storage/client_test.go
@@ -614,19 +614,22 @@ func (s *clientTestSuite) TestListBuckets() {
 	s.assert.Contains(buckets, storageTestConfigurationParameters.BucketName)
 }
 
-// TODO: Cannot run this test in current test account with buckets we don't have permission for
-// func (s *clientTestSuite) TestDefaultBucketName() {
-// 	defer s.cleanupTest()
-// 	// write config with no bucket name
-// 	config := fmt.Sprintf("s3storage:\n  key-id: %s\n  secret-key: %s\n  endpoint: %s\n  region: %s\n  use-path-style: %t\n",
-// 		storageTestConfigurationParameters.KeyID, storageTestConfigurationParameters.SecretKey,
-// 		storageTestConfigurationParameters.Endpoint, storageTestConfigurationParameters.Region,
-// 		storageTestConfigurationParameters.UsePathStyle)
-// 	err := s.setupTestHelper(config, false)
-// 	s.assert.NoError(err)
-// 	buckets, _ := s.client.ListBuckets()
-// 	s.assert.Contains(buckets, s.client.Config.authConfig.BucketName)
-// }
+func (s *clientTestSuite) TestDefaultBucketName() {
+	defer s.cleanupTest()
+	// write config with no bucket name
+	config := fmt.Sprintf(
+		"s3storage:\n  key-id: %s\n  secret-key: %s\n  endpoint: %s\n  region: %s\n  use-path-style: %t\n",
+		storageTestConfigurationParameters.KeyID,
+		storageTestConfigurationParameters.SecretKey,
+		storageTestConfigurationParameters.Endpoint,
+		storageTestConfigurationParameters.Region,
+		storageTestConfigurationParameters.UsePathStyle,
+	)
+	err := s.setupTestHelper(config, false)
+	s.assert.NoError(err)
+	buckets, _ := s.client.ListBuckets()
+	s.assert.Contains(buckets, s.client.Config.authConfig.BucketName)
+}
 
 func (s *clientTestSuite) TestSetPrefixPath() {
 	defer s.cleanupTest()

--- a/component/s3storage/connection.go
+++ b/component/s3storage/connection.go
@@ -83,7 +83,7 @@ type S3Connection interface {
 	UpdateConfig(cfg Config) error
 
 	ListBuckets() ([]string, error)
-	ListAccessibleBuckets() ([]string, error)
+	ListAuthorizedBuckets() ([]string, error)
 
 	// This is just for test, shall not be used otherwise
 	SetPrefixPath(string) error

--- a/component/s3storage/connection.go
+++ b/component/s3storage/connection.go
@@ -83,6 +83,7 @@ type S3Connection interface {
 	UpdateConfig(cfg Config) error
 
 	ListBuckets() ([]string, error)
+	ListAccessibleBuckets() ([]string, error)
 
 	// This is just for test, shall not be used otherwise
 	SetPrefixPath(string) error

--- a/component/s3storage/s3storage.go
+++ b/component/s3storage/s3storage.go
@@ -183,6 +183,10 @@ func (s3 *S3Storage) ListBuckets() ([]string, error) {
 	return s3.storage.ListBuckets()
 }
 
+func (s3 *S3Storage) ListAuthorizedBuckets() ([]string, error) {
+	return s3.storage.ListAuthorizedBuckets()
+}
+
 // ------------------------- Core Operations -------------------------------------------
 
 // Directory operations

--- a/component/s3storage/s3wrappers.go
+++ b/component/s3storage/s3wrappers.go
@@ -277,11 +277,11 @@ func (cl *Client) headObject(name string, isSymlink bool, isDir bool) (*internal
 }
 
 // Wrapper for awsS3Client.HeadBucket
-func (cl *Client) headBucket() (*s3.HeadBucketOutput, error) {
+func (cl *Client) headBucket(bucketName string) (*s3.HeadBucketOutput, error) {
 	headBucketOutput, err := cl.awsS3Client.HeadBucket(context.Background(), &s3.HeadBucketInput{
-		Bucket: aws.String(cl.Config.authConfig.BucketName),
+		Bucket: aws.String(bucketName),
 	})
-	return headBucketOutput, parseS3Err(err, "HeadBucket "+cl.Config.authConfig.BucketName)
+	return headBucketOutput, parseS3Err(err, "HeadBucket "+bucketName)
 }
 
 // Wrapper for awsS3Client.CopyObject


### PR DESCRIPTION
Having `bucket-name` be optional was broken when `ListBuckets` would return buckets for which the credentials do not provide access. This adds a new function, `filterAccessibleBuckets()`, to call `HeadBucket` on the listed buckets in parallel, and identify the accessible one(s). Then we can choose a default which actually works.

### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #
