### PR TITLE
Cancelled context errors don't update connection state

### DIFF
--- a/component/azstorage/azstorage.go
+++ b/component/azstorage/azstorage.go
@@ -264,6 +264,13 @@ func (az *AzStorage) timeToRetry() bool {
 func (az *AzStorage) updateConnectionState(err error) bool {
 	az.state.Lock()
 	defer az.state.Unlock()
+
+	// A context.Canceled error means az.ctx was already cancelled by us when we went offline.
+	// It carries no new connectivity information, so we must not update state.
+	if errors.Is(err, context.Canceled) {
+		return az.state.firstOffline == nil
+	}
+
 	currentTime := time.Now()
 	az.state.lastConnectionAttempt = &currentTime
 	connected := !isOfflineError(err)

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -2022,6 +2022,7 @@ func (fc *FileCache) flushFileCloud(options internal.FlushFileOptions) error {
 	switch {
 	case err == nil:
 		fc.clearHandleDirty(options.Handle)
+		fc.pendingOps.Delete(options.Handle.Path)
 	case isOffline(err) && fc.offlineAccess:
 		log.Warn("FileCache::flushFileCloud : %s upload delayed (offline)", options.Handle.Path)
 		// add file to upload queue

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -2158,7 +2158,7 @@ func (suite *fileCacheTestSuite) TestConnectedToOffline() {
 		&internal.ReadInBufferOptions{Handle: openHandle, Offset: 0, Data: buf},
 	)
 	suite.assert.NoError(err, "read from completely-open file should succeed when offline")
-	suite.assert.Greater(n, 0)
+	suite.assert.Positive(n)
 
 	// Write to the completely-open file while offline
 	newData := []byte("offline write")

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -1947,6 +1947,240 @@ func (suite *fileCacheTestSuite) TestOpenCreateGetAttr() {
 // Tests for GetProperties in OpenFile should be done in E2E tests
 // - there is no good way to test it here with a loopback FS without a mock component.
 
+func (suite *fileCacheTestSuite) TestReleaseFileOffline() {
+	// enable mock component
+	suite.cleanupTest()
+	defaultConfig := fmt.Sprintf(
+		"file_cache:\n  path: %s\n  offload-io: true",
+		suite.cache_path,
+	)
+	suite.useMock = true
+	suite.setupTestHelper(defaultConfig)
+	defer suite.cleanupTest()
+
+	// Create a file in the local cache to simulate a previous download
+	path := "release-offline-file"
+	localPath := filepath.Join(suite.cache_path, path)
+	err := os.MkdirAll(filepath.Dir(localPath), 0777)
+	suite.assert.NoError(err)
+	err = os.WriteFile(localPath, []byte("cached data"), 0777)
+	suite.assert.NoError(err)
+	suite.fileCache.policy.CacheValid(localPath)
+
+	// GetAttr fails: cloud is unreachable
+	suite.mock.EXPECT().
+		GetAttr(internal.GetAttrOptions{Name: path}).
+		Return(nil, &common.CloudUnreachableError{}).
+		AnyTimes()
+
+	// Open the file while offline (succeeds from local cache)
+	handle, err := suite.fileCache.OpenFile(
+		internal.OpenFileOptions{Name: path, Flags: os.O_RDWR, Mode: 0777},
+	)
+	suite.assert.NoError(err)
+	suite.assert.NotNil(handle)
+
+	// Write data to make the handle dirty
+	data := []byte("new data written offline")
+	_, err = suite.fileCache.WriteFile(
+		&internal.WriteFileOptions{Handle: handle, Offset: 0, Data: data},
+	)
+	suite.assert.NoError(err)
+	suite.assert.True(handle.Dirty())
+
+	// Upload attempt fails (still offline)
+	suite.mock.EXPECT().CopyFromFile(gomock.Any()).Return(&common.CloudUnreachableError{})
+
+	// ReleaseFile should succeed: upload is deferred to pendingOps
+	err = suite.fileCache.ReleaseFile(internal.ReleaseFileOptions{Handle: handle})
+	suite.assert.NoError(err)
+
+	// The file should be queued for later upload
+	_, pending := suite.fileCache.pendingOps.Load(path)
+	suite.assert.True(pending, "dirty file should be queued for upload when released offline")
+}
+
+func (suite *fileCacheTestSuite) TestOfflineToConnected() {
+	// Set up mock manually so CloudConnected can change during the test
+	suite.cleanupTest()
+	defaultConfig := fmt.Sprintf(
+		"file_cache:\n  path: %s\n  offload-io: true",
+		suite.cache_path,
+	)
+	suite.assert = assert.New(suite.T())
+	err := config.ReadConfigFromReader(strings.NewReader(defaultConfig))
+	suite.assert.NoError(err)
+	suite.mockCtrl = gomock.NewController(suite.T())
+	suite.mock = internal.NewMockComponent(suite.mockCtrl)
+	suite.fileCache = newTestFileCache(suite.mock)
+	suite.useMock = true
+
+	connected := false
+	suite.mock.EXPECT().CloudConnected().AnyTimes().DoAndReturn(func() bool {
+		return connected
+	})
+
+	err = suite.fileCache.Start(context.Background())
+	suite.assert.NoError(err)
+	defer suite.cleanupTest()
+
+	// Create a file in the local cache to simulate a previous download
+	path := "offline-to-connected-file"
+	localPath := filepath.Join(suite.cache_path, path)
+	err = os.MkdirAll(filepath.Dir(localPath), 0777)
+	suite.assert.NoError(err)
+	err = os.WriteFile(localPath, []byte("initial cached data"), 0777)
+	suite.assert.NoError(err)
+	suite.fileCache.policy.CacheValid(localPath)
+
+	// GetAttr always returns offline error for this test
+	suite.mock.EXPECT().
+		GetAttr(internal.GetAttrOptions{Name: path}).
+		Return(nil, &common.CloudUnreachableError{}).
+		AnyTimes()
+
+	// Open the file while offline: succeeds from local cache
+	handle, err := suite.fileCache.OpenFile(
+		internal.OpenFileOptions{Name: path, Flags: os.O_RDWR, Mode: 0777},
+	)
+	suite.assert.NoError(err)
+	suite.assert.NotNil(handle)
+
+	// Simulate connection restored
+	connected = true
+
+	// Write to the file (now connected, but write is purely local)
+	newData := []byte("written after reconnect")
+	_, err = suite.fileCache.WriteFile(
+		&internal.WriteFileOptions{Handle: handle, Offset: 0, Data: newData},
+	)
+	suite.assert.NoError(err)
+	suite.assert.True(handle.Dirty())
+
+	// Upload succeeds (now connected)
+	suite.mock.EXPECT().CopyFromFile(gomock.Any()).Return(nil)
+
+	// Release should upload successfully
+	err = suite.fileCache.ReleaseFile(internal.ReleaseFileOptions{Handle: handle})
+	suite.assert.NoError(err)
+	suite.assert.False(handle.Dirty(), "handle should be clean after successful upload")
+
+	// File should not be in pendingOps after a successful upload
+	_, pending := suite.fileCache.pendingOps.Load(path)
+	suite.assert.False(pending, "file should not be queued after successful upload on reconnect")
+}
+
+func (suite *fileCacheTestSuite) TestConnectedToOffline() {
+	// Set up mock manually so CloudConnected can change during the test
+	suite.cleanupTest()
+	defaultConfig := fmt.Sprintf(
+		"file_cache:\n  path: %s\n  offload-io: true",
+		suite.cache_path,
+	)
+	suite.assert = assert.New(suite.T())
+	err := config.ReadConfigFromReader(strings.NewReader(defaultConfig))
+	suite.assert.NoError(err)
+	suite.mockCtrl = gomock.NewController(suite.T())
+	suite.mock = internal.NewMockComponent(suite.mockCtrl)
+	suite.fileCache = newTestFileCache(suite.mock)
+	suite.useMock = true
+
+	connected := true
+	suite.mock.EXPECT().CloudConnected().AnyTimes().DoAndReturn(func() bool {
+		return connected
+	})
+
+	err = suite.fileCache.Start(context.Background())
+	suite.assert.NoError(err)
+	defer suite.cleanupTest()
+
+	// --- Lazy-open file: exists in cloud but not in local cache ---
+	// When opened while connected, download is deferred (lazy open).
+	// When accessed after going offline, the open should fail.
+	// When closed while offline, it should succeed without error.
+	lazyPath := "connected-to-offline-lazy"
+	lazyAttr := &internal.ObjAttr{Path: lazyPath, Size: 10, Mtime: time.Now()}
+	// First GetAttr call (during OpenFile): cloud is reachable
+	suite.mock.EXPECT().
+		GetAttr(internal.GetAttrOptions{Name: lazyPath}).
+		Return(lazyAttr, nil).
+		Times(1)
+	// Subsequent GetAttr calls (during deferred open attempts while offline)
+	suite.mock.EXPECT().
+		GetAttr(internal.GetAttrOptions{Name: lazyPath}).
+		Return(nil, &common.CloudUnreachableError{}).
+		AnyTimes()
+
+	lazyHandle, err := suite.fileCache.OpenFile(
+		internal.OpenFileOptions{Name: lazyPath, Flags: os.O_RDONLY, Mode: 0444},
+	)
+	suite.assert.NoError(err)
+	suite.assert.NotNil(lazyHandle)
+	// File was not downloaded: still in lazy open state
+	suite.assert.NoFileExists(filepath.Join(suite.cache_path, lazyPath))
+
+	// --- Completely-open file: already cached locally ---
+	// When opened while connected, it opens immediately from local cache.
+	openPath := "connected-to-offline-open"
+	openLocalPath := filepath.Join(suite.cache_path, openPath)
+	err = os.MkdirAll(filepath.Dir(openLocalPath), 0777)
+	suite.assert.NoError(err)
+	err = os.WriteFile(openLocalPath, []byte("cached content"), 0777)
+	suite.assert.NoError(err)
+	suite.fileCache.policy.CacheValid(openLocalPath)
+
+	openAttr := &internal.ObjAttr{Path: openPath, Size: 14, Mtime: time.Now()}
+	suite.mock.EXPECT().
+		GetAttr(internal.GetAttrOptions{Name: openPath}).
+		Return(openAttr, nil).
+		AnyTimes()
+
+	openHandle, err := suite.fileCache.OpenFile(
+		internal.OpenFileOptions{Name: openPath, Flags: os.O_RDWR, Mode: 0644},
+	)
+	suite.assert.NoError(err)
+	suite.assert.NotNil(openHandle)
+	suite.assert.FileExists(openLocalPath)
+
+	// Simulate connection drop
+	connected = false
+
+	// Access the lazy-open file: should fail (data unavailable offline)
+	buf := make([]byte, 10)
+	_, err = suite.fileCache.ReadInBuffer(
+		&internal.ReadInBufferOptions{Handle: lazyHandle, Offset: 0, Data: buf},
+	)
+	suite.assert.Error(err, "read on lazy-open file should fail when going offline")
+
+	// Close the lazy-open file: should succeed with no error even while offline
+	err = suite.fileCache.ReleaseFile(internal.ReleaseFileOptions{Handle: lazyHandle})
+	suite.assert.NoError(err, "releasing a lazy-open file should succeed even when offline")
+
+	// Access the completely-open file: should still succeed (local data is available)
+	n, err := suite.fileCache.ReadInBuffer(
+		&internal.ReadInBufferOptions{Handle: openHandle, Offset: 0, Data: buf},
+	)
+	suite.assert.NoError(err, "read from completely-open file should succeed when offline")
+	suite.assert.Greater(n, 0)
+
+	// Write to the completely-open file while offline
+	newData := []byte("offline write")
+	_, err = suite.fileCache.WriteFile(
+		&internal.WriteFileOptions{Handle: openHandle, Offset: 0, Data: newData},
+	)
+	suite.assert.NoError(err)
+	suite.assert.True(openHandle.Dirty())
+
+	// Release should succeed: upload is deferred to pendingOps
+	suite.mock.EXPECT().CopyFromFile(gomock.Any()).Return(&common.CloudUnreachableError{})
+	err = suite.fileCache.ReleaseFile(internal.ReleaseFileOptions{Handle: openHandle})
+	suite.assert.NoError(err, "releasing a completely-open file should succeed when offline")
+
+	// The dirty file should be queued for upload
+	_, pending := suite.fileCache.pendingOps.Load(openPath)
+	suite.assert.True(pending, "dirty file should be queued for upload when released offline")
+}
+
 func (suite *fileCacheTestSuite) TestCloseFileAndEvict() {
 	defer suite.cleanupTest()
 	suite.cleanupTest()

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -1944,9 +1944,6 @@ func (suite *fileCacheTestSuite) TestOpenCreateGetAttr() {
 	suite.NotNil(attr)
 }
 
-// Tests for GetProperties in OpenFile should be done in E2E tests
-// - there is no good way to test it here with a loopback FS without a mock component.
-
 func (suite *fileCacheTestSuite) TestReleaseFileOffline() {
 	// enable mock component
 	suite.cleanupTest()

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -2197,6 +2197,50 @@ func (suite *fileCacheTestSuite) TestFlushFile() {
 	suite.assert.Equal(data, d)
 }
 
+func (suite *fileCacheTestSuite) TestFlushFileOffline() {
+	// enable mock component
+	suite.cleanupTest()
+	defaultConfig := fmt.Sprintf(
+		"file_cache:\n  path: %s\n  offload-io: true",
+		suite.cache_path,
+	)
+	suite.useMock = true
+	suite.setupTestHelper(defaultConfig)
+	defer suite.cleanupTest()
+
+	file := "offline-flush-file"
+	suite.mock.EXPECT().
+		GetAttr(internal.GetAttrOptions{Name: file}).
+		Return(nil, &common.CloudUnreachableError{})
+
+	handle, err := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
+	suite.assert.NoError(err)
+
+	data := []byte("offline flush data")
+	bytesWritten, err := suite.fileCache.WriteFile(
+		&internal.WriteFileOptions{Handle: handle, Offset: 0, Data: data},
+	)
+	suite.assert.NoError(err)
+	suite.assert.Equal(len(data), bytesWritten)
+
+	suite.mock.EXPECT().
+		CopyFromFile(gomock.Any()).
+		Return(&common.CloudUnreachableError{})
+
+	err = suite.fileCache.FlushFile(internal.FlushFileOptions{Handle: handle})
+	suite.assert.NoError(err)
+
+	localData, err := os.ReadFile(filepath.Join(suite.cache_path, file))
+	suite.assert.NoError(err)
+	suite.assert.Equal(data, localData)
+
+	op, exists := suite.fileCache.pendingOps.Load(file)
+	suite.assert.True(exists, "File should be queued in pendingOps for deferred upload")
+	if exists {
+		suite.assert.Equal(pendingFlags{}, op)
+	}
+}
+
 func (suite *fileCacheTestSuite) TestFlushFileErrorBadFd() {
 	defer suite.cleanupTest()
 	// Setup
@@ -2389,7 +2433,7 @@ loopbackfs:
 	suite.assert.Equal(data, uploadedData, "Uploaded file content should match original")
 }
 
-func (suite *fileCacheTestSuite) TestCreateFileAndRename() {
+func (suite *fileCacheTestSuite) TestRenamePendingOp() {
 	defer suite.cleanupTest()
 
 	now := time.Now()

--- a/component/s3storage/s3storage.go
+++ b/component/s3storage/s3storage.go
@@ -59,7 +59,6 @@ type connectionState struct {
 	lastConnectionAttempt *time.Time
 	firstOffline          *time.Time
 	retryTicker           *time.Ticker
-	contextEpoch          uint64
 }
 
 const compName = "s3storage"
@@ -210,13 +209,12 @@ func (s3 *S3Storage) CloudConnected() bool {
 	if connected || !s3.timeToRetry() {
 		return connected
 	}
-	_, epoch := s3.requestContext()
 	// check connection
 	log.Info("S3Storage::CloudConnected : Checking connection...")
 	ctx, cancelFun := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancelFun()
 	err := s3.Storage.ConnectionOkay(ctx)
-	nowConnected := s3.updateConnectionState(err, epoch)
+	nowConnected := s3.updateConnectionState(err)
 	return nowConnected
 }
 
@@ -236,17 +234,13 @@ func (s3 *S3Storage) timeToRetry() bool {
 	}
 }
 
-func (s3 *S3Storage) requestContext() (context.Context, uint64) {
-	s3.state.Lock()
-	defer s3.state.Unlock()
-	return s3.ctx, s3.state.contextEpoch
-}
-
-func (s3 *S3Storage) updateConnectionState(err error, requestEpoch uint64) bool {
+func (s3 *S3Storage) updateConnectionState(err error) bool {
 	s3.state.Lock()
 	defer s3.state.Unlock()
 
-	if errors.Is(err, &common.CloudUnreachableError{}) && requestEpoch != s3.state.contextEpoch {
+	// A context.Canceled error means s3.ctx was already cancelled by us when we went offline.
+	// It carries no new connectivity information, so we must not update state.
+	if errors.Is(err, context.Canceled) {
 		return s3.state.firstOffline == nil
 	}
 
@@ -260,7 +254,6 @@ func (s3 *S3Storage) updateConnectionState(err error, requestEpoch uint64) bool 
 		if connected {
 			s3.state.firstOffline = nil
 			// reset the context to allow new requests
-			s3.state.contextEpoch++
 			s3.ctx, s3.cancelFn = context.WithCancel(context.Background())
 			// stop the retry ticker
 			s3.state.retryTicker.Stop()
@@ -291,10 +284,9 @@ func (s3 *S3Storage) ListAuthorizedBuckets() ([]string, error) {
 func (s3 *S3Storage) CreateDir(options internal.CreateDirOptions) error {
 	log.Trace("S3Storage::CreateDir : %s", options.Name)
 
-	ctx, epoch := s3.requestContext()
-	err := s3.Storage.CreateDirectory(ctx, internal.TruncateDirName(options.Name))
+	err := s3.Storage.CreateDirectory(s3.ctx, internal.TruncateDirName(options.Name))
 	if s3.stConfig.enableDirMarker {
-		s3.updateConnectionState(err, epoch)
+		s3.updateConnectionState(err)
 	}
 
 	if err == nil {
@@ -312,9 +304,8 @@ func (s3 *S3Storage) CreateDir(options internal.CreateDirOptions) error {
 func (s3 *S3Storage) DeleteDir(options internal.DeleteDirOptions) error {
 	log.Trace("S3Storage::DeleteDir : %s", options.Name)
 
-	ctx, epoch := s3.requestContext()
-	err := s3.Storage.DeleteDirectory(ctx, internal.TruncateDirName(options.Name))
-	s3.updateConnectionState(err, epoch)
+	err := s3.Storage.DeleteDirectory(s3.ctx, internal.TruncateDirName(options.Name))
+	s3.updateConnectionState(err)
 
 	if err == nil {
 		s3StatsCollector.PushEvents(deleteDir, options.Name, nil)
@@ -338,9 +329,8 @@ func formatListDirName(path string) string {
 func (s3 *S3Storage) IsDirEmpty(options internal.IsDirEmptyOptions) bool {
 	log.Trace("S3Storage::IsDirEmpty : %s", options.Name)
 	// List up to two objects, since one could be the directory with a trailing slash
-	ctx, epoch := s3.requestContext()
-	list, _, err := s3.Storage.List(ctx, formatListDirName(options.Name), nil, 2)
-	s3.updateConnectionState(err, epoch)
+	list, _, err := s3.Storage.List(s3.ctx, formatListDirName(options.Name), nil, 2)
+	s3.updateConnectionState(err)
 	if err != nil {
 		log.Err("S3Storage::IsDirEmpty : error listing [%s]", err)
 		return false
@@ -369,9 +359,8 @@ func (s3 *S3Storage) StreamDir(
 		entriesRemaining = maxResultsPerListCall
 	}
 	for entriesRemaining > 0 {
-		ctx, epoch := s3.requestContext()
-		newList, nextMarker, err := s3.Storage.List(ctx, path, marker, entriesRemaining)
-		s3.updateConnectionState(err, epoch)
+		newList, nextMarker, err := s3.Storage.List(s3.ctx, path, marker, entriesRemaining)
+		s3.updateConnectionState(err)
 		if err != nil {
 			log.Err("S3Storage::StreamDir : %s Failed to read dir [%s]", options.Name, err)
 			return objectList, "", err
@@ -420,9 +409,8 @@ func (s3 *S3Storage) RenameDir(options internal.RenameDirOptions) error {
 	options.Src = internal.TruncateDirName(options.Src)
 	options.Dst = internal.TruncateDirName(options.Dst)
 
-	ctx, epoch := s3.requestContext()
-	err := s3.Storage.RenameDirectory(ctx, options.Src, options.Dst)
-	s3.updateConnectionState(err, epoch)
+	err := s3.Storage.RenameDirectory(s3.ctx, options.Src, options.Dst)
+	s3.updateConnectionState(err)
 
 	if err == nil {
 		s3StatsCollector.PushEvents(
@@ -447,9 +435,8 @@ func (s3 *S3Storage) CreateFile(options internal.CreateFileOptions) (*handlemap.
 		return nil, syscall.EFAULT
 	}
 
-	ctx, epoch := s3.requestContext()
-	err := s3.Storage.CreateFile(ctx, options.Name, options.Mode)
-	s3.updateConnectionState(err, epoch)
+	err := s3.Storage.CreateFile(s3.ctx, options.Name, options.Mode)
+	s3.updateConnectionState(err)
 	if err != nil {
 		return nil, err
 	}
@@ -470,9 +457,8 @@ func (s3 *S3Storage) CreateFile(options internal.CreateFileOptions) (*handlemap.
 func (s3 *S3Storage) OpenFile(options internal.OpenFileOptions) (*handlemap.Handle, error) {
 	log.Trace("S3Storage::OpenFile : %s", options.Name)
 
-	ctx, epoch := s3.requestContext()
-	attr, err := s3.Storage.GetAttr(ctx, options.Name)
-	s3.updateConnectionState(err, epoch)
+	attr, err := s3.Storage.GetAttr(s3.ctx, options.Name)
+	s3.updateConnectionState(err)
 	if err != nil {
 		return nil, err
 	}
@@ -505,9 +491,8 @@ func (s3 *S3Storage) ReleaseFile(options internal.ReleaseFileOptions) error {
 func (s3 *S3Storage) DeleteFile(options internal.DeleteFileOptions) error {
 	log.Trace("S3Storage::DeleteFile : %s", options.Name)
 
-	ctx, epoch := s3.requestContext()
-	err := s3.Storage.DeleteFile(ctx, options.Name)
-	s3.updateConnectionState(err, epoch)
+	err := s3.Storage.DeleteFile(s3.ctx, options.Name)
+	s3.updateConnectionState(err)
 
 	if err == nil {
 		s3StatsCollector.PushEvents(deleteFile, options.Name, nil)
@@ -521,10 +506,9 @@ func (s3 *S3Storage) RenameFile(options internal.RenameFileOptions) error {
 	log.Trace("S3Storage::RenameFile : %s to %s", options.Src, options.Dst)
 
 	isSymLink := options.SrcAttr != nil && options.SrcAttr.IsSymlink()
-	ctx, epoch := s3.requestContext()
-	err := s3.Storage.RenameFile(ctx, options.Src, options.Dst, isSymLink)
+	err := s3.Storage.RenameFile(s3.ctx, options.Src, options.Dst, isSymLink)
 
-	s3.updateConnectionState(err, epoch)
+	s3.updateConnectionState(err)
 	if err == nil {
 		s3StatsCollector.PushEvents(
 			renameFile,
@@ -553,15 +537,14 @@ func (s3 *S3Storage) ReadInBuffer(options *internal.ReadInBufferOptions) (int, e
 		return 0, nil
 	}
 
-	ctx, epoch := s3.requestContext()
 	err := s3.Storage.ReadInBuffer(
-		ctx,
+		s3.ctx,
 		options.Handle.Path,
 		options.Offset,
 		dataLen,
 		options.Data,
 	)
-	s3.updateConnectionState(err, epoch)
+	s3.updateConnectionState(err)
 	if err != nil {
 		log.Err(
 			"S3Storage::ReadInBuffer : Failed to read %s [%s]",
@@ -575,9 +558,8 @@ func (s3 *S3Storage) ReadInBuffer(options *internal.ReadInBufferOptions) (int, e
 }
 
 func (s3 *S3Storage) WriteFile(options *internal.WriteFileOptions) (int, error) {
-	ctx, epoch := s3.requestContext()
-	err := s3.Storage.Write(ctx, options)
-	s3.updateConnectionState(err, epoch)
+	err := s3.Storage.Write(s3.ctx, options)
+	s3.updateConnectionState(err)
 	return len(options.Data), err
 }
 
@@ -590,9 +572,8 @@ func (s3 *S3Storage) GetFileBlockOffsets(
 
 func (s3 *S3Storage) TruncateFile(options internal.TruncateFileOptions) error {
 	log.Trace("S3Storage::TruncateFile : %s to %d bytes", options.Name, options.NewSize)
-	ctx, epoch := s3.requestContext()
-	err := s3.Storage.TruncateFile(ctx, options.Name, options.NewSize)
-	s3.updateConnectionState(err, epoch)
+	err := s3.Storage.TruncateFile(s3.ctx, options.Name, options.NewSize)
+	s3.updateConnectionState(err)
 
 	if err == nil {
 		s3StatsCollector.PushEvents(
@@ -607,17 +588,15 @@ func (s3 *S3Storage) TruncateFile(options internal.TruncateFileOptions) error {
 
 func (s3 *S3Storage) CopyToFile(options internal.CopyToFileOptions) error {
 	log.Trace("S3Storage::CopyToFile : Read file %s", options.Name)
-	ctx, epoch := s3.requestContext()
-	err := s3.Storage.ReadToFile(ctx, options.Name, options.Offset, options.Count, options.File)
-	s3.updateConnectionState(err, epoch)
+	err := s3.Storage.ReadToFile(s3.ctx, options.Name, options.Offset, options.Count, options.File)
+	s3.updateConnectionState(err)
 	return err
 }
 
 func (s3 *S3Storage) CopyFromFile(options internal.CopyFromFileOptions) error {
 	log.Trace("S3Storage::CopyFromFile : Upload file %s", options.Name)
-	ctx, epoch := s3.requestContext()
-	err := s3.Storage.WriteFromFile(ctx, options.Name, options.Metadata, options.File)
-	s3.updateConnectionState(err, epoch)
+	err := s3.Storage.WriteFromFile(s3.ctx, options.Name, options.Metadata, options.File)
+	s3.updateConnectionState(err)
 	return err
 }
 
@@ -632,10 +611,9 @@ func (s3 *S3Storage) CreateLink(options internal.CreateLinkOptions) error {
 		return syscall.ENOTSUP
 	}
 	log.Trace("S3Storage::CreateLink : Create symlink %s -> %s", options.Name, options.Target)
-	ctx, epoch := s3.requestContext()
-	err := s3.Storage.CreateLink(ctx, options.Name, options.Target, true)
+	err := s3.Storage.CreateLink(s3.ctx, options.Name, options.Target, true)
 
-	s3.updateConnectionState(err, epoch)
+	s3.updateConnectionState(err)
 	if err == nil {
 		s3StatsCollector.PushEvents(
 			createLink,
@@ -655,9 +633,8 @@ func (s3 *S3Storage) ReadLink(options internal.ReadLinkOptions) (string, error) 
 	}
 	log.Trace("S3Storage::ReadLink : Read symlink %s", options.Name)
 
-	ctx, epoch := s3.requestContext()
-	data, err := s3.Storage.ReadBuffer(ctx, options.Name, 0, 0, true)
-	s3.updateConnectionState(err, epoch)
+	data, err := s3.Storage.ReadBuffer(s3.ctx, options.Name, 0, 0, true)
+	s3.updateConnectionState(err)
 
 	if err != nil {
 		s3StatsCollector.PushEvents(readLink, options.Name, nil)
@@ -670,9 +647,8 @@ func (s3 *S3Storage) ReadLink(options internal.ReadLinkOptions) (string, error) 
 // Attribute operations
 func (s3 *S3Storage) GetAttr(options internal.GetAttrOptions) (*internal.ObjAttr, error) {
 	//log.Trace("S3Storage::GetAttr : Get attributes of file %s", name)
-	ctx, epoch := s3.requestContext()
-	attr, err := s3.Storage.GetAttr(ctx, options.Name)
-	s3.updateConnectionState(err, epoch)
+	attr, err := s3.Storage.GetAttr(s3.ctx, options.Name)
+	s3.updateConnectionState(err)
 	return attr, err
 }
 
@@ -701,20 +677,18 @@ func (s3 *S3Storage) Chown(options internal.ChownOptions) error {
 
 func (s3 *S3Storage) FlushFile(options internal.FlushFileOptions) error {
 	log.Trace("S3Storage::FlushFile : Flush file %s", options.Handle.Path)
-	ctx, epoch := s3.requestContext()
 	err := s3.Storage.StageAndCommit(
-		ctx,
+		s3.ctx,
 		options.Handle.Path,
 		options.Handle.CacheObj.BlockOffsetList,
 	)
-	s3.updateConnectionState(err, epoch)
+	s3.updateConnectionState(err)
 	return err
 }
 
 func (s3 *S3Storage) GetCommittedBlockList(name string) (*internal.CommittedBlockList, error) {
-	ctx, epoch := s3.requestContext()
-	cbl, err := s3.Storage.GetCommittedBlockList(ctx, name)
-	s3.updateConnectionState(err, epoch)
+	cbl, err := s3.Storage.GetCommittedBlockList(s3.ctx, name)
+	s3.updateConnectionState(err)
 	return cbl, err
 }
 
@@ -723,9 +697,8 @@ func (s3 *S3Storage) StageData(opt internal.StageDataOptions) error {
 }
 
 func (s3 *S3Storage) CommitData(opt internal.CommitDataOptions) error {
-	ctx, epoch := s3.requestContext()
-	err := s3.Storage.CommitBlocks(ctx, opt.Name, opt.List)
-	s3.updateConnectionState(err, epoch)
+	err := s3.Storage.CommitBlocks(s3.ctx, opt.Name, opt.List)
+	s3.updateConnectionState(err)
 	return err
 }
 
@@ -741,9 +714,8 @@ func (s3 *S3Storage) StatFs() (*common.Statfs_t, bool, error) {
 	// cache_size - used = f_frsize * f_bavail/1024
 	// cache_size - used = vfs.f_bfree * vfs.f_frsize / 1024
 	// if cache size is set to 0 then we have the root mount usage
-	ctx, epoch := s3.requestContext()
-	sizeUsed, err := s3.Storage.GetUsedSize(ctx)
-	s3.updateConnectionState(err, epoch)
+	sizeUsed, err := s3.Storage.GetUsedSize(s3.ctx)
+	s3.updateConnectionState(err)
 	if err != nil {
 		// TODO: will returning EIO break any applications that depend on StatFs?
 		return nil, true, err

--- a/component/s3storage/s3storage.go
+++ b/component/s3storage/s3storage.go
@@ -59,6 +59,7 @@ type connectionState struct {
 	lastConnectionAttempt *time.Time
 	firstOffline          *time.Time
 	retryTicker           *time.Ticker
+	contextEpoch          uint64
 }
 
 const compName = "s3storage"
@@ -204,17 +205,18 @@ func (s3 *S3Storage) Stop() error {
 
 // Online check
 func (s3 *S3Storage) CloudConnected() bool {
-	log.Trace("S3Storage::CloudConnected")
 	connected := s3.state.firstOffline == nil
 	// don't check the connection when it's up, or if we are not ready to retry
 	if connected || !s3.timeToRetry() {
 		return connected
 	}
+	_, epoch := s3.requestContext()
 	// check connection
+	log.Info("S3Storage::CloudConnected : Checking connection...")
 	ctx, cancelFun := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancelFun()
 	err := s3.Storage.ConnectionOkay(ctx)
-	nowConnected := s3.updateConnectionState(err)
+	nowConnected := s3.updateConnectionState(err, epoch)
 	return nowConnected
 }
 
@@ -234,9 +236,20 @@ func (s3 *S3Storage) timeToRetry() bool {
 	}
 }
 
-func (s3 *S3Storage) updateConnectionState(err error) bool {
+func (s3 *S3Storage) requestContext() (context.Context, uint64) {
 	s3.state.Lock()
 	defer s3.state.Unlock()
+	return s3.ctx, s3.state.contextEpoch
+}
+
+func (s3 *S3Storage) updateConnectionState(err error, requestEpoch uint64) bool {
+	s3.state.Lock()
+	defer s3.state.Unlock()
+
+	if errors.Is(err, &common.CloudUnreachableError{}) && requestEpoch != s3.state.contextEpoch {
+		return s3.state.firstOffline == nil
+	}
+
 	currentTime := time.Now()
 	s3.state.lastConnectionAttempt = &currentTime
 	connected := !errors.Is(err, &common.CloudUnreachableError{})
@@ -247,6 +260,7 @@ func (s3 *S3Storage) updateConnectionState(err error) bool {
 		if connected {
 			s3.state.firstOffline = nil
 			// reset the context to allow new requests
+			s3.state.contextEpoch++
 			s3.ctx, s3.cancelFn = context.WithCancel(context.Background())
 			// stop the retry ticker
 			s3.state.retryTicker.Stop()
@@ -277,9 +291,10 @@ func (s3 *S3Storage) ListAuthorizedBuckets() ([]string, error) {
 func (s3 *S3Storage) CreateDir(options internal.CreateDirOptions) error {
 	log.Trace("S3Storage::CreateDir : %s", options.Name)
 
-	err := s3.Storage.CreateDirectory(s3.ctx, internal.TruncateDirName(options.Name))
+	ctx, epoch := s3.requestContext()
+	err := s3.Storage.CreateDirectory(ctx, internal.TruncateDirName(options.Name))
 	if s3.stConfig.enableDirMarker {
-		s3.updateConnectionState(err)
+		s3.updateConnectionState(err, epoch)
 	}
 
 	if err == nil {
@@ -297,8 +312,9 @@ func (s3 *S3Storage) CreateDir(options internal.CreateDirOptions) error {
 func (s3 *S3Storage) DeleteDir(options internal.DeleteDirOptions) error {
 	log.Trace("S3Storage::DeleteDir : %s", options.Name)
 
-	err := s3.Storage.DeleteDirectory(s3.ctx, internal.TruncateDirName(options.Name))
-	s3.updateConnectionState(err)
+	ctx, epoch := s3.requestContext()
+	err := s3.Storage.DeleteDirectory(ctx, internal.TruncateDirName(options.Name))
+	s3.updateConnectionState(err, epoch)
 
 	if err == nil {
 		s3StatsCollector.PushEvents(deleteDir, options.Name, nil)
@@ -322,8 +338,9 @@ func formatListDirName(path string) string {
 func (s3 *S3Storage) IsDirEmpty(options internal.IsDirEmptyOptions) bool {
 	log.Trace("S3Storage::IsDirEmpty : %s", options.Name)
 	// List up to two objects, since one could be the directory with a trailing slash
-	list, _, err := s3.Storage.List(s3.ctx, formatListDirName(options.Name), nil, 2)
-	s3.updateConnectionState(err)
+	ctx, epoch := s3.requestContext()
+	list, _, err := s3.Storage.List(ctx, formatListDirName(options.Name), nil, 2)
+	s3.updateConnectionState(err, epoch)
 	if err != nil {
 		log.Err("S3Storage::IsDirEmpty : error listing [%s]", err)
 		return false
@@ -352,8 +369,9 @@ func (s3 *S3Storage) StreamDir(
 		entriesRemaining = maxResultsPerListCall
 	}
 	for entriesRemaining > 0 {
-		newList, nextMarker, err := s3.Storage.List(s3.ctx, path, marker, entriesRemaining)
-		s3.updateConnectionState(err)
+		ctx, epoch := s3.requestContext()
+		newList, nextMarker, err := s3.Storage.List(ctx, path, marker, entriesRemaining)
+		s3.updateConnectionState(err, epoch)
 		if err != nil {
 			log.Err("S3Storage::StreamDir : %s Failed to read dir [%s]", options.Name, err)
 			return objectList, "", err
@@ -402,8 +420,9 @@ func (s3 *S3Storage) RenameDir(options internal.RenameDirOptions) error {
 	options.Src = internal.TruncateDirName(options.Src)
 	options.Dst = internal.TruncateDirName(options.Dst)
 
-	err := s3.Storage.RenameDirectory(s3.ctx, options.Src, options.Dst)
-	s3.updateConnectionState(err)
+	ctx, epoch := s3.requestContext()
+	err := s3.Storage.RenameDirectory(ctx, options.Src, options.Dst)
+	s3.updateConnectionState(err, epoch)
 
 	if err == nil {
 		s3StatsCollector.PushEvents(
@@ -428,8 +447,9 @@ func (s3 *S3Storage) CreateFile(options internal.CreateFileOptions) (*handlemap.
 		return nil, syscall.EFAULT
 	}
 
-	err := s3.Storage.CreateFile(s3.ctx, options.Name, options.Mode)
-	s3.updateConnectionState(err)
+	ctx, epoch := s3.requestContext()
+	err := s3.Storage.CreateFile(ctx, options.Name, options.Mode)
+	s3.updateConnectionState(err, epoch)
 	if err != nil {
 		return nil, err
 	}
@@ -450,8 +470,9 @@ func (s3 *S3Storage) CreateFile(options internal.CreateFileOptions) (*handlemap.
 func (s3 *S3Storage) OpenFile(options internal.OpenFileOptions) (*handlemap.Handle, error) {
 	log.Trace("S3Storage::OpenFile : %s", options.Name)
 
-	attr, err := s3.Storage.GetAttr(s3.ctx, options.Name)
-	s3.updateConnectionState(err)
+	ctx, epoch := s3.requestContext()
+	attr, err := s3.Storage.GetAttr(ctx, options.Name)
+	s3.updateConnectionState(err, epoch)
 	if err != nil {
 		return nil, err
 	}
@@ -484,8 +505,9 @@ func (s3 *S3Storage) ReleaseFile(options internal.ReleaseFileOptions) error {
 func (s3 *S3Storage) DeleteFile(options internal.DeleteFileOptions) error {
 	log.Trace("S3Storage::DeleteFile : %s", options.Name)
 
-	err := s3.Storage.DeleteFile(s3.ctx, options.Name)
-	s3.updateConnectionState(err)
+	ctx, epoch := s3.requestContext()
+	err := s3.Storage.DeleteFile(ctx, options.Name)
+	s3.updateConnectionState(err, epoch)
 
 	if err == nil {
 		s3StatsCollector.PushEvents(deleteFile, options.Name, nil)
@@ -499,9 +521,10 @@ func (s3 *S3Storage) RenameFile(options internal.RenameFileOptions) error {
 	log.Trace("S3Storage::RenameFile : %s to %s", options.Src, options.Dst)
 
 	isSymLink := options.SrcAttr != nil && options.SrcAttr.IsSymlink()
-	err := s3.Storage.RenameFile(s3.ctx, options.Src, options.Dst, isSymLink)
+	ctx, epoch := s3.requestContext()
+	err := s3.Storage.RenameFile(ctx, options.Src, options.Dst, isSymLink)
 
-	s3.updateConnectionState(err)
+	s3.updateConnectionState(err, epoch)
 	if err == nil {
 		s3StatsCollector.PushEvents(
 			renameFile,
@@ -530,14 +553,15 @@ func (s3 *S3Storage) ReadInBuffer(options *internal.ReadInBufferOptions) (int, e
 		return 0, nil
 	}
 
+	ctx, epoch := s3.requestContext()
 	err := s3.Storage.ReadInBuffer(
-		s3.ctx,
+		ctx,
 		options.Handle.Path,
 		options.Offset,
 		dataLen,
 		options.Data,
 	)
-	s3.updateConnectionState(err)
+	s3.updateConnectionState(err, epoch)
 	if err != nil {
 		log.Err(
 			"S3Storage::ReadInBuffer : Failed to read %s [%s]",
@@ -551,8 +575,9 @@ func (s3 *S3Storage) ReadInBuffer(options *internal.ReadInBufferOptions) (int, e
 }
 
 func (s3 *S3Storage) WriteFile(options *internal.WriteFileOptions) (int, error) {
-	err := s3.Storage.Write(s3.ctx, options)
-	s3.updateConnectionState(err)
+	ctx, epoch := s3.requestContext()
+	err := s3.Storage.Write(ctx, options)
+	s3.updateConnectionState(err, epoch)
 	return len(options.Data), err
 }
 
@@ -565,8 +590,9 @@ func (s3 *S3Storage) GetFileBlockOffsets(
 
 func (s3 *S3Storage) TruncateFile(options internal.TruncateFileOptions) error {
 	log.Trace("S3Storage::TruncateFile : %s to %d bytes", options.Name, options.NewSize)
-	err := s3.Storage.TruncateFile(s3.ctx, options.Name, options.NewSize)
-	s3.updateConnectionState(err)
+	ctx, epoch := s3.requestContext()
+	err := s3.Storage.TruncateFile(ctx, options.Name, options.NewSize)
+	s3.updateConnectionState(err, epoch)
 
 	if err == nil {
 		s3StatsCollector.PushEvents(
@@ -581,15 +607,17 @@ func (s3 *S3Storage) TruncateFile(options internal.TruncateFileOptions) error {
 
 func (s3 *S3Storage) CopyToFile(options internal.CopyToFileOptions) error {
 	log.Trace("S3Storage::CopyToFile : Read file %s", options.Name)
-	err := s3.Storage.ReadToFile(s3.ctx, options.Name, options.Offset, options.Count, options.File)
-	s3.updateConnectionState(err)
+	ctx, epoch := s3.requestContext()
+	err := s3.Storage.ReadToFile(ctx, options.Name, options.Offset, options.Count, options.File)
+	s3.updateConnectionState(err, epoch)
 	return err
 }
 
 func (s3 *S3Storage) CopyFromFile(options internal.CopyFromFileOptions) error {
 	log.Trace("S3Storage::CopyFromFile : Upload file %s", options.Name)
-	err := s3.Storage.WriteFromFile(s3.ctx, options.Name, options.Metadata, options.File)
-	s3.updateConnectionState(err)
+	ctx, epoch := s3.requestContext()
+	err := s3.Storage.WriteFromFile(ctx, options.Name, options.Metadata, options.File)
+	s3.updateConnectionState(err, epoch)
 	return err
 }
 
@@ -604,9 +632,10 @@ func (s3 *S3Storage) CreateLink(options internal.CreateLinkOptions) error {
 		return syscall.ENOTSUP
 	}
 	log.Trace("S3Storage::CreateLink : Create symlink %s -> %s", options.Name, options.Target)
-	err := s3.Storage.CreateLink(s3.ctx, options.Name, options.Target, true)
+	ctx, epoch := s3.requestContext()
+	err := s3.Storage.CreateLink(ctx, options.Name, options.Target, true)
 
-	s3.updateConnectionState(err)
+	s3.updateConnectionState(err, epoch)
 	if err == nil {
 		s3StatsCollector.PushEvents(
 			createLink,
@@ -626,8 +655,9 @@ func (s3 *S3Storage) ReadLink(options internal.ReadLinkOptions) (string, error) 
 	}
 	log.Trace("S3Storage::ReadLink : Read symlink %s", options.Name)
 
-	data, err := s3.Storage.ReadBuffer(s3.ctx, options.Name, 0, 0, true)
-	s3.updateConnectionState(err)
+	ctx, epoch := s3.requestContext()
+	data, err := s3.Storage.ReadBuffer(ctx, options.Name, 0, 0, true)
+	s3.updateConnectionState(err, epoch)
 
 	if err != nil {
 		s3StatsCollector.PushEvents(readLink, options.Name, nil)
@@ -640,8 +670,9 @@ func (s3 *S3Storage) ReadLink(options internal.ReadLinkOptions) (string, error) 
 // Attribute operations
 func (s3 *S3Storage) GetAttr(options internal.GetAttrOptions) (*internal.ObjAttr, error) {
 	//log.Trace("S3Storage::GetAttr : Get attributes of file %s", name)
-	attr, err := s3.Storage.GetAttr(s3.ctx, options.Name)
-	s3.updateConnectionState(err)
+	ctx, epoch := s3.requestContext()
+	attr, err := s3.Storage.GetAttr(ctx, options.Name)
+	s3.updateConnectionState(err, epoch)
 	return attr, err
 }
 
@@ -670,18 +701,20 @@ func (s3 *S3Storage) Chown(options internal.ChownOptions) error {
 
 func (s3 *S3Storage) FlushFile(options internal.FlushFileOptions) error {
 	log.Trace("S3Storage::FlushFile : Flush file %s", options.Handle.Path)
+	ctx, epoch := s3.requestContext()
 	err := s3.Storage.StageAndCommit(
-		s3.ctx,
+		ctx,
 		options.Handle.Path,
 		options.Handle.CacheObj.BlockOffsetList,
 	)
-	s3.updateConnectionState(err)
+	s3.updateConnectionState(err, epoch)
 	return err
 }
 
 func (s3 *S3Storage) GetCommittedBlockList(name string) (*internal.CommittedBlockList, error) {
-	cbl, err := s3.Storage.GetCommittedBlockList(s3.ctx, name)
-	s3.updateConnectionState(err)
+	ctx, epoch := s3.requestContext()
+	cbl, err := s3.Storage.GetCommittedBlockList(ctx, name)
+	s3.updateConnectionState(err, epoch)
 	return cbl, err
 }
 
@@ -690,8 +723,9 @@ func (s3 *S3Storage) StageData(opt internal.StageDataOptions) error {
 }
 
 func (s3 *S3Storage) CommitData(opt internal.CommitDataOptions) error {
-	err := s3.Storage.CommitBlocks(s3.ctx, opt.Name, opt.List)
-	s3.updateConnectionState(err)
+	ctx, epoch := s3.requestContext()
+	err := s3.Storage.CommitBlocks(ctx, opt.Name, opt.List)
+	s3.updateConnectionState(err, epoch)
 	return err
 }
 
@@ -707,8 +741,9 @@ func (s3 *S3Storage) StatFs() (*common.Statfs_t, bool, error) {
 	// cache_size - used = f_frsize * f_bavail/1024
 	// cache_size - used = vfs.f_bfree * vfs.f_frsize / 1024
 	// if cache size is set to 0 then we have the root mount usage
-	sizeUsed, err := s3.Storage.GetUsedSize(s3.ctx)
-	s3.updateConnectionState(err)
+	ctx, epoch := s3.requestContext()
+	sizeUsed, err := s3.Storage.GetUsedSize(ctx)
+	s3.updateConnectionState(err, epoch)
 	if err != nil {
 		// TODO: will returning EIO break any applications that depend on StatFs?
 		return nil, true, err

--- a/component/s3storage/s3storage_test.go
+++ b/component/s3storage/s3storage_test.go
@@ -486,6 +486,23 @@ func (s *s3StorageTestSuite) TestCloudOfflineContext() {
 	s.s3Storage.updateConnectionState(nil)
 }
 
+func (s *s3StorageTestSuite) TestStaleContextErrorDoesNotRevertOnlineState() {
+	defer s.cleanupTest()
+
+	s.s3Storage.updateConnectionState(&common.CloudUnreachableError{})
+	s.assert.False(s.s3Storage.CloudConnected())
+
+	connected := s.s3Storage.updateConnectionState(nil)
+	s.assert.True(connected)
+	s.assert.True(s.s3Storage.CloudConnected())
+
+	connected = s.s3Storage.updateConnectionState(
+		common.NewCloudUnreachableError(context.Canceled),
+	)
+	s.assert.True(connected)
+	s.assert.True(s.s3Storage.CloudConnected())
+}
+
 func (s *s3StorageTestSuite) TestCreateDir() {
 	defer s.cleanupTest()
 	// Testing dir and dir/

--- a/test-scripts/block.sh
+++ b/test-scripts/block.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 #command to block outgoing calls to Lyve Cloud and Azure Blob Storage
+sudo iptables -I OUTPUT 1 -p tcp -d 127.0.0.1 --dport 4566 -j REJECT
 sudo iptables -I OUTPUT 1 -d 192.55.0.0/16 -j REJECT
 sudo iptables -I OUTPUT 1 -d 20.60.0.0/16 -j REJECT

--- a/test-scripts/connect.sh
+++ b/test-scripts/connect.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 #command to accept outgoing calls to Lyve Cloud and Azure Blob Storage
+sudo iptables -D OUTPUT -p tcp -d 127.0.0.1 --dport 4566 -j REJECT
 sudo iptables -D OUTPUT -d 192.55.0.0/16 -j REJECT
 sudo iptables -D OUTPUT -d 20.60.0.0/16 -j REJECT


### PR DESCRIPTION
A minor change to prevent us from treating our offline state as new information.

The purpose of this change is to avoid a race condition, where the network comes back, and two things happen at once:

1. The component checks the cloud and sees it's actually connected.
2. Another cloud call comes in from a host application and hits the cancelled context.

Then it would be possible for there to be two connection state updates calling `updateConnectionState` simultaneously. If the retry mechanism gets in first, it sets `firstOffline` to nil (we're connected), then the failed host app call updates the connection state next, and falsely identifies the cancelled context as a new connection failure - bring the whole component back offline until the next retry.

I see this change as the simplest way to eliminate this problem. Just don't treat a cancelled context as *evidence* of a failure. Because it isn't. It's just a *result* of a failure.