### PR TITLE
Improve exception handling

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,9 +16,9 @@ Always reference these instructions first and fallback to search or bash command
   sudo apt install -y libfuse3-dev fuse3 gcc
   ```
 
-- Install Go 1.25.4+ (already available in most environments):
+- Install Go 1.27.0+ (already available in most environments; version is pinned in [go.mod](../go.mod)):
   ```bash
-  go version  # Should show 1.25.4 or higher
+  go version  # Should show 1.27.0 or higher
   ```
 
 - Build cloudfuse binary:
@@ -57,7 +57,7 @@ Always reference these instructions first and fallback to search or bash command
   ```bash
   # Install golangci-lint if not available
   curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
-  
+
   # Run linting
   $(go env GOPATH)/bin/golangci-lint run --tests=false --build-tags fuse3 --max-issues-per-linter=0
   ```
@@ -103,13 +103,14 @@ Always reference these instructions first and fallback to search or bash command
 ## Build System Details
 
 - **Primary Build Script**: `./build.sh` - builds cloudfuse with fuse3 by default
-- **Build Variants**: 
+- **Build Variants**:
   - `./build.sh` - standard fuse3 build
   - `./build.sh fuse2` - legacy fuse2 build
   - `./build.sh health` - health monitor binary
 - **Output**: `cloudfuse` binary (~30MB) and optionally `cfusemon` binary (~6MB)
-- **Go Version**: Requires Go 1.25.4+ (specified in go.mod)
-- **Tags**: Use `fuse3` tag for testing/building (default), `fuse2` for legacy systems
+- **Go Version**: Requires Go 1.27.0+ (specified in [go.mod](../go.mod))
+- **Linux CGO compiler**: `zig` (see [build.sh](../build.sh)); Windows uses `CGO_ENABLED=0`
+- **Build Tags**: `fuse3` (default) or `fuse2` (legacy). Test tags also include `unittest`, and CI uses `azurite` and `authtest`. Source files use modern `//go:build` constraints (e.g. `//go:build linux`, `//go:build windows`, `//go:build !fuse3`) with platform suffixes like `_linux.go` / `_windows.go` — edit the file matching the target OS/tag.
 
 ## Testing Infrastructure
 
@@ -128,9 +129,20 @@ Always reference these instructions first and fallback to search or bash command
 - **test/**: All testing code and scripts
 - **tools/health-monitor/**: cloudfuse monitoring tool
 
+### Component Pipeline Conventions
+
+Components are stacked into a pipeline ordered by priority (see [internal/pipeline.go](../internal/pipeline.go) and [internal/component.go](../internal/component.go)):
+
+- Register in `init()` via `internal.AddComponent(name, constructor)`.
+- Embed `internal.BaseComponent`; set priority with `Producer()` (1000) → `LevelMid()` (500) → `LevelOne()` (400) → `LevelTwo()` (300) → `Consumer()` (100).
+- Load config with `config.UnmarshalKey(compName, &opts)`.
+- Scaffold a new component with `go generate` (see [internal/component.template](../internal/component.template) and the `//go:generate` directive in [main.go](../main.go)).
+- Log via the `common/log` package (`log.Debug/Info/Err/Crit/Trace`), never `fmt.Println`.
+- **Every new source file must include the MIT license header** (copy from an existing file such as [internal/component.go](../internal/component.go); see [copyright](../copyright)).
+
 ## Configuration
 
-- **Sample Configs**: 
+- **Sample Configs**:
   - `sampleFileCacheConfig.yaml` - file-based caching
   - `sampleBlockCacheConfig.yaml` - block-based caching
   - `setup/baseConfig.yaml` - complete configuration options

--- a/common/log/base_logger.go
+++ b/common/log/base_logger.go
@@ -257,11 +257,16 @@ func (l *BaseLogger) logDumper(id int, channel <-chan string) {
 	defer l.workerDone.Done()
 
 	for j := range channel {
-		l.logger.Println(j)
+		// write directly so the error is visible. log.Println discards it.
+		n, err := io.WriteString(l.logFileHandle, j+"\n")
+		if err != nil {
+			// don't count bytes we didn't write, or a full disk drives rotation
+			// until every retained log file has been replaced by an empty one
+			continue
+		}
 
-		l.fileConfig.currentLogSize += (uint64)(len(j))
+		l.fileConfig.currentLogSize += uint64(n)
 		if l.fileConfig.currentLogSize > l.fileConfig.LogSize {
-			//fmt.Println("Calling logrotate : ", l.fileConfig.currentLogSize, " : ", l.fileConfig.logSize)
 			_ = l.LogRotate()
 		}
 	}
@@ -310,5 +315,5 @@ func (l *BaseLogger) LogRotate() error {
 	l.logger.SetOutput(l.logFileHandle)
 	l.fileConfig.currentLogSize = 0
 
-	return nil
+	return err
 }

--- a/component/file_cache/async.go
+++ b/component/file_cache/async.go
@@ -38,6 +38,12 @@ import (
 	"github.com/netresearch/go-cron"
 )
 
+// bounds on the backoff between upload cycles that ended in failure
+const (
+	minRetryDelay = time.Second
+	maxRetryDelay = 15 * time.Second
+)
+
 type UploadWindow struct {
 	name        string `yaml:"name"`
 	cronExpr    string `yaml:"cron"`
@@ -217,12 +223,21 @@ func (fc *FileCache) addPendingOp(name string, value pendingFlags) {
 
 // persistent background thread function
 func (fc *FileCache) servicePendingOps() {
+	// grows while upload cycles keep failing, resets as soon as one succeeds
+	var retryDelay time.Duration
 	for {
 		select {
 		case <-fc.componentStopping:
 			log.Crit("FileCache::servicePendingOps : Stopping")
 			return
 		case <-fc.startScheduledUploads:
+			if retryDelay > 0 {
+				select {
+				case <-time.After(retryDelay):
+				case <-fc.componentStopping:
+					return
+				}
+			}
 			// check if we're connected
 			// exponential backoff is implemented inside CloudConnected(),
 			//  so we're safe to call it naively every second like this
@@ -239,7 +254,16 @@ func (fc *FileCache) servicePendingOps() {
 				"FileCache::servicePendingOps : Completed upload cycle, processed %d files",
 				numFilesProcessed,
 			)
-			if err == nil && numFilesProcessed == 0 {
+			if err != nil {
+				retryDelay = min(max(2*retryDelay, minRetryDelay), maxRetryDelay)
+				log.Warn(
+					"FileCache::servicePendingOps : Upload cycle failed, retrying in %v",
+					retryDelay,
+				)
+				break
+			}
+			retryDelay = 0
+			if numFilesProcessed == 0 {
 				// we're online but there's nothing to do
 				// wait for a task to be added
 				select {

--- a/component/file_cache/async.go
+++ b/component/file_cache/async.go
@@ -221,6 +221,12 @@ func (fc *FileCache) addPendingOp(name string, value pendingFlags) {
 	}
 }
 
+// syncsPendingOps : whether servicePendingOps is running. Queueing an op without it
+// would pin the cached file forever, since eviction skips pending ops.
+func (fc *FileCache) syncsPendingOps() bool {
+	return len(fc.schedule) > 0 || fc.offlineAccess
+}
+
 // persistent background thread function
 func (fc *FileCache) servicePendingOps() {
 	// grows while upload cycles keep failing, resets as soon as one succeeds

--- a/component/file_cache/async.go
+++ b/component/file_cache/async.go
@@ -234,33 +234,12 @@ func (fc *FileCache) servicePendingOps() {
 				}
 				break
 			}
-			numFilesProcessed := 0
-			// Iterate over pending ops
-			fc.pendingOps.Range(func(key, value any) bool {
-				numFilesProcessed++
-				select {
-				case <-fc.componentStopping:
-					return false
-				case <-fc.startScheduledUploads:
-					path := key.(string)
-					value := value.(pendingFlags)
-					err := fc.updateObject(path, value)
-					if isOffline(err) {
-						return false // connection lost - abort iteration
-					}
-					if err != nil {
-						log.Err("FileCache::servicePendingOps : %s upload failed: %v", path, err)
-					}
-				default:
-					return false // upload window ended
-				}
-				return true // Continue the iteration
-			})
+			numFilesProcessed, err := fc.runPendingOpCycle()
 			log.Info(
 				"FileCache::servicePendingOps : Completed upload cycle, processed %d files",
 				numFilesProcessed,
 			)
-			if numFilesProcessed == 0 {
+			if err == nil && numFilesProcessed == 0 {
 				// we're online but there's nothing to do
 				// wait for a task to be added
 				select {
@@ -270,6 +249,37 @@ func (fc *FileCache) servicePendingOps() {
 			}
 		}
 	}
+}
+
+// runPendingOpCycle : sync pending ops with cloud storage until the upload window
+// closes or an operation fails. Returns the number of ops attempted, and the error
+// that ended the cycle, if any.
+func (fc *FileCache) runPendingOpCycle() (int, error) {
+	numFilesProcessed := 0
+	var cycleErr error
+
+	fc.pendingOps.Range(func(key, value any) bool {
+		select {
+		case <-fc.componentStopping:
+			return false
+		case <-fc.startScheduledUploads:
+			name := key.(string)
+			numFilesProcessed++
+			cycleErr = fc.updateObject(name, value.(pendingFlags))
+			if cycleErr != nil {
+				// a failure here is a property of the endpoint (offline, full, throttled,
+				// unauthorized) far more often than of the object, so stop the cycle
+				// instead of repeating a known failure against every remaining file
+				log.Err("FileCache::runPendingOpCycle : %s sync failed: %v", name, cycleErr)
+				return false
+			}
+			return true
+		default:
+			return false // upload window ended
+		}
+	})
+
+	return numFilesProcessed, cycleErr
 }
 
 // synchronize pending operation with cloud storage
@@ -294,8 +304,9 @@ func (fc *FileCache) updateObject(name string, flags pendingFlags) error {
 	// in case of inconsistency, local state takes precedence (except to prevent incorrect deletions)
 	if !flags.isDeletion && localErr != nil {
 		log.Err("FileCache::updateObject : %s stat failed. Here's why: %v", name, localErr)
+		// the op is resolved, not failed - dropping it must not end the cycle
 		fc.pendingOps.Delete(name)
-		return localErr
+		return nil
 	}
 	if flags.isDeletion && !localMissing {
 		log.Err("FileCache::updateObject : %s exists. Ignoring deletion flag!", name)

--- a/component/file_cache/async.go
+++ b/component/file_cache/async.go
@@ -221,7 +221,6 @@ func (fc *FileCache) servicePendingOps() {
 		select {
 		case <-fc.componentStopping:
 			log.Crit("FileCache::servicePendingOps : Stopping")
-			// TODO: Persist pending ops
 			return
 		case <-fc.startScheduledUploads:
 			// check if we're connected

--- a/component/file_cache/async.go
+++ b/component/file_cache/async.go
@@ -295,12 +295,7 @@ func (fc *FileCache) runPendingOpCycle() (int, error) {
 		case <-fc.startScheduledUploads:
 			name := key.(string)
 			numFilesProcessed++
-			cycleErr = fc.updateObject(name, value.(pendingFlags))
-			if cycleErr != nil {
-				// a failure here is a property of the endpoint (offline, full, throttled,
-				// unauthorized) far more often than of the object, so stop the cycle
-				// instead of repeating a known failure against every remaining file
-				log.Err("FileCache::runPendingOpCycle : %s sync failed: %v", name, cycleErr)
+			if !fc.updateObject(name, value.(pendingFlags)) {
 				return false
 			}
 			return true
@@ -313,7 +308,8 @@ func (fc *FileCache) runPendingOpCycle() (int, error) {
 }
 
 // synchronize pending operation with cloud storage
-func (fc *FileCache) updateObject(name string, flags pendingFlags) error {
+// returns false if we should stop iterating (offline, etc.)
+func (fc *FileCache) updateObject(name string, flags pendingFlags) bool {
 	log.Trace("FileCache::updateObject : %s", name)
 
 	// lock the file
@@ -324,7 +320,7 @@ func (fc *FileCache) updateObject(name string, flags pendingFlags) error {
 	// don't double upload
 	_, stillPending := fc.pendingOps.Load(name)
 	if !stillPending {
-		return nil
+		return true
 	}
 
 	// look up file (or folder!)
@@ -334,9 +330,10 @@ func (fc *FileCache) updateObject(name string, flags pendingFlags) error {
 	// in case of inconsistency, local state takes precedence (except to prevent incorrect deletions)
 	if !flags.isDeletion && localErr != nil {
 		log.Err("FileCache::updateObject : %s stat failed. Here's why: %v", name, localErr)
-		// the op is resolved, not failed - dropping it must not end the cycle
+		// there is no file to upload, so consider the inconsistency resolved
 		fc.pendingOps.Delete(name)
-		return nil
+		// this file failed, but we can continue with the rest of the pending ops
+		return true
 	}
 	if flags.isDeletion && !localMissing {
 		log.Err("FileCache::updateObject : %s exists. Ignoring deletion flag!", name)
@@ -353,7 +350,7 @@ func (fc *FileCache) updateObject(name string, flags pendingFlags) error {
 		if flags.isDeletion && fc.notInCloud(name) {
 			log.Info("FileCache::updateObject : %s skipping cloud deletion (not in cloud)", name)
 			fc.pendingOps.Delete(name)
-			return nil
+			return true
 		}
 		if flags.isDir {
 			// delete folder
@@ -380,14 +377,14 @@ func (fc *FileCache) updateObject(name string, flags pendingFlags) error {
 	// handle errors
 	if cloudErr != nil {
 		log.Err("FileCache::updateObject : %s %s %s failed [%v]", name, objType, op, cloudErr)
-		return cloudErr
+		return false
 	}
 
 	// update state
 	log.Info("FileCache::updateObject : %s sync successful", name)
 	fc.pendingOps.Delete(name)
 
-	return nil
+	return true
 }
 
 // returns true if we *know* that this entity does not exist in cloud storage

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -1190,6 +1190,45 @@ func unlockAll(flocks []*common.LockMapItem) {
 	}
 }
 
+// cacheFileMode returns the mode to use for a local cache file. On platforms
+// without POSIX modes the caller's mode is meaningless and may leave the file
+// read-only, so the cache default is used instead.
+func (fc *FileCache) cacheFileMode(mode os.FileMode) os.FileMode {
+	if runtime.GOOS == "windows" {
+		return fc.defaultPermission
+	}
+	return mode
+}
+
+// clearCacheFileReadOnly drops the read-only attribute that older Windows builds
+// left on cache files, which blocks writes, truncates and replacing renames.
+// Reports whether the caller should retry. Where modes are real, so is the error.
+func (fc *FileCache) clearCacheFileReadOnly(path string) bool {
+	if runtime.GOOS != "windows" {
+		return false
+	}
+	if err := os.Chmod(path, fc.defaultPermission); err != nil {
+		log.Warn("FileCache::clearCacheFileReadOnly : %s failed [%v]", path, err)
+		return false
+	}
+	log.Info("FileCache::clearCacheFileReadOnly : cleared read-only on %s", path)
+	return true
+}
+
+// openCacheFile opens a file in the local cache, recovering from a stale read-only
+// attribute if that is what blocked the open.
+func (fc *FileCache) openCacheFile(
+	path string,
+	flags int,
+	mode os.FileMode,
+) (*os.File, error) {
+	f, err := common.OpenFile(path, flags, mode)
+	if os.IsPermission(err) && fc.clearCacheFileReadOnly(path) {
+		f, err = common.OpenFile(path, flags, mode)
+	}
+	return f, err
+}
+
 // CreateFile: Create the file in local cache.
 func (fc *FileCache) CreateFile(options internal.CreateFileOptions) (*handlemap.Handle, error) {
 	//defer exectime.StatTimeCurrentBlock("FileCache::CreateFile")()
@@ -1250,7 +1289,11 @@ func (fc *FileCache) CreateFile(options internal.CreateFileOptions) (*handlemap.
 	}
 
 	// Open the file and grab a shared lock to prevent deletion by the cache policy.
-	f, err := common.OpenFile(localPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, options.Mode)
+	f, err := fc.openCacheFile(
+		localPath,
+		os.O_RDWR|os.O_CREATE|os.O_TRUNC,
+		fc.cacheFileMode(options.Mode),
+	)
 	if err != nil {
 		log.Err(
 			"FileCache::CreateFile : error opening local file %s [%s]",
@@ -1260,7 +1303,7 @@ func (fc *FileCache) CreateFile(options internal.CreateFileOptions) (*handlemap.
 		return nil, err
 	}
 	// The user might change permissions WHILE creating the file therefore we need to account for that
-	if options.Mode != common.DefaultFilePermissionBits {
+	if runtime.GOOS != "windows" && options.Mode != common.DefaultFilePermissionBits {
 		fc.missedChmodList.LoadOrStore(options.Name, true)
 	}
 
@@ -1398,7 +1441,7 @@ func (fc *FileCache) openFileInternal(handle *handlemap.Handle, flock *common.Lo
 	}
 	fileOptions := val.(openFileOptions)
 	flags = fileOptions.flags
-	fMode = fileOptions.fMode
+	fMode = fc.cacheFileMode(fileOptions.fMode)
 	overwrite := flags&os.O_TRUNC != 0
 	create := flags&os.O_CREATE != 0
 
@@ -1444,7 +1487,7 @@ func (fc *FileCache) openFileInternal(handle *handlemap.Handle, flock *common.Lo
 		}
 
 		// Open a download handle
-		downloadHandle, err := common.OpenFile(localPath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, fMode)
+		downloadHandle, err := fc.openCacheFile(localPath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, fMode)
 		if err != nil {
 			log.Err("FileCache::openFileInternal : %s open dl handle failed [%v]", handle.Path, err)
 			return err
@@ -1482,7 +1525,7 @@ func (fc *FileCache) openFileInternal(handle *handlemap.Handle, flock *common.Lo
 		// Only set permissions when creating a new file (O_CREATE flag is set)
 		if create {
 			fileMode := fc.defaultPermission
-			if attr != nil && !attr.IsModeDefault() {
+			if runtime.GOOS != "windows" && attr != nil && !attr.IsModeDefault() {
 				fileMode = attr.Mode
 			}
 
@@ -1516,7 +1559,7 @@ func (fc *FileCache) openFileInternal(handle *handlemap.Handle, flock *common.Lo
 	fileCacheStatsCollector.UpdateStats(stats_manager.Increment, dlFiles, (int64)(1))
 
 	// Open the file and grab a shared lock to prevent deletion by the cache policy.
-	f, err := common.OpenFile(localPath, flags, fMode)
+	f, err := fc.openCacheFile(localPath, flags, fMode)
 	if err != nil {
 		log.Err(
 			"FileCache::openFileInternal : error opening cached file %s [%s]",
@@ -2301,6 +2344,14 @@ func (fc *FileCache) renameLocalFile(
 	localSrcPath := filepath.Join(fc.tmpPath, srcName)
 	localDstPath := filepath.Join(fc.tmpPath, dstName)
 
+	if runtime.GOOS == "windows" {
+		if dstInfo, dstErr := os.Stat(localDstPath); dstErr == nil {
+			if !dstInfo.IsDir() && dstInfo.Mode().Perm()&0o200 == 0 {
+				fc.clearCacheFileReadOnly(localDstPath)
+			}
+		}
+	}
+
 	err := os.Rename(localSrcPath, localDstPath)
 	switch {
 	case err == nil:
@@ -2413,7 +2464,7 @@ func (fc *FileCache) TruncateFile(options internal.TruncateFileOptions) error {
 			// Recover missing fd on valid handles by reopening the cached path.
 			// This avoids issues when truncate arrives before the handle has a live file object.
 			localPath := filepath.Join(fc.tmpPath, options.Name)
-			reopened, reopenErr := common.OpenFile(localPath, os.O_RDWR, fc.defaultPermission)
+			reopened, reopenErr := fc.openCacheFile(localPath, os.O_RDWR, fc.defaultPermission)
 			if reopenErr == nil {
 				options.Handle.UnixFD = uint64(reopened.Fd())
 				options.Handle.SetFileObject(reopened)
@@ -2477,7 +2528,7 @@ func (fc *FileCache) TruncateFile(options internal.TruncateFileOptions) error {
 			offlineOkay = true
 		case !needData:
 			log.Debug("FileCache::TruncateFile : %s Creating file (offline)", options.Name)
-			if f, err := common.OpenFile(
+			if f, err := fc.openCacheFile(
 				localPath,
 				os.O_CREATE|os.O_WRONLY|os.O_TRUNC,
 				fc.defaultPermission,
@@ -2506,6 +2557,9 @@ func (fc *FileCache) TruncateFile(options internal.TruncateFileOptions) error {
 		fc.policy.CacheValid(localPath)
 		if info.Size() != options.NewSize {
 			err := os.Truncate(localPath, options.NewSize)
+			if os.IsPermission(err) && fc.clearCacheFileReadOnly(localPath) {
+				err = os.Truncate(localPath, options.NewSize)
+			}
 			if err != nil {
 				log.Err(
 					"FileCache::TruncateFile : %s failed to truncate cached file [%v]",

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -192,7 +192,7 @@ func (fc *FileCache) Start(ctx context.Context) error {
 	} else {
 		close(fc.startScheduledUploads)
 	}
-	if len(fc.schedule) > 0 || fc.offlineAccess {
+	if fc.syncsPendingOps() {
 		fc.pendingOpAdded = make(chan struct{}, 1)
 		go fc.servicePendingOps()
 	}
@@ -2067,6 +2067,11 @@ func (fc *FileCache) flushFileCloud(options internal.FlushFileOptions) error {
 		// add file to upload queue
 		fc.addPendingOp(options.Handle.Path, pendingFlags{})
 		err = nil
+	case fc.syncsPendingOps():
+		log.Err("FileCache::flushFileCloud : %s upload failed [%v]", options.Handle.Path, err)
+		// queue for retry, which also protects the cached data from eviction.
+		// the error is still returned - the caller must not assume the data is safe
+		fc.addPendingOp(options.Handle.Path, pendingFlags{})
 	default:
 		log.Err("FileCache::flushFileCloud : %s upload failed [%v]", options.Handle.Path, err)
 	}

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -2870,9 +2870,8 @@ func (suite *fileCacheTestSuite) TestUpdateObjectOfflineErrorKeepsPending() {
 	suite.fileCache.addPendingOp(name, pendingFlags{})
 	suite.mock.EXPECT().CopyFromFile(gomock.Any()).Return(&common.CloudUnreachableError{})
 
-	err = suite.fileCache.updateObject(name, pendingFlags{})
-	suite.assert.Error(err)
-	suite.assert.ErrorIs(err, &common.CloudUnreachableError{})
+	success := suite.fileCache.updateObject(name, pendingFlags{})
+	suite.assert.False(success)
 
 	_, stillPending := suite.fileCache.pendingOps.Load(name)
 	suite.assert.True(
@@ -2897,8 +2896,8 @@ func (suite *fileCacheTestSuite) TestUpdateObjectDeletionMissingLocalFile() {
 	suite.mock.EXPECT().GetAttr(internal.GetAttrOptions{Name: name}).Return(nil, nil)
 	suite.mock.EXPECT().DeleteFile(internal.DeleteFileOptions{Name: name}).Return(nil)
 
-	err := suite.fileCache.updateObject(name, pendingFlags{isDeletion: true})
-	suite.assert.NoError(err)
+	success := suite.fileCache.updateObject(name, pendingFlags{isDeletion: true})
+	suite.assert.True(success)
 
 	_, stillPending := suite.fileCache.pendingOps.Load(name)
 	suite.assert.False(stillPending, "delete should be synced and removed from pendingOps")

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -1454,7 +1454,9 @@ func (suite *fileCacheTestSuite) TestCreateFileWithNoPerm() {
 		err = suite.fileCache.ReleaseFile(internal.ReleaseFileOptions{Handle: f})
 		suite.assert.NoError(err)
 		info, _ := os.Stat(suite.cache_path + "/" + path)
-		suite.assert.Equal(info.Mode(), os.FileMode(0444))
+		// On Windows, cacheFileMode replaces the requested mode with defaultPermission;
+		// a writable file is reported as 0666 by os.Stat.
+		suite.assert.Equal(info.Mode(), os.FileMode(0666))
 	} else {
 		defer suite.cleanupTest()
 		// Default is to not create empty files on create file to support immutable storage.

--- a/component/file_cache/file_cache_windows.go
+++ b/component/file_cache/file_cache_windows.go
@@ -44,14 +44,18 @@ import (
 func newObjAttr(path string, info fs.FileInfo) *internal.ObjAttr {
 	stat := info.Sys().(*syscall.Win32FileAttributeData)
 	attrs := &internal.ObjAttr{
-		Path:  common.NormalizeObjectName(path),
-		Name:  common.NormalizeObjectName(info.Name()),
-		Size:  info.Size(),
-		Mode:  info.Mode(),
+		Path: common.NormalizeObjectName(path),
+		Name: common.NormalizeObjectName(info.Name()),
+		Size: info.Size(),
+		// mask off the permission bits, which are meaningless on Windows
+		Mode:  info.Mode() &^ os.ModePerm,
 		Mtime: time.Unix(0, stat.LastWriteTime.Nanoseconds()),
 		Atime: time.Unix(0, stat.LastAccessTime.Nanoseconds()),
 		Ctime: time.Unix(0, stat.CreationTime.Nanoseconds()),
 	}
+
+	// let the fuse layer supply the configured default permission
+	attrs.Flags.Set(internal.PropFlagModeDefault)
 
 	if info.Mode()&os.ModeSymlink != 0 {
 		attrs.Flags.Set(internal.PropFlagSymlink)

--- a/component/libfuse/libfuse2_handler.go
+++ b/component/libfuse/libfuse2_handler.go
@@ -71,7 +71,11 @@ type CgofuseFS struct {
 	gid uint32
 }
 
-const windowsDefaultSDDL = "D:P(A;;FA;;;WD)" // Enables everyone on system to have access to mount
+// Grants everyone full access to the mount. The owner and group are required for
+// Explorer's basic Security tab to render, and OICI makes the ACE inheritable so
+// newly created files get the same access instead of the creating process's
+// default DACL (which WinFSP would map to a mode with no owner write bit).
+const windowsDefaultSDDL = "O:BAG:BAD:P(A;OICI;FA;;;WD)"
 const maxPathSize = 4096
 
 // Note: libfuse prepends "/" to the path.
@@ -1271,6 +1275,13 @@ func (cf *CgofuseFS) Chmod(path string, mode uint32) int {
 		return errno
 	}
 	log.Trace("Libfuse::Chmod : %s", name)
+
+	if runtime.GOOS == "windows" {
+		// WinFSP synthesizes this mode from the read-only attribute, so it carries no
+		// permission intent worth storing. Report success and discard it.
+		return 0
+	}
+
 	modeBits := fileModeFromFuse(mode)
 
 	err := fuseFS.NextComponent().Chmod(

--- a/component/libfuse/libfuse2_handler_test_wrapper.go
+++ b/component/libfuse/libfuse2_handler_test_wrapper.go
@@ -1727,6 +1727,12 @@ func testChmod(suite *libfuseTestSuite) {
 	defer suite.cleanupTest()
 	name := "path"
 	path := "/" + name
+	if runtime.GOOS == "windows" {
+		// Chmod is a no-op on Windows; it always succeeds without forwarding.
+		err := cfuseFS.Chmod(path, 0775)
+		suite.assert.Equal(0, err)
+		return
+	}
 	mode := fs.FileMode(0775)
 	options := internal.ChmodOptions{Name: name, Mode: mode}
 	suite.mock.EXPECT().Chmod(options).Return(nil)
@@ -1739,6 +1745,12 @@ func testChmodNotExists(suite *libfuseTestSuite) {
 	defer suite.cleanupTest()
 	name := "path"
 	path := "/" + name
+	if runtime.GOOS == "windows" {
+		// Chmod is a no-op on Windows; it always succeeds without forwarding.
+		err := cfuseFS.Chmod(path, 0775)
+		suite.assert.Equal(0, err)
+		return
+	}
 	mode := fs.FileMode(0775)
 	options := internal.ChmodOptions{Name: name, Mode: mode}
 	suite.mock.EXPECT().Chmod(options).Return(syscall.ENOENT)
@@ -1751,6 +1763,12 @@ func testChmodError(suite *libfuseTestSuite) {
 	defer suite.cleanupTest()
 	name := "path"
 	path := "/" + name
+	if runtime.GOOS == "windows" {
+		// Chmod is a no-op on Windows; it always succeeds without forwarding.
+		err := cfuseFS.Chmod(path, 0775)
+		suite.assert.Equal(0, err)
+		return
+	}
 	mode := fs.FileMode(0775)
 	options := internal.ChmodOptions{Name: name, Mode: mode}
 	suite.mock.EXPECT().Chmod(options).Return(errors.New("failed to chmod"))

--- a/component/s3storage/s3storage_test.go
+++ b/component/s3storage/s3storage_test.go
@@ -1324,6 +1324,8 @@ func (s *s3StorageTestSuite) TestCopyFromFile() {
 	defer os.Remove(f.Name())
 	_, err = f.Write(data)
 	s.assert.NoError(err)
+	err = f.Sync()
+	s.assert.NoError(err)
 
 	err = s.s3Storage.CopyFromFile(internal.CopyFromFileOptions{Name: name, File: f})
 

--- a/component/size_tracker/size_tracker.go
+++ b/component/size_tracker/size_tracker.go
@@ -148,6 +148,20 @@ func (st *SizeTracker) Configure(_ bool) error {
 				log.Err("SizeTracker::Configure : Invalid display capacity")
 			}
 		}
+		// allowing displayCapacity to be larger than totalBucketCapacity causes errors
+		if st.displayCapacity > st.totalBucketCapacity {
+			log.Err(
+				"SizeTracker::Configure : display capacity (%d MB) exceeds total bucket capacity (%d MB)",
+				st.displayCapacity/common.MbToBytes,
+				conf.TotalBucketCapacity,
+			)
+			return fmt.Errorf(
+				"SizeTracker: invalid configuration [size_tracker.bucket-capacity-fallback (%d MB)"+
+					" cannot be less than libfuse.display-capacity-mb (%d MB)]",
+				st.displayCapacity/common.MbToBytes,
+				conf.TotalBucketCapacity,
+			)
+		}
 		// calculate server count
 		// round to the nearest whole number
 		st.serverCount = (st.totalBucketCapacity + st.displayCapacity/2) / st.displayCapacity


### PR DESCRIPTION
Improve exception handling:

* Enforce display capacity <= total bucket capacity
* Don't ignore log output errors - they cause us to erase previous logs by rotating
* Back off on all cloud errors when uploading pending ops
* Retry failed uploads asynchronously, when permitted

Fix Windows permissions:

* Windows does not have a compatible permissions system, so don't let file permissions be set
* Set SDDL in a way that makes sense to explorer (add an owner and group)
* Include code to repair permissions on existing file cache files on Windows systems ("rogue read-only")
* Update copilot instructions