### PR TITLE
Handle size-tracker hard-limit correctly in file cache

### DIFF
--- a/component/file_cache/async.go
+++ b/component/file_cache/async.go
@@ -27,6 +27,7 @@ package file_cache
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -296,6 +297,8 @@ func (fc *FileCache) runPendingOpCycle() (int, error) {
 			name := key.(string)
 			numFilesProcessed++
 			if !fc.updateObject(name, value.(pendingFlags)) {
+				// record the failure so the caller backs off instead of busy-retrying
+				cycleErr = fmt.Errorf("sync failed for %s", name)
 				return false
 			}
 			return true

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -2105,6 +2105,8 @@ func (fc *FileCache) flushFileCloud(options internal.FlushFileOptions) error {
 	case err == nil:
 		fc.clearHandleDirty(options.Handle)
 		fc.pendingOps.Delete(options.Handle.Path)
+	case errors.Is(err, syscall.ENOSPC):
+		log.Err("FileCache::flushFileCloud : %s upload failed [%v]", options.Handle.Path, err)
 	case isOffline(err) && fc.offlineAccess:
 		log.Warn("FileCache::flushFileCloud : %s upload delayed (offline)", options.Handle.Path)
 		// add file to upload queue

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -2499,6 +2499,43 @@ func (suite *fileCacheTestSuite) TestFlushFileOffline() {
 	}
 }
 
+func (suite *fileCacheTestSuite) TestFlushFileNoRetryOnEnospc() {
+	// enable mock component
+	suite.cleanupTest()
+	defaultConfig := fmt.Sprintf(
+		"file_cache:\n  path: %s\n  offload-io: true",
+		suite.cache_path,
+	)
+	suite.useMock = true
+	suite.setupTestHelper(defaultConfig)
+	defer suite.cleanupTest()
+
+	file := "enospc-flush-file"
+	localPath := filepath.Join(suite.cache_path, file)
+	err := os.MkdirAll(filepath.Dir(localPath), 0777)
+	suite.assert.NoError(err)
+	f, err := os.OpenFile(localPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0777)
+	suite.assert.NoError(err)
+	_, err = f.Write([]byte("enospc flush data"))
+	suite.assert.NoError(err)
+
+	handle := handlemap.NewHandle(file)
+	handle.SetFileObject(f)
+	handle.Flags.Set(handlemap.HandleFlagDirty)
+	defer f.Close()
+
+	suite.mock.EXPECT().
+		CopyFromFile(gomock.Any()).
+		Return(syscall.ENOSPC)
+
+	err = suite.fileCache.FlushFile(internal.FlushFileOptions{Handle: handle})
+	suite.assert.ErrorIs(err, syscall.ENOSPC)
+
+	_, exists := suite.fileCache.pendingOps.Load(file)
+	suite.assert.False(exists, "ENOSPC should not be queued in pendingOps")
+	suite.assert.True(handle.Dirty(), "ENOSPC should keep handle dirty")
+}
+
 func (suite *fileCacheTestSuite) TestFlushFileErrorBadFd() {
 	defer suite.cleanupTest()
 	// Setup


### PR DESCRIPTION
Back off async retries on cloud error.
Always return ENOSPC to host (don't retry async).