### PR TITLE
Use fake version check in unit tests

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -109,13 +109,16 @@ func getRemoteVersion(req string) (string, error) {
 }
 
 // beginDetectNewVersion : Get latest release version and compare if user needs an upgrade or not
-func beginDetectNewVersion() chan interface{} {
+func beginDetectNewVersion(testURL string) chan interface{} {
 	completed := make(chan interface{})
 	stderr := os.Stderr
 	go func() {
 		defer close(completed)
 
 		latestVersionUrl := common.CloudfuseReleaseURL + "/latest"
+		if testURL != "" {
+			latestVersionUrl = testURL
+		}
 		remoteVersion, err := getRemoteVersion(latestVersionUrl)
 		if err != nil {
 			log.Err("beginDetectNewVersion: error getting latest version [%s]", err.Error())
@@ -167,7 +170,7 @@ func beginDetectNewVersion() chan interface{} {
 func VersionCheck() error {
 	select {
 	//either wait till this routine completes or timeout if it exceeds 8 secs
-	case <-beginDetectNewVersion():
+	case <-beginDetectNewVersion(""):
 	case <-time.After(8 * time.Second):
 		return fmt.Errorf(
 			"unable to obtain latest version information. please check your internet connection",


### PR DESCRIPTION
Use a dummy http server running on loopback to prevent running into GitHub's API rate limits in CI