### PR TITLE
Always flush on sync (remove flags)

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1501,7 +1501,6 @@ func (tui *appContext) createYAMLConfig() error {
 			TmpPath:       tui.config.cacheLocation,
 			Timeout:       uint32(tui.config.cacheRetentionDurationSec),
 			AllowNonEmpty: !tui.config.clearCacheOnStart,
-			SyncToFlush:   true,
 		}
 		// If cache size is not set to 80%, convert currentCacheSizeGB to MB and set file_cache.max-size-mb to it
 		if tui.config.cacheSize != "80" {

--- a/cmd/health-monitor.go
+++ b/cmd/health-monitor.go
@@ -56,7 +56,6 @@ var configFile string
 func resetMonitorOptions() {
 	options.MonitorOpt = monitorOptions{}
 	cacheMonitorOptions = file_cache.FileCacheOptions{}
-	cacheMonitorOptions.SyncToFlush = true
 }
 
 var healthMonCmd = &cobra.Command{

--- a/cmd/health-monitor_test.go
+++ b/cmd/health-monitor_test.go
@@ -127,9 +127,8 @@ func (suite *hmonTestSuite) TestBuildHmonCliParams() {
 		OutputPath:      "/tmp/health_monitor",
 	}
 	cacheMonitorOptions = file_cache.FileCacheOptions{
-		TmpPath:     "/tmp/file_cache",
-		MaxSizeMB:   200,
-		SyncToFlush: true,
+		TmpPath:   "/tmp/file_cache",
+		MaxSizeMB: 200,
 	}
 
 	cliParams := buildCliParamForMonitor()

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -65,7 +65,6 @@ type FileCache struct {
 	allowOther      bool
 	offloadIO       bool
 	syncToFlush     bool
-	syncToDelete    bool
 	maxCacheSizeMB  float64
 
 	defaultPermission os.FileMode
@@ -107,7 +106,6 @@ type FileCacheOptions struct {
 	OffloadIO         bool `config:"offload-io"   yaml:"offload-io,omitempty"`
 
 	SyncToFlush bool `config:"sync-to-flush" yaml:"sync-to-flush"`
-	SyncNoOp    bool `config:"ignore-sync"   yaml:"ignore-sync,omitempty"`
 
 	RefreshSec uint32 `config:"refresh-sec" yaml:"refresh-sec,omitempty"`
 	HardLimit  bool   `config:"hard-limit"  yaml:"hard-limit,omitempty"`
@@ -266,7 +264,6 @@ func (fc *FileCache) Configure(_ bool) error {
 	fc.policyTrace = conf.EnablePolicyTrace
 	fc.offloadIO = conf.OffloadIO
 	fc.syncToFlush = conf.SyncToFlush
-	fc.syncToDelete = !conf.SyncNoOp
 	fc.refreshSec = conf.RefreshSec
 	fc.hardLimit = conf.HardLimit
 
@@ -418,7 +415,7 @@ func (fc *FileCache) Configure(_ bool) error {
 	}
 
 	log.Crit(
-		"FileCache::Configure : create-empty %t, cache-timeout %d, tmp-path %s, max-size-mb %d, high-mark %d, low-mark %d, refresh-sec %v, max-eviction %v, hard-limit %v, policy %s, allow-non-empty-temp %t, cleanup-on-start %t, policy-trace %t, offload-io %t, sync-to-flush %t, ignore-sync %t, defaultPermission %v, diskHighWaterMark %v, maxCacheSize %v, mountPath %v, schedule-len %v",
+		"FileCache::Configure : create-empty %t, cache-timeout %d, tmp-path %s, max-size-mb %d, high-mark %d, low-mark %d, refresh-sec %v, max-eviction %v, hard-limit %v, policy %s, allow-non-empty-temp %t, cleanup-on-start %t, policy-trace %t, offload-io %t, sync-to-flush %t, defaultPermission %v, diskHighWaterMark %v, maxCacheSize %v, mountPath %v, schedule-len %v",
 		fc.createEmptyFile,
 		int(fc.cacheTimeout),
 		fc.tmpPath,
@@ -434,7 +431,6 @@ func (fc *FileCache) Configure(_ bool) error {
 		fc.policyTrace,
 		fc.offloadIO,
 		fc.syncToFlush,
-		fc.syncToDelete,
 		fc.defaultPermission,
 		fc.diskHighWaterMark,
 		fc.maxCacheSizeMB,
@@ -464,7 +460,6 @@ func (fc *FileCache) OnConfigChange() {
 		fc.maxCacheSizeMB = conf.MaxSizeMB
 	}
 	fc.syncToFlush = conf.SyncToFlush
-	fc.syncToDelete = !conf.SyncNoOp
 	_ = fc.policy.UpdateConfig(fc.GetPolicyConfig(conf))
 }
 
@@ -1552,14 +1547,6 @@ func (fc *FileCache) releaseFileInternal(
 		flock.LazyOpen = false
 	}
 
-	// If it is an fsync op then purge the file
-	if options.Handle.Fsynced() {
-		log.Trace("FileCache::releaseFileInternal : fsync/sync op, purging %s", options.Handle.Path)
-		localPath := filepath.Join(fc.tmpPath, options.Handle.Path)
-		fc.policy.CachePurge(localPath)
-		return nil
-	}
-
 	return nil
 }
 
@@ -1697,14 +1684,6 @@ func (fc *FileCache) SyncFile(options internal.SyncFileOptions) error {
 			log.Err("FileCache::SyncFile : failed to flush file %s", options.Handle.Path)
 			return err
 		}
-	} else if fc.syncToDelete {
-		err := fc.NextComponent().SyncFile(options)
-		if err != nil {
-			log.Err("FileCache::SyncFile : %s failed", options.Handle.Path)
-			return err
-		}
-
-		options.Handle.Flags.Set(handlemap.HandleFlagFSynced)
 	}
 
 	return nil

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -64,7 +64,6 @@ type FileCache struct {
 	scheduleOps     sync.Map // uses object name (common.JoinUnixFilepath)
 	allowOther      bool
 	offloadIO       bool
-	syncToFlush     bool
 	maxCacheSizeMB  float64
 
 	defaultPermission os.FileMode
@@ -104,8 +103,6 @@ type FileCacheOptions struct {
 
 	EnablePolicyTrace bool `config:"policy-trace" yaml:"policy-trace,omitempty"`
 	OffloadIO         bool `config:"offload-io"   yaml:"offload-io,omitempty"`
-
-	SyncToFlush bool `config:"sync-to-flush" yaml:"sync-to-flush"`
 
 	RefreshSec uint32 `config:"refresh-sec" yaml:"refresh-sec,omitempty"`
 	HardLimit  bool   `config:"hard-limit"  yaml:"hard-limit,omitempty"`
@@ -238,7 +235,6 @@ func (fc *FileCache) Configure(_ bool) error {
 	log.Trace("FileCache::Configure : %s", fc.Name())
 
 	conf := FileCacheOptions{}
-	conf.SyncToFlush = true
 	err := config.UnmarshalKey(compName, &conf)
 	if err != nil {
 		log.Err("FileCache: config error [invalid config attributes]")
@@ -263,7 +259,6 @@ func (fc *FileCache) Configure(_ bool) error {
 	fc.allowNonEmpty = conf.AllowNonEmpty
 	fc.policyTrace = conf.EnablePolicyTrace
 	fc.offloadIO = conf.OffloadIO
-	fc.syncToFlush = conf.SyncToFlush
 	fc.refreshSec = conf.RefreshSec
 	fc.hardLimit = conf.HardLimit
 
@@ -355,10 +350,6 @@ func (fc *FileCache) Configure(_ bool) error {
 		return fmt.Errorf("config error in %s [%s]", fc.Name(), "failed to create cache policy")
 	}
 
-	if config.IsSet(compName + ".sync-to-flush") {
-		log.Warn("Sync will upload current contents of file.")
-	}
-
 	fc.diskHighWaterMark = 0
 	if fc.hardLimit && fc.maxCacheSizeMB != 0 {
 		fc.diskHighWaterMark = fc.maxCacheSizeMB * MB
@@ -415,7 +406,7 @@ func (fc *FileCache) Configure(_ bool) error {
 	}
 
 	log.Crit(
-		"FileCache::Configure : create-empty %t, cache-timeout %d, tmp-path %s, max-size-mb %d, high-mark %d, low-mark %d, refresh-sec %v, max-eviction %v, hard-limit %v, policy %s, allow-non-empty-temp %t, cleanup-on-start %t, policy-trace %t, offload-io %t, sync-to-flush %t, defaultPermission %v, diskHighWaterMark %v, maxCacheSize %v, mountPath %v, schedule-len %v",
+		"FileCache::Configure : create-empty %t, cache-timeout %d, tmp-path %s, max-size-mb %d, high-mark %d, low-mark %d, refresh-sec %v, max-eviction %v, hard-limit %v, policy %s, allow-non-empty-temp %t, cleanup-on-start %t, policy-trace %t, offload-io %t, defaultPermission %v, diskHighWaterMark %v, maxCacheSize %v, mountPath %v, schedule-len %v",
 		fc.createEmptyFile,
 		int(fc.cacheTimeout),
 		fc.tmpPath,
@@ -430,7 +421,6 @@ func (fc *FileCache) Configure(_ bool) error {
 		conf.CleanupOnStart,
 		fc.policyTrace,
 		fc.offloadIO,
-		fc.syncToFlush,
 		fc.defaultPermission,
 		fc.diskHighWaterMark,
 		fc.maxCacheSizeMB,
@@ -446,7 +436,6 @@ func (fc *FileCache) OnConfigChange() {
 	log.Trace("FileCache::OnConfigChange : %s", fc.Name())
 
 	conf := FileCacheOptions{}
-	conf.SyncToFlush = true
 	err := config.UnmarshalKey(compName, &conf)
 	if err != nil {
 		log.Err("FileCache: config error [invalid config attributes]")
@@ -459,7 +448,6 @@ func (fc *FileCache) OnConfigChange() {
 	if conf.MaxSizeMB > 0 {
 		fc.maxCacheSizeMB = conf.MaxSizeMB
 	}
-	fc.syncToFlush = conf.SyncToFlush
 	_ = fc.policy.UpdateConfig(fc.GetPolicyConfig(conf))
 }
 
@@ -1676,17 +1664,7 @@ func (fc *FileCache) WriteFile(options *internal.WriteFileOptions) (int, error) 
 
 func (fc *FileCache) SyncFile(options internal.SyncFileOptions) error {
 	log.Trace("FileCache::SyncFile : handle=%d, path=%s", options.Handle.ID, options.Handle.Path)
-	if fc.syncToFlush {
-		err := fc.FlushFile(
-			internal.FlushFileOptions{Handle: options.Handle, CloseInProgress: true},
-		) //nolint
-		if err != nil {
-			log.Err("FileCache::SyncFile : failed to flush file %s", options.Handle.Path)
-			return err
-		}
-	}
-
-	return nil
+	return fc.FlushFile(internal.FlushFileOptions{Handle: options.Handle, CloseInProgress: true})
 }
 
 // in SyncDir we're not going to clear the file cache for now

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -1664,7 +1664,12 @@ func (fc *FileCache) WriteFile(options *internal.WriteFileOptions) (int, error) 
 
 func (fc *FileCache) SyncFile(options internal.SyncFileOptions) error {
 	log.Trace("FileCache::SyncFile : handle=%d, path=%s", options.Handle.ID, options.Handle.Path)
-	return fc.FlushFile(internal.FlushFileOptions{Handle: options.Handle, CloseInProgress: true})
+	err := fc.NextComponent().SyncFile(options)
+	if err == nil {
+		err = fc.FlushFile(internal.FlushFileOptions{Handle: options.Handle, CloseInProgress: true})
+	}
+
+	return err
 }
 
 // in SyncDir we're not going to clear the file cache for now

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -186,7 +186,6 @@ func (suite *fileCacheTestSuite) TestEmpty() {
 	suite.assert.False(suite.fileCache.createEmptyFile)
 	suite.assert.False(suite.fileCache.allowNonEmpty)
 	suite.assert.InDelta(216000, suite.fileCache.cacheTimeout, 1.0)
-	suite.assert.True(suite.fileCache.syncToFlush)
 }
 
 // Tests configuration of file cache
@@ -202,9 +201,8 @@ func (suite *fileCacheTestSuite) TestConfig() {
 	createEmptyFile := true
 	allowNonEmptyTemp := true
 	cleanupOnStart := true
-	syncToFlush := false
 	config := fmt.Sprintf(
-		"file_cache:\n  path: %s\n  offload-io: true\n  policy: %s\n  max-size-mb: %d\n  timeout-sec: %d\n  max-eviction: %d\n  high-threshold: %d\n  low-threshold: %d\n  create-empty-file: %t\n  allow-non-empty-temp: %t\n  cleanup-on-start: %t\n  sync-to-flush: %t",
+		"file_cache:\n  path: %s\n  offload-io: true\n  policy: %s\n  max-size-mb: %d\n  timeout-sec: %d\n  max-eviction: %d\n  high-threshold: %d\n  low-threshold: %d\n  create-empty-file: %t\n  allow-non-empty-temp: %t\n  cleanup-on-start: %t",
 		suite.cache_path,
 		policy,
 		maxSizeMb,
@@ -215,7 +213,6 @@ func (suite *fileCacheTestSuite) TestConfig() {
 		createEmptyFile,
 		allowNonEmptyTemp,
 		cleanupOnStart,
-		syncToFlush,
 	)
 	suite.setupTestHelper(
 		config,
@@ -1113,56 +1110,29 @@ func (suite *fileCacheTestSuite) TestChmodNonexistentCreateEmptyFile() {
 
 func (suite *fileCacheTestSuite) TestSyncFile() {
 	defer suite.cleanupTest()
-
-	suite.fileCache.syncToFlush = false
-	path := "file3"
-
-	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: path, Mode: 0777})
-	err := suite.fileCache.ReleaseFile(internal.ReleaseFileOptions{Handle: handle})
-	suite.assert.NoError(err)
-
-	// On a sync we open, sync, flush and close
-	handle, err = suite.fileCache.OpenFile(
-		internal.OpenFileOptions{Name: path, Flags: os.O_RDWR, Mode: 0777},
-	)
-	handlemap.Add(handle)
-	suite.assert.NoError(err)
-	err = suite.fileCache.SyncFile(internal.SyncFileOptions{Handle: handle})
-	suite.assert.NoError(err)
+	// Setup
+	file := "file3"
+	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
 	testData := "test data"
 	data := []byte(testData)
-
-	_, err = suite.fileCache.WriteFile(
+	_, err := suite.fileCache.WriteFile(
 		&internal.WriteFileOptions{Handle: handle, Offset: 0, Data: data},
 	)
 	suite.assert.NoError(err)
-	handle, loaded := handlemap.Load(handle.ID)
-	suite.assert.True(loaded)
-	err = suite.fileCache.FlushFile(internal.FlushFileOptions{Handle: handle})
-	suite.assert.NoError(err)
-	err = suite.fileCache.ReleaseFile(internal.ReleaseFileOptions{Handle: handle})
-	suite.assert.NoError(err)
 
-	// Path should not be in file cache
-	suite.assert.NoFileExists(filepath.Join(suite.cache_path, path))
+	// Path should not be in fake storage
+	suite.assert.NoFileExists(filepath.Join(suite.fake_storage_path, file))
 
-	path = "file.fsync"
-	suite.fileCache.syncToFlush = true
-	handle, err = suite.fileCache.CreateFile(internal.CreateFileOptions{Name: path, Mode: 0777})
-	suite.assert.NoError(err)
-	_, err = suite.fileCache.WriteFile(
-		&internal.WriteFileOptions{Handle: handle, Offset: 0, Data: data},
-	)
-	suite.assert.NoError(err)
-	suite.assert.True(handle.Dirty())
+	// Sync the File
 	err = suite.fileCache.SyncFile(internal.SyncFileOptions{Handle: handle})
 	suite.assert.NoError(err)
 	suite.assert.False(handle.Dirty())
-	suite.assert.FileExists(suite.fake_storage_path + "/" + path)
 
-	err = suite.fileCache.ReleaseFile(internal.ReleaseFileOptions{Handle: handle})
-	suite.assert.NoError(err)
-	suite.fileCache.syncToFlush = false
+	// Path should be in fake storage
+	suite.assert.FileExists(filepath.Join(suite.fake_storage_path, file))
+	// Check that fake_storage updated with data
+	d, _ := os.ReadFile(filepath.Join(suite.fake_storage_path, file))
+	suite.assert.Equal(data, d)
 }
 
 func (suite *fileCacheTestSuite) TestDeleteFile() {

--- a/internal/handlemap/handle_map.go
+++ b/internal/handlemap/handle_map.go
@@ -45,7 +45,7 @@ const InvalidHandleID HandleID = 0
 const (
 	HandleFlagUnknown  uint64 = iota
 	HandleFlagDirty           // File has been modified with write operation or is a new file
-	HandleFlagFSynced         // User has called fsync on the file explicitly
+	_                         // Skip (formerly HandleFlagFSynced)
 	HandleFlagCached          // File is cached in the local system by cloudfuse
 	HandleOpenedAppend        // File is opened for Append
 )
@@ -96,11 +96,6 @@ func NewHandle(path string) *Handle {
 // Dirty : Handle is dirty or not
 func (handle *Handle) Dirty() bool {
 	return handle.Flags.IsSet(HandleFlagDirty)
-}
-
-// Fsynced : Handle is Fsynced or not
-func (handle *Handle) Fsynced() bool {
-	return handle.Flags.IsSet(HandleFlagFSynced)
 }
 
 // Cached : File is cached on local disk or not

--- a/internal/handlemap/handle_map_test.go
+++ b/internal/handlemap/handle_map_test.go
@@ -57,15 +57,11 @@ func (suite *HandleMapSuite) TestHandleFlags() {
 	suite.assert.Equal("abc", h.Path)
 
 	suite.assert.False(h.Dirty())
-	suite.assert.False(h.Fsynced())
 	suite.assert.False(h.Cached())
 	suite.assert.Nil(h.GetFileObject())
 
 	h.Flags.Set(HandleFlagDirty)
 	suite.assert.True(h.Dirty())
-
-	h.Flags.Set(HandleFlagFSynced)
-	suite.assert.True(h.Fsynced())
 
 	h.Flags.Set(HandleFlagCached)
 	suite.assert.True(h.Cached())

--- a/sample_configs/sampleFileCacheConfigAzure.yaml
+++ b/sample_configs/sampleFileCacheConfigAzure.yaml
@@ -19,7 +19,6 @@ file_cache:
   path: /<PATH>/<TO>/<CACHE_DIR>
   timeout-sec: 64000000
   allow-non-empty-temp: true
-  ignore-sync: true
 
 attr_cache:
   timeout-sec: 7200

--- a/sample_configs/sampleFileCacheConfigS3.yaml
+++ b/sample_configs/sampleFileCacheConfigS3.yaml
@@ -19,7 +19,6 @@ file_cache:
   path: /<PATH>/<TO>/<CACHE_DIR>
   timeout-sec: 64000000
   allow-non-empty-temp: true
-  ignore-sync: true
 
 attr_cache:
   timeout-sec: 7200

--- a/sample_configs/sampleFileCacheWithSASConfigAzure.yaml
+++ b/sample_configs/sampleFileCacheWithSASConfigAzure.yaml
@@ -19,7 +19,6 @@ file_cache:
   path: /<PATH>/<TO>/<CACHE_DIR>
   timeout-sec: 64000000
   allow-non-empty-temp: true
-  ignore-sync: true
 
 attr_cache:
   timeout-sec: 7200

--- a/setup/advancedConfig.yaml
+++ b/setup/advancedConfig.yaml
@@ -127,7 +127,6 @@ file_cache:
   offload-io: true|false <by default libfuse will service reads/writes to files for better perf. Set to true to make file-cache component service read/write calls.>
   sync-to-flush: true|false <sync call to a file will force upload of the contents to storage account. Default - true>
   refresh-sec: <number of seconds after which compare lmt of file in local cache and container and refresh file if container has the latest copy>
-  ignore-sync: true|false <sync call will be ignored and locally cached file will not be deleted>
   hard-limit: true|false <if set to true, file-cache will not allow read/writes to file which exceed the configured limits>
 
 # Attribute cache related configuration

--- a/setup/advancedConfig.yaml
+++ b/setup/advancedConfig.yaml
@@ -1,6 +1,6 @@
 # MUST READ :
 #   If you are creating a cloudfuse config file using this kindly take care of below points
-#   1. All boolean configs (true|false config) (except ignore-open-flags, virtual-directory, sync-to-flush) are set to 'false' by default.
+#   1. All boolean configs (true|false config) (except ignore-open-flags, virtual-directory) are set to 'false' by default.
 #      No need to mention them in your config file unless you are setting them to true.
 #   2. 'loopbackfs' is purely for testing and shall not be used in production configuration.
 #   3. 'stream', 'block-cache', and 'file_cache' can not co-exist and config file shall have only one of them based on your use case.
@@ -125,7 +125,6 @@ file_cache:
   cleanup-on-start: true|false <cleanup the temp directory on startup, if it's not empty>
   policy-trace: true|false <generate eviction policy logs showing which files will expire soon>
   offload-io: true|false <by default libfuse will service reads/writes to files for better perf. Set to true to make file-cache component service read/write calls.>
-  sync-to-flush: true|false <sync call to a file will force upload of the contents to storage account. Default - true>
   refresh-sec: <number of seconds after which compare lmt of file in local cache and container and refresh file if container has the latest copy>
   hard-limit: true|false <if set to true, file-cache will not allow read/writes to file which exceed the configured limits>
 

--- a/setup/baseConfig.yaml
+++ b/setup/baseConfig.yaml
@@ -120,7 +120,6 @@ file_cache:
   offload-io: true|false <by default libfuse will service reads/writes to files for better perf. Set to true to make file-cache component service read/write calls.>
   sync-to-flush: true|false <sync call to a file will force upload of the contents to storage account. Default - true>
   refresh-sec: <number of seconds after which compare lmt of file in local cache and container and refresh file if container has the latest copy>
-  ignore-sync: true|false <sync call will be ignored and locally cached file will not be deleted>
   hard-limit: true|false <if set to true, file-cache will not allow read/writes to file which exceed the configured limits>
 
 # Attribute cache related configuration

--- a/setup/baseConfig.yaml
+++ b/setup/baseConfig.yaml
@@ -1,6 +1,6 @@
 # MUST READ :
 #   If you are creating a cloudfuse config file using this kindly take care of below points
-#   1. All boolean configs (true|false config) (except ignore-open-flags, virtual-directory, sync-to-flush) are set to 'false' by default.
+#   1. All boolean configs (true|false config) (except ignore-open-flags, virtual-directory) are set to 'false' by default.
 #      No need to mention them in your config file unless you are setting them to true.
 #   2. 'loopbackfs' is purely for testing and shall not be used in production configuration.
 #   3. 'stream', 'block-cache', and 'file_cache' can not co-exist and config file shall have only one of them based on your use case.
@@ -118,7 +118,6 @@ file_cache:
   cleanup-on-start: true|false <cleanup the temp directory on startup, if it's not empty>
   policy-trace: true|false <generate eviction policy logs showing which files will expire soon>
   offload-io: true|false <by default libfuse will service reads/writes to files for better perf. Set to true to make file-cache component service read/write calls.>
-  sync-to-flush: true|false <sync call to a file will force upload of the contents to storage account. Default - true>
   refresh-sec: <number of seconds after which compare lmt of file in local cache and container and refresh file if container has the latest copy>
   hard-limit: true|false <if set to true, file-cache will not allow read/writes to file which exceed the configured limits>
 

--- a/testdata/config/azure_key_perf.yaml
+++ b/testdata/config/azure_key_perf.yaml
@@ -22,7 +22,6 @@ file_cache:
   timeout-sec: 30
   allow-non-empty-temp: true
   cleanup-on-start: true
-  sync-to-flush: true
 
 attr_cache:
   timeout-sec: 7200


### PR DESCRIPTION
Sync now always just calls flush, but with the CloseInProgress flag, which ensures flush actually happens and is not put off (in case of LazyWrite).
This is primarily a readability improvement, and does not change default functionality.